### PR TITLE
Fix campaign_contact.updated_at value in saveNewIncomingMessage.

### DIFF
--- a/src/server/api/lib/message-sending.js
+++ b/src/server/api/lib/message-sending.js
@@ -26,7 +26,7 @@ export async function saveNewIncomingMessage(messageInstance) {
   // Prefer to match on campaign contact ID
   if (messageInstance.campaign_contact_id) {
     updateQuery = updateQuery.where({
-      campaign_contact_id: messageInstance.campaign_contact_id
+      id: messageInstance.campaign_contact_id
     })
   } else {
     updateQuery = updateQuery.where({


### PR DESCRIPTION
Passing 'now()' as a string cause the timestamp to be incorrectly set to '0000-00-00 00:00:00'. This is because unix_timestamp('now()') returns 0.000000. To fix, we switch from rethink to knex and use a knex serverside function for now().