### PR TITLE
Fix sweeper Opt In-n-Out

### DIFF
--- a/src/components/IncomingMessageList/MessageColumn/MessageOptOut.jsx
+++ b/src/components/IncomingMessageList/MessageColumn/MessageOptOut.jsx
@@ -61,6 +61,7 @@ class MessageOptOut extends Component {
         throw response.errors
       }
       this.props.optOutChanged(false)
+      this.handleCloseAlert()
     } catch (error) {
       const dialogActions = [
         <FlatButton
@@ -168,8 +169,7 @@ const mapMutationsToProps = () => ({
         createOptOut(optOut: $optOut, campaignContactId: $campaignContactId) {
           id
           optOut {
-            id
-            createdAt
+            cell
           }
         }
       }

--- a/src/components/IncomingMessageList/MessageColumn/index.jsx
+++ b/src/components/IncomingMessageList/MessageColumn/index.jsx
@@ -9,7 +9,7 @@ class MessageColumn extends Component {
     super(props)
 
     const { conversation } = props
-    const isOptedOut = !!conversation.contact.optOut.cell
+    const isOptedOut = (conversation.contact.optOut && !!conversation.contact.optOut.cell)
     this.state = {
       messages: conversation.contact.messages,
       isOptedOut

--- a/src/components/IncomingMessageList/index.jsx
+++ b/src/components/IncomingMessageList/index.jsx
@@ -11,10 +11,16 @@ import ConversationPreviewModal from './ConversationPreviewModal';
 
 import { MESSAGE_STATUSES } from '../../components/IncomingMessageFilter'
 
+const formatContactName = (contact) => {
+  const { firstName, lastName, optOut } = contact
+  const suffix = (optOut && optOut.cell) ? ' ⛔' : ''
+  return `${firstName} ${lastName}${suffix}`
+}
+
 const prepareDataTableData = (conversations) => conversations.map((conversation, index) => ({
   campaignTitle: conversation.campaign.title,
   texter: conversation.texter.displayName,
-  to: conversation.contact.firstName + ' ' + conversation.contact.lastName + (conversation.contact.optOut.cell ? '⛔️' : ''),
+  to: formatContactName(conversation.contact),
   status: conversation.contact.messageStatus,
   messages: conversation.contact.messages,
   updatedAt: conversation.contact.updatedAt,


### PR DESCRIPTION
- Fix opt-in error handling and state management.
- Fixed underlying MySQL complaint about using the parent table of an update in a subquery.
- Added defensive fixes client-side for accessing optOut property.
- Invalidate campaign contact DataLoader cache before returning after updating opt-out status.