### PR TITLE
Reap connections in MySQL

### DIFF
--- a/src/server/models/thinky.js
+++ b/src/server/models/thinky.js
@@ -46,7 +46,11 @@ if (process.env.DB_JSON || global.DB_JSON) {
     connection: process.env.DATABASE_URL,
     pool: {
       min: parseInt(process.env.DB_MIN_POOL || 2, 10),
-      max: parseInt(process.env.DB_MAX_POOL || 10, 10)
+      max: parseInt(process.env.DB_MAX_POOL || 10, 10),
+      // free resouces are destroyed after this many milliseconds
+      idleTimeoutMillis: parseInt(process.env.DB_IDLE_TIMEOUT_MS || 30000),
+      // how often to check for idle resources to destroy
+      reapIntervalMillis: parseInt(process.env.DB_REAP_INTERVAL_MS || 1000)
     },
     ssl: use_ssl
   }


### PR DESCRIPTION
The reap connections settings were only set for Postgres. We probably want to test this a bit more before rolling it out. Wonder if we'll see some big performance increases or if it'll just tank...