### PR TITLE
Revert react-formal upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "react-async-script": "^0.6.0",
     "react-chartjs": "^0.7.3",
     "react-dom": "^15.6.1",
-    "react-formal": "^0.25.4",
+    "react-formal": "^0.18.9",
     "react-router": "^2.5.2",
     "react-router-redux": "^4.0.5",
     "react-select": "^2.0.0",

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -21,7 +21,7 @@ Form.addInputTypes({
   date: GSDateField,
   email: GSTextField,
   script: GSScriptField,
-  scriptOptions: GSScriptOptionsField,
+  scriptoptions: GSScriptOptionsField,
   select: GSSelectField
 });
 

--- a/src/components/CampaignInteractionStepsForm.jsx
+++ b/src/components/CampaignInteractionStepsForm.jsx
@@ -225,7 +225,7 @@ class CampaignInteractionStepsForm extends React.Component {
               <Form.Field
                 {...dataTest("editorInteraction")}
                 name="scriptOptions"
-                type="scriptOptions"
+                type="scriptoptions"
                 label="Script"
                 hintText="This is what your texters will send to your contacts. E.g. Hi, {firstName}. It's {texterFirstName} here."
                 customFields={customFields}


### PR DESCRIPTION
The upgrade was to allow case-sensitive type names. The upgrade introduced multiple bugs, specifically around how onChange was passed.