### PR TITLE
fix: use timezone-aware logic everywhere

### DIFF
--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -241,7 +241,7 @@ const rootSchema = `
     assignment(id:String!): Assignment
     organizations: [Organization]
     availableActions(organizationId:String!): [Action]
-    conversations(cursor:OffsetLimitCursor!, organizationId:String!, campaignsFilter:CampaignsFilter, assignmentsFilter:AssignmentsFilter, contactsFilter:ContactsFilter, contactNameFilter:ContactNameFilter, utc:String): PaginatedConversations
+    conversations(cursor:OffsetLimitCursor!, organizationId:String!, campaignsFilter:CampaignsFilter, assignmentsFilter:AssignmentsFilter, contactsFilter:ContactsFilter, contactNameFilter:ContactNameFilter): PaginatedConversations
     campaigns(organizationId:String!, cursor:OffsetLimitCursor, campaignsFilter: CampaignsFilter): CampaignsReturn
     people(organizationId:String!, cursor:OffsetLimitCursor, campaignsFilter:CampaignsFilter, role: String, userIds:[String]): UsersReturn
     peopleByUserIds(userIds:[String], organizationId:String!): UsersList

--- a/src/components/IncomingMessageList/MessageColumn/MessageList.jsx
+++ b/src/components/IncomingMessageList/MessageColumn/MessageList.jsx
@@ -62,15 +62,13 @@ class MessageList extends Component {
               </p>
               <p style={senderInfoStyle}>
                 {message.isFromContact
-                  ? `Received at ${moment(
-                      message.createdAt.replace("Z", "-04:00")
-                    ).fromNow()}`
+                  ? `Received at ${moment(message.createdAt).fromNow()}`
                   : message.sendStatus == "ERROR"
                     ? `Carrier rejected this message sent by ${senderName} at ${moment(
-                        message.createdAt.replace("Z", "-04:00")
+                        message.createdAt
                       ).fromNow()}`
                     : `Sent by ${senderName} ${moment(
-                        message.createdAt.replace("Z", "-04:00")
+                        message.createdAt
                       ).fromNow()}`}
               </p>
             </div>

--- a/src/components/IncomingMessageList/index.jsx
+++ b/src/components/IncomingMessageList/index.jsx
@@ -271,8 +271,7 @@ IncomingMessageList.propTypes = {
   onPageChanged: type.func,
   onPageSizeChanged: type.func,
   onConversationSelected: type.func,
-  onConversationCountChanged: type.func,
-  utc: type.string
+  onConversationCountChanged: type.func
 };
 
 const mapQueriesToProps = ({ ownProps }) => ({
@@ -285,7 +284,6 @@ const mapQueriesToProps = ({ ownProps }) => ({
         $campaignsFilter: CampaignsFilter
         $assignmentsFilter: AssignmentsFilter
         $contactNameFilter: ContactNameFilter
-        $utc: String
       ) {
         conversations(
           cursor: $cursor
@@ -294,7 +292,6 @@ const mapQueriesToProps = ({ ownProps }) => ({
           contactsFilter: $contactsFilter
           assignmentsFilter: $assignmentsFilter
           contactNameFilter: $contactNameFilter
-          utc: $utc
         ) {
           pageInfo {
             limit
@@ -340,8 +337,7 @@ const mapQueriesToProps = ({ ownProps }) => ({
       contactsFilter: ownProps.contactsFilter,
       campaignsFilter: ownProps.campaignsFilter,
       assignmentsFilter: ownProps.assignmentsFilter,
-      contactNameFilter: ownProps.contactNameFilter,
-      utc: ownProps.utc
+      contactNameFilter: ownProps.contactNameFilter
     },
     forceFetch: true
   }

--- a/src/components/MessageList.jsx
+++ b/src/components/MessageList.jsx
@@ -51,9 +51,7 @@ const MessageList = function MessageList(props) {
         leftIcon={<ProhibitedIcon style={{ fill: red300 }} />}
         disabled
         primaryText={`${contact.firstName} opted out of texts`}
-        secondaryText={moment(
-          optOut.createdAt.replace("Z", "-04:00")
-        ).fromNow()}
+        secondaryText={moment(optOut.createdAt).fromNow()}
       />
     </div>
   ) : (
@@ -75,9 +73,7 @@ const MessageList = function MessageList(props) {
             primaryText={
               <span style={{ whiteSpace: "pre-wrap" }}>{message.text}</span>
             }
-            secondaryText={`${moment(
-              message.createdAt.replace("Z", "-04:00")
-            ).fromNow()}`}
+            secondaryText={`${moment(message.createdAt).fromNow()}`}
           />
         );
       })}

--- a/src/containers/AdminIncomingMessageList/index.jsx
+++ b/src/containers/AdminIncomingMessageList/index.jsx
@@ -79,8 +79,6 @@ export class AdminIncomingMessageList extends Component {
       assignmentsFilter,
       contactNameFilter: undefined,
       needsRender: false,
-      // TODO - this is local timezone, not UTC
-      utc: Date.now().toString(),
       campaigns: [],
       reassignmentTexters: [],
       campaignTexters: [],
@@ -184,8 +182,6 @@ export class AdminIncomingMessageList extends Component {
       };
     }
 
-    // TODO - this is local timezone, not UTC
-    newState.utc = Date.now().toString();
     this.setState(newState);
   };
 
@@ -240,8 +236,6 @@ export class AdminIncomingMessageList extends Component {
     );
 
     this.setState({
-      // TODO - this is local timezone, not UTC
-      utc: Date.now().toString(),
       needsRender: true
     });
   };
@@ -477,7 +471,6 @@ export class AdminIncomingMessageList extends Component {
             includeEscalated={includeEscalated}
             contactNameFilter={this.state.contactNameFilter}
             selectedRows={this.state.selectedRows}
-            utc={this.state.utc}
             onPageChanged={this.handlePageChange}
             onPageSizeChanged={this.handlePageSizeChange}
             onConversationSelected={this.handleRowSelection}

--- a/src/server/api/campaign-contact.js
+++ b/src/server/api/campaign-contact.js
@@ -1,5 +1,5 @@
 import { CampaignContact, r, cacheableData } from "../models";
-import { mapFieldsToModel, normalizeTimezone } from "./lib/utils";
+import { mapFieldsToModel } from "./lib/utils";
 import { log, getTopMostParent, zipToTimeZone } from "../../lib";
 
 export const resolvers = {
@@ -42,7 +42,7 @@ export const resolvers = {
         updatedAt = campaignContact.created_at;
       }
 
-      return normalizeTimezone(updatedAt);
+      return updatedAt;
     },
     messageStatus: async (campaignContact, _, { loaders }) => {
       if (campaignContact.message_status) {

--- a/src/server/api/conversations.js
+++ b/src/server/api/conversations.js
@@ -100,8 +100,7 @@ export async function getConversations(
   campaignsFilter,
   assignmentsFilter,
   contactsFilter,
-  contactNameFilter,
-  utc
+  contactNameFilter
 ) {
   /* Query #1 == get campaign_contact.id for all the conversations matching
    * the criteria with offset and limit. */

--- a/src/server/api/lib/twilio.js
+++ b/src/server/api/lib/twilio.js
@@ -1,5 +1,6 @@
 import Twilio from "twilio";
 import _ from "lodash";
+import moment from "moment-timezone";
 import { getFormattedPhoneNumber } from "../../../lib/phone-format";
 import { Log, Message, PendingMessagePart, r } from "../../models";
 import { log } from "../../../lib";
@@ -273,11 +274,9 @@ async function sendMessage(message, organizationId, trx) {
       // the send_before time, less 30 seconds
       // we subtract the MESSAGE_VALIDITY_PADDING_SECONDS seconds to allow time for the message to be sent by
       // a downstream service
-      // TODO - this is local timezone, not UTC
       const messageValidityPeriod =
-        Math.ceil((message.send_before - Date.now()) / 1000) -
+        moment().diff(moment(message.send_before), "seconds") -
         MESSAGE_VALIDITY_PADDING_SECONDS;
-
       if (messageValidityPeriod < 0) {
         // this is an edge case
         // it means the message arrived in this function already too late to be sent

--- a/src/server/api/lib/twilio.js
+++ b/src/server/api/lib/twilio.js
@@ -275,7 +275,7 @@ async function sendMessage(message, organizationId, trx) {
       // we subtract the MESSAGE_VALIDITY_PADDING_SECONDS seconds to allow time for the message to be sent by
       // a downstream service
       const messageValidityPeriod =
-        moment().diff(moment(message.send_before), "seconds") -
+        moment(message.send_before).diff(moment(), "seconds") -
         MESSAGE_VALIDITY_PADDING_SECONDS;
       if (messageValidityPeriod < 0) {
         // this is an edge case

--- a/src/server/api/lib/utils.js
+++ b/src/server/api/lib/utils.js
@@ -24,11 +24,3 @@ export const capitalizeWord = word => {
   }
   return "";
 };
-
-export const normalizeTimezone = serverDate => {
-  const now = new Date();
-  const currentTzOffset = now.getTimezoneOffset() / 60;
-  serverDate = new Date(serverDate);
-  serverDate.setHours(serverDate.getHours() - currentTzOffset);
-  return serverDate;
-};

--- a/src/server/api/message.js
+++ b/src/server/api/message.js
@@ -1,4 +1,4 @@
-import { mapFieldsToModel, normalizeTimezone } from "./lib/utils";
+import { mapFieldsToModel } from "./lib/utils";
 import { Message } from "../models";
 
 export const resolvers = {
@@ -10,14 +10,12 @@ export const resolvers = {
         "userNumber",
         "contactNumber",
         "isFromContact",
-        "sendStatus"
+        "sendStatus",
+        "createdAt"
       ],
       Message
     ),
     campaignId: instance => instance["campaign_id"],
-    createdAt: instance => {
-      return normalizeTimezone(instance.created_at);
-    },
     userId: instance => instance["user_id"]
   }
 };

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -5,6 +5,7 @@ import { GraphQLError } from "graphql/error";
 import isUrl from "is-url";
 import request from "superagent";
 import _ from "lodash";
+import moment from "moment-timezone";
 import { organizationCache } from "../models/cacheable_queries/organization";
 
 import { gzip, log, makeTree } from "../../lib";
@@ -536,8 +537,7 @@ async function sendMessage(
 
   const sendBeforeDate = sendBefore ? sendBefore.toDate() : null;
 
-  // TODO - this is local timezone, not UTC
-  if (sendBeforeDate && sendBeforeDate <= Date.now()) {
+  if (sendBeforeDate && moment(sendBeforeDate).isSameOrBefore(moment())) {
     throw new GraphQLError("Outside permitted texting time for this recipient");
   }
 
@@ -2448,8 +2448,7 @@ const rootResolvers = {
         campaignsFilter,
         assignmentsFilter,
         contactsFilter,
-        contactNameFilter,
-        utc
+        contactNameFilter
       },
       { user }
     ) => {
@@ -2461,8 +2460,7 @@ const rootResolvers = {
         campaignsFilter,
         assignmentsFilter,
         contactsFilter,
-        contactNameFilter,
-        utc
+        contactNameFilter
       );
     },
     campaigns: async (


### PR DESCRIPTION
The `conversations()` doesn't use the `utc` argument so I just removed it.