### PR TITLE
Increase Nginx timeout

### DIFF
--- a/.ebextensions/02_extend-proxy-timeout.config
+++ b/.ebextensions/02_extend-proxy-timeout.config
@@ -1,0 +1,10 @@
+container_commands:
+  extend_proxy_timeout:
+    command: |
+      sed -i '/\s*location \/ {/c \
+              location / { \
+                  proxy_connect_timeout       600;\
+                  proxy_send_timeout          600;\
+                  proxy_read_timeout          600;\
+                  send_timeout                600;\
+              ' /tmp/deployment/config/#etc#nginx#conf.d#00_elastic_beanstalk_proxy.conf


### PR DESCRIPTION
Following instructions [here](https://medium.com/tomincode/extending-gateway-timeouts-with-node-js-elastic-beanstalk-applications-5cb256f08f4b) and [here](https://stackoverflow.com/a/47169533):

1. Increase load balancer timeout in [EC2 console](https://us-east-2.console.aws.amazon.com/ec2/v2/home?region=us-east-2#LoadBalancers:sort=loadBalancerName).
2. Add timeout directives to Nginx configuration with additional EB configuration file (d751ff8)