### PR TITLE
Request ID along with organization

### DIFF
--- a/src/components/TexterRequest.jsx
+++ b/src/components/TexterRequest.jsx
@@ -140,6 +140,7 @@ const mapQueriesToProps = ({ ownProps }) => ({
   data: {
     query: gql`query currentUser($organizationId: String!) {
       organization(id: $organizationId) {
+        id
         textRequestFormEnabled
         textRequestMaxCount
         textsAvailable


### PR DESCRIPTION
GraphQL needs this ID for updating client-side cache and complains without it.