### PR TITLE
mobile cleanup

### DIFF
--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -140,13 +140,14 @@ const inlineStyles = {
     display: 'inline-block'
   },
   actionToolbar: {
+    height: 118,
     backgroundColor: 'white',
     '@media(min-width: 450px)': {
       marginBottom: 5
     },
     '@media(max-width: 450px)': {
-      marginBottom: 50
-    }
+      marginBottom: 50,
+    },
   },
 
   actionToolbarFirst: {


### PR DESCRIPTION
Used proper `max-width` > `maxWidth` for media queries within aprhodite

Make the toolbar taller on mobile to fit the wrapped buttons