### PR TITLE
Fix mid-response Texter page refresh

### DIFF
--- a/src/components/AssignmentTexter.jsx
+++ b/src/components/AssignmentTexter.jsx
@@ -51,10 +51,6 @@ class AssignmentTexter extends React.Component {
   }
 
   componentWillUpdate(nextProps, nextState) {
-    if (this.contactCount() === 0) {
-      setTimeout(() => window.location.reload(), 5000)
-    }
-
     // When we send a message that changes the contact status,
     // then if parent.refreshData is called, then props.contactIds
     // will return a new list with the last contact removed and
@@ -74,6 +70,7 @@ class AssignmentTexter extends React.Component {
       }
     }
   }
+
   /*
     getContactData is a place where we've hit scaling issues in the past, and will be important
     to think carefully about for scaling considerations in the future.


### PR DESCRIPTION
I believe this is the culprit (see reasoning below), but even if not the state where `this.contactCount() === 0` is handled in `render()` so this is superfluous.

For the block I removed to cause a page refresh `contactIds` would need to be an empty array. This could potentially happen to due `refetchData()` being called on the query in `TexterTodo` as `loadData()` only displays the loading indicator during the first load -- all changes to the GraphQL props are passed down. `TexterTodo` polls every 20 seconds so this would not be unheard of.

`refetchData()` is also called:

* in `AssignmentTexterContact/index.jsx` after bulk send
* in `AssignmentTexterContact/index.jsx` if contact is out of timezone
* (via `TexterTodo.assignContactsIfNeeded()`) in `AssignmentTexter.jsx` in `handleFinishContact()` if there is no next contact
* (via `TexterTodo.assignContactsIfNeeded()`) in `TexterTodo` in `componentWillMount()`

(`assignContactsIfNeeded()` does nothing unless contacts.length === 0. It refetchs if dynamic assignment, otherwise it boots back to ToDos page)

`contactIds` is created by mapping `TexterTodo.props.data.assignment.contacts`. During a refetch, I _assume_ that `TexterTodo.props.data.assignment` would be `undefined` which would cause an error rather than mapping to an empty array, but I don't know how GraphQL handles `refetch()` -- maybe it does temporarily return an empty array -- and I can't find documentation for it.

Thoughts?