### PR TITLE
fix: construct and use RegEx correctly

### DIFF
--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -149,10 +149,9 @@ const replaceShortLinkDomains = async (organizationId, messageText) => {
   }
 
   const replacerReducer = (text, domain) => {
-    const domainRegex = RegExp(
-      "/(https?://)" + escapeRegExp(domain) + "(:*)/g"
-    );
-    return text.replace(domainRegex, "$1" + targetDomain + "$3");
+    const safeDomain = escapeRegExp(domain);
+    const domainRegex = RegExp(`(https?://)${safeDomain}(:*)`, "g");
+    return text.replace(domainRegex, "$1" + targetDomain + "$2");
   };
   const finalMessageText = domains.reduce(replacerReducer, messageText);
   return finalMessageText;


### PR DESCRIPTION
The previous RegEx mixed syntax for raw RegEx construction and construction using `Regex()`.
With the new RegEx there are only two match groups (as it should be): the text before the domain
and the text after the domain.