### PR TITLE
Reduce scope of regex to specific domain

### DIFF
--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -149,7 +149,12 @@ const replaceShortLinkDomains = async (organizationId, messageText) => {
   }
 
   const replacerReducer = (text, domain) => {
-    return replaceAll(text, domain, targetDomain);
+    const domainRegex = RegExp(
+      "/(https?:\/\/)"
+      + escapeRegExp(domain)
+      + "(:*)/g"
+    );
+    return text.replace(domainRegex, "$1" + targetDomain + "$3");
   };
   const finalMessageText = domains.reduce(replacerReducer, messageText);
   return finalMessageText;


### PR DESCRIPTION
The replaceAll approach produced incorrect outputs in certain conditions. Say we have two domains: adomain.com domain.com and our target domain is adomain.com. Using the replaceAll approach, the text "Go to https://adomain.com/link" will have both matching domains replaced with the target domain and will end up as "Go to https://aadomain.com/link". Instead, we want to use a more targeted regex to match on and replace the extact host portion of the URL.