### PR TITLE
Prevent nodemon from restarting node server on client-side code changes

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,11 @@
+{
+  "verbose": true,
+  "ignore": [
+    "src/client",
+    "src/components/",
+    "src/containers/",
+    "src/store",
+    "src/styles",
+    "src/routes.jsx"
+  ]
+}


### PR DESCRIPTION
> Both nodemon and webpack are monitoring for changes in client-side code, causing a double restart every time a change is made in client-side code. This sometimes results in errors when webpack compiles changes faster than nodemon can restart the server.
> 
> With this config, nodemon will ignore saves in client-side code directories and files. Webpack will still recompile when these files are modified.
> -- @azuzunaga