### PR TITLE
Clean up Twilio's message report handler

### DIFF
--- a/dev-tools/reapply-message-reports.sql
+++ b/dev-tools/reapply-message-reports.sql
@@ -1,0 +1,52 @@
+-- Select query to look at forward progress differences
+with latest_log as
+  (select message_sid,
+          (case
+               when message_status = 'queued' then 'SENDING'
+               when message_status = 'failed' then 'ERROR'
+               when message_status = 'sent' then 'SENT'
+               when message_status = 'delivered' then 'DELIVERED'
+               when message_status = 'undelivered' then 'ERROR'
+           end) as spoke_status
+   from (
+           (select distinct on (message_sid) message_sid,
+                               body::json->>'MessageStatus' as message_status
+            from log
+            where created_at > now() - interval '20 minute'
+            order by message_sid,
+                     created_at desc)) as log_status)
+select message.service_id,
+       message.send_status,
+       latest_log.spoke_status
+from message,
+     latest_log
+where message.service_id = latest_log.message_sid
+  and message.send_status <> latest_log.spoke_status
+  and message.send_status <> 'DELIVERED'
+  and message.send_status <> 'ERROR' ;
+
+-- Update query to replay the log entries
+-- (This may need some chunking to work on a large replay)
+with latest_log as
+  (select message_sid,
+          (case
+               when message_status = 'queued' then 'SENDING'
+               when message_status = 'failed' then 'ERROR'
+               when message_status = 'sent' then 'SENT'
+               when message_status = 'delivered' then 'DELIVERED'
+               when message_status = 'undelivered' then 'ERROR'
+           end) as spoke_status
+   from (
+           (select distinct on (message_sid) message_sid,
+                               body::json->>'MessageStatus' as message_status
+            from log
+            order by message_sid,
+                     created_at desc)) as log_status)
+update message
+set send_status = latest_log.spoke_status
+from latest_log
+where message.service_id = latest_log.message_sid
+  and message.send_status <> latest_log.spoke_status
+  and message.send_status <> 'DELIVERED'
+  and message.send_status <> 'ERROR' ;
+

--- a/dev-tools/reapply-message-reports.sql
+++ b/dev-tools/reapply-message-reports.sql
@@ -1,52 +1,92 @@
 -- Select query to look at forward progress differences
-with latest_log as
-  (select message_sid,
-          (case
-               when message_status = 'queued' then 'SENDING'
-               when message_status = 'failed' then 'ERROR'
-               when message_status = 'sent' then 'SENT'
-               when message_status = 'delivered' then 'DELIVERED'
-               when message_status = 'undelivered' then 'ERROR'
-           end) as spoke_status
-   from (
-           (select distinct on (message_sid) message_sid,
-                               body::json->>'MessageStatus' as message_status
-            from log
-            where created_at > now() - interval '20 minute'
-            order by message_sid,
-                     created_at desc)) as log_status)
-select message.service_id,
-       message.send_status,
-       latest_log.spoke_status
-from message,
-     latest_log
-where message.service_id = latest_log.message_sid
+with
+  latest_log as (
+    select
+      message_sid,
+      service_response_at,
+      (case
+        when message_status = 'queued' then 'SENDING'
+        when message_status = 'failed' then 'ERROR'
+        when message_status = 'sent' then 'SENT'
+        when message_status = 'delivered' then 'DELIVERED'
+        when message_status = 'undelivered' then 'ERROR'
+        end) as spoke_status
+    from (
+      select distinct on (message_sid)
+        message_sid,
+        created_at as service_response_at,
+        body::json->>'MessageStatus' as message_status
+      from
+        log
+      where
+        created_at > now() - interval '20 minute'
+      order by
+        message_sid,
+        created_at desc
+    ) as log_status
+  )
+select
+  message.service_id,
+  message.send_status,
+  latest_log.spoke_status,
+  latest_log.service_response_at
+from
+  message,
+  latest_log
+where
+  message.service_id = latest_log.message_sid
   and message.send_status <> latest_log.spoke_status
   and message.send_status <> 'DELIVERED'
-  and message.send_status <> 'ERROR' ;
+  and message.send_status <> 'ERROR'
+;
 
--- Update query to replay the log entries
--- (This may need some chunking to work on a large replay)
-with latest_log as
-  (select message_sid,
-          (case
-               when message_status = 'queued' then 'SENDING'
-               when message_status = 'failed' then 'ERROR'
-               when message_status = 'sent' then 'SENT'
-               when message_status = 'delivered' then 'DELIVERED'
-               when message_status = 'undelivered' then 'ERROR'
-           end) as spoke_status
-   from (
-           (select distinct on (message_sid) message_sid,
-                               body::json->>'MessageStatus' as message_status
-            from log
-            order by message_sid,
-                     created_at desc)) as log_status)
-update message
-set send_status = latest_log.spoke_status
-from latest_log
-where message.service_id = latest_log.message_sid
-  and message.send_status <> latest_log.spoke_status
-  and message.send_status <> 'DELIVERED'
-  and message.send_status <> 'ERROR' ;
-
+-- Update query to replay the log entries (idempotent)
+with
+  latest_log as (
+    select
+      message_sid,
+      service_response_at,
+      (case
+        when message_status = 'queued' then 'SENDING'
+        when message_status = 'failed' then 'ERROR'
+        when message_status = 'sent' then 'SENT'
+        when message_status = 'delivered' then 'DELIVERED'
+        when message_status = 'undelivered' then 'ERROR'
+      end) as spoke_status
+    from (
+      select distinct on (message_sid)
+        message_sid,
+        created_at as service_response_at,
+        body::json->>'MessageStatus' as message_status
+      from
+        log
+      order by
+        message_sid,
+        created_at desc
+    ) as log_status
+  ),
+  update_payload as (
+    select
+      message.service_id,
+      latest_log.spoke_status,
+      latest_log.service_response_at
+    from
+      message,
+      latest_log
+    where
+      message.service_id = latest_log.message_sid
+      and message.send_status <> latest_log.spoke_status
+      and message.send_status <> 'DELIVERED'
+      and message.send_status <> 'ERROR'
+    limit 100
+  )
+update
+  message
+set
+  send_status = update_payload.spoke_status,
+  service_response_at = update_payload.service_response_at
+from
+  update_payload
+where
+  message.service_id = update_payload.service_id
+;

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -151,12 +151,7 @@ app.post(
   "/twilio-message-report",
   twilio.headerValidator(),
   wrap(async (req, res) => {
-    try {
-      const body = req.body;
-      await twilio.handleDeliveryReport(body);
-    } catch (ex) {
-      log.error(ex);
-    }
+    await twilio.handleDeliveryReport(req.body);
     const resp = new TwimlResponse();
     res.writeHead(200, { "Content-Type": "text/xml" });
     res.end(resp.toString());


### PR DESCRIPTION
I have tested the select and update queries limited to the last 20 minutes within transactions that were then rolled back.