### PR TITLE
Combine many queries into one.

### DIFF
--- a/migrations/20190523154700_add_index_campaign_contact_get_assignment.js
+++ b/migrations/20190523154700_add_index_campaign_contact_get_assignment.js
@@ -1,0 +1,13 @@
+// Add index for fetching current assignment target
+exports.up = function(knex, Promise) {
+  return knex.schema.alterTable('campaign_contact', table => {
+    table.index(['campaign_id, assignment_id, message_status, is_opted_out'], 'campaign_contact_get_current_assignment_index')
+  })
+}
+
+// Drop index for fetching current assignment target
+exports.down = function(knex, Promise) {
+  return knex.schema.alterTable('campaign_contact', table => {
+    table.dropIndex(['campaign_id, assignment_id, message_status, is_opted_out'], 'campaign_contact_get_current_assignment_index')
+  })
+}


### PR DESCRIPTION
This is still not great, and likely needs further optimization

```

spoke_prod=> explain analyze select
spoke_prod->       campaign.*
spoke_prod->     from
spoke_prod->       campaign
spoke_prod->     left join
spoke_prod->       campaign_contact
spoke_prod->       on campaign_contact.id = (
spoke_prod(>         select id
spoke_prod(>         from campaign_contact
spoke_prod(>         where
spoke_prod(>           campaign_contact.campaign_id = campaign.id
spoke_prod(>           and assignment_id is null
spoke_prod(>           and message_status = 'needsMessage'
spoke_prod(>           and is_opted_out = false
spoke_prod(>         limit 1
spoke_prod(>       )
spoke_prod->     where
spoke_prod->       is_started = true
spoke_prod->       and is_archived = false
spoke_prod->       and is_autoassign_enabled = true
spoke_prod->       and texting_hours_end > extract(hour from (CURRENT_TIMESTAMP at time zone campaign.timezone))
spoke_prod->       and campaign_contact.id is not null
spoke_prod-> ;
                                                                                               QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=3.15..42.56 rows=1 width=218) (actual time=8395.925..25602.874 rows=1 loops=1)
   ->  Seq Scan on campaign  (cost=0.00..31.40 rows=1 width=218) (actual time=0.234..0.630 rows=16 loops=1)
         Filter: (is_started AND (NOT is_archived) AND is_autoassign_enabled AND ((texting_hours_end)::double precision > date_part('hour'::text, timezone(timezone, CURRENT_TIMESTAMP))))
         Rows Removed by Filter: 538
   ->  Index Only Scan using campaign_contact_pkey on campaign_contact  (cost=3.15..11.17 rows=1 width=4) (actual time=0.002..0.002 rows=0 loops=16)
         Index Cond: ((id = (SubPlan 1)) AND (id IS NOT NULL))
         Heap Fetches: 1
         SubPlan 1
           ->  Limit  (cost=0.43..2.71 rows=1 width=4) (actual time=1600.129..1600.129 rows=0 loops=16)
                 ->  Index Scan using campaign_contact_campaign_id_index on campaign_contact campaign_contact_1  (cost=0.43..3412.04 rows=1498 width=4) (actual time=1600.128..1600.128 rows=0 loops=16)
                       Index Cond: (campaign_id = campaign.id)
                       Filter: ((assignment_id IS NULL) AND (NOT is_opted_out) AND (message_status = 'needsMessage'::text))
                       Rows Removed by Filter: 12352
 Planning time: 0.895 ms
 Execution time: 25602.931 ms
(15 rows)
```