### PR TITLE
Optimize "Release for Second Pass" query

### DIFF
--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1516,7 +1516,6 @@ const rootMutations = {
             where
               newer_contact.cell = current_contact.cell
               and newer_contact.created_at > current_contact.created_at
-            limit 1
           )
         ;
       `, [parseInt(campaignId)])


### PR DESCRIPTION
The two part `whereIn` query was timing out. If reporting `skippingCells` is important, we can do that with a second query (executed first):

```sql
select
  count(current_contact.cell)
from
  campaign_contact as current_contact
where
  current_contact.message_status = 'messaged'
  and current_contact.campaign_id = 576
  and exists (
    select
      cell
    from
      campaign_contact as newer_contact
    where
      newer_contact.cell = current_contact.cell
      and newer_contact.created_at > current_contact.created_at
    limit 1
  )
;
```