### PR TITLE
Add datadog support via dogstatsd

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "body-parser": "^1.15.2",
     "camelcase-keys": "^4.1.0",
     "chart.js": "^1.1.1",
+    "connect-datadog-graphql": "0.0.10",
     "cookie-session": "^2.0.0-alpha.1",
     "dataloader": "^1.2.0",
     "dotenv": "^8.0.0",

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -75,18 +75,20 @@ if (!DEBUG && process.env.PUBLIC_DIR) {
 app.use(bodyParser.json({ limit: "50mb" }));
 app.use(bodyParser.urlencoded({ extended: true }));
 
-const datadogOptions = {
-  path: true,
-  method: false,
-  response_code: true,
-  graphql_paths: "/graphql"
-};
+if (process.env.DD_AGENT_HOST && process.env.DD_DOGSTATSD_PORT) {
+  const datadogOptions = {
+    path: true,
+    method: false,
+    response_code: true,
+    graphql_paths: "/graphql"
+  };
 
-if (process.env.CLIENT_NAME) {
-  datadogOptions.tags = [`client:${process.env.CLIENT_NAME}`];
+  if (process.env.CLIENT_NAME) {
+    datadogOptions.tags = [`client:${process.env.CLIENT_NAME}`];
+  }
+
+  app.use(connectDatadog(datadogOptions));
 }
-
-app.use(connectDatadog(datadogOptions));
 
 app.use(
   cookieSession({

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -28,6 +28,7 @@ import googleLibPhoneNumber from "google-libphonenumber";
 import requestLogging from "../lib/request-logging";
 import { checkForBadDeliverability } from "./api/lib/alerts";
 import cron from "node-cron";
+import connectDatadog from "connect-datadog-graphql";
 
 cron.schedule("0 */1 * * *", checkForBadDeliverability);
 
@@ -73,6 +74,19 @@ if (!DEBUG && process.env.PUBLIC_DIR) {
 
 app.use(bodyParser.json({ limit: "50mb" }));
 app.use(bodyParser.urlencoded({ extended: true }));
+
+const datadogOptions = {
+  path: true,
+  method: false,
+  response_code: true,
+  graphql_paths: "/graphql"
+};
+
+if (process.env.CLIENT_NAME) {
+  datadogOptions.tags = [`client:${process.env.CLIENT_NAME}`];
+}
+
+app.use(connectDatadog(datadogOptions));
 
 app.use(
   cookieSession({


### PR DESCRIPTION
This requires 2 new environment variables to actually run: `DD_AGENT_HOST` and `DD_DOGSTATSD_PORT`.