### PR TITLE
Fix "Escalate conversation"

### DIFF
--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -49,7 +49,7 @@ const rootSchema = `
     campaignTitlePrefixes: [String]!
   }
 
-  input OptOutInput {
+  input ContactActionInput {
     assignmentId: String!
     cell: Phone!
     message: MessageInput
@@ -221,8 +221,8 @@ const rootSchema = `
     updateEscalationUserId(organizationId: String!, escalationUserId: Int): Organization
     bulkSendMessages(assignmentId: Int!): [CampaignContact]
     sendMessage(message:MessageInput!, campaignContactId:String!): CampaignContact,
-    escalateConversation(campaignContactId: String!, message: String): CampaignContact
-    createOptOut(optOut:OptOutInput!, campaignContactId:String!):CampaignContact,
+    escalateConversation(campaignContactId: String!, escalate: ContactActionInput!): CampaignContact
+    createOptOut(optOut:ContactActionInput!, campaignContactId:String!):CampaignContact,
     removeOptOut(cell:Phone!):[CampaignContact],
     editCampaignContactMessageStatus(messageStatus: String!, campaignContactId:String!): CampaignContact,
     deleteQuestionResponses(interactionStepIds:[String], campaignContactId:String!): CampaignContact,

--- a/src/components/AssignmentTexter.jsx
+++ b/src/components/AssignmentTexter.jsx
@@ -297,13 +297,7 @@ class AssignmentTexter extends React.Component {
     }
 
     if (payload.escalate) {
-      const message = payload.escalate.message ? ` with message '${payload.escalate.message}'` : ''
-      console.log(`Escalate contact: ${contact_id}${message}`)
-    }
-
-    if (payload.escalate) {
-      const { message } = payload.escalate
-      promises.push(this.props.mutations.escalateContact(contact_id, message)
+      promises.push(this.props.mutations.escalateContact(contact_id, payload.escalate)
         .then(catchError))
     }
 
@@ -424,7 +418,7 @@ AssignmentTexter.propTypes = {
 const mapMutationsToProps = () => ({
   createOptOut: (optOut, campaignContactId) => ({
     mutation: gql`
-      mutation createOptOut($optOut: OptOutInput!, $campaignContactId: String!) {
+      mutation createOptOut($optOut: ContactActionInput!, $campaignContactId: String!) {
         createOptOut(optOut: $optOut, campaignContactId: $campaignContactId) {
           id
           optOut {
@@ -439,10 +433,10 @@ const mapMutationsToProps = () => ({
       campaignContactId
     }
   }),
-  escalateContact: (campaignContactId, message) => ({
+  escalateContact: (campaignContactId, escalate) => ({
     mutation: gql`
-      mutation escalateConversation($campaignContactId: String!, $message: String) {
-        escalateConversation(campaignContactId: $campaignContactId, message: $message) {
+      mutation escalateConversation($campaignContactId: String!, $escalate: ContactActionInput!) {
+        escalateConversation(campaignContactId: $campaignContactId, escalate: $escalate) {
           id
           assignmentId
         }
@@ -450,7 +444,7 @@ const mapMutationsToProps = () => ({
     `,
     variables: {
       campaignContactId,
-      message
+      escalate
     }
   }),
   editCampaignContactMessageStatus: (messageStatus, campaignContactId) => ({

--- a/src/components/IncomingMessageList/MessageColumn/MessageOptOut.jsx
+++ b/src/components/IncomingMessageList/MessageColumn/MessageOptOut.jsx
@@ -165,7 +165,7 @@ MessageOptOut.propTypes = {
 const mapMutationsToProps = () => ({
   createOptOut: (optOut, campaignContactId) => ({
     mutation: gql`
-      mutation createOptOut($optOut: OptOutInput!, $campaignContactId: String!) {
+      mutation createOptOut($optOut: ContactActionInput!, $campaignContactId: String!) {
         createOptOut(optOut: $optOut, campaignContactId: $campaignContactId) {
           id
           optOut {

--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -433,33 +433,20 @@ export class AssignmentTexterContact extends React.Component {
 
   handleEscalate = () => {
     const { disabled, escalateMessageText } = this.state
-    const { contact } = this.props
+    const { assignment, contact } = this.props
     if (disabled) {
       return // stops from multi-send
     }
     this.setState({ disabled: true })
 
-    const escalate = {}
+    const escalate = {
+      cell: contact.cell,
+      assignmentId: assignment.id
+    }
+
     if (escalateMessageText && escalateMessageText.length) {
-      const message = this.createMessageToContact(optOutMessageText)
+      const message = this.createMessageToContact(escalateMessageText)
       escalate.message = message
-    }
-
-    const payload = Object.assign({}, { escalate })
-    this.props.sendMessage(contact.id, payload)
-  }
-
-  handleEscalate = () => {
-    const { disabled, escalateMessageText } = this.state
-    const { contact } = this.props
-    if (disabled) {
-      return // stops from multi-send
-    }
-    this.setState({ disabled: true })
-
-    const escalate = {}
-    if (escalateMessageText && escalateMessageText.length) {
-      escalate.message = escalateMessageText
     }
 
     const payload = Object.assign({}, { escalate })


### PR DESCRIPTION
**Standardize ContactAction usage**
We use common ContactAction UI for opt-outs and escalations, but the mutations were different. This removes rebase artifacts (duplicate definitions) and standardizes how contact action mutations are declared.