### PR TITLE
Fix created_at filter.

### DIFF
--- a/src/workers/cron/release-old-unsent-messages.js
+++ b/src/workers/cron/release-old-unsent-messages.js
@@ -19,7 +19,7 @@ async function main() {
   let oneHourAgo = new Date(),
       oneWeekAgo = new Date();
   oneHourAgo.setHours(oneHourAgo.getHours() - 1);
-  oneWeekAgo.setDate(oneWeekAgo.getDate() - 1);
+  oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
 
   const selectResult = await db.raw(
     `


### PR DESCRIPTION
Many campaign contacts still have '0000-00-00 00:00:00' as their updated_at value due to a bug in how it was set (fixed in #114). Only searching within the last week for stale assignments prevents picking up on valid assignments with the buggy created_at value.

The comparison operators have been fixed as well; "more than one hour ago" should be `updated_at < oneHourAgo` and "within the last week" should be `updated_at > oneWeekAgo`.

Numeric exit codes were also added to make sure failed processes are treated as errors.