### PR TITLE
Escape findAndReplace RegEx

### DIFF
--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1139,10 +1139,7 @@ const rootMutations = {
 
         const scriptUpdates = [];
         for (let step of interactionStepsToChange) {
-          const newText = step.script.replace(
-            new RegExp(searchString, "g"),
-            replaceString
-          );
+          const newText = replaceAll(step.script, searchString, replaceString);
 
           const scriptUpdate = {
             campaignId: step.campaign_id,


### PR DESCRIPTION
`replaceAll` was added for replacing short link domains and escapes RegEx special characters.