### PR TITLE
add campaign title to the beginning of campaign message review

### DIFF
--- a/src/components/IncomingMessageList/ConversationPreviewModal.jsx
+++ b/src/components/IncomingMessageList/ConversationPreviewModal.jsx
@@ -61,7 +61,10 @@ const ConversationPreviewModal = (props) => {
 
   return (
     <Dialog
-      title='Conversation Review'
+      title={conversation
+        ? `Conversation Review: ${conversation.campaign.title}`
+        : 'Conversation Review'
+      }
       open={isOpen}
       actions={primaryActions}
       modal={false}


### PR DESCRIPTION
The problem here was that they couldn't select the fill campaign name if the campaign name was one word, since mui Datatables set's the cell override to hidden and text-overflow to ellipses.

I could not figure out how to override that styling, so I made it so they can see and select the campaign name via opening up the conversation. 