### PR TITLE
exclude opt-ed out contacts from becoming getting released

### DIFF
--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1643,7 +1643,8 @@ const rootMutations = {
         } else {
           return await trx('campaign_contact').where({
             campaign_id: parseInt(campaignId),
-            message_status: messageStatus
+            message_status: messageStatus,
+            is_opted_out: false
           }).update({
             assignment_id: null
           })


### PR DESCRIPTION
Confirmed with Kohlee that it was only when hours = 0. That matches the query using is_opted_out = false for the handwritten one, but not for the knex one.

