### PR TITLE
build(elastic-beanstalk): fix eb dir permissions

### DIFF
--- a/.ebextensions/03_fix_eb_permissions.config
+++ b/.ebextensions/03_fix_eb_permissions.config
@@ -1,0 +1,10 @@
+files:
+  "/opt/elasticbeanstalk/hooks/appdeploy/pre/00_set_tmp_permissions.sh":
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      #!/usr/bin/env bash
+      chown -R ec2-user /tmp
+      chown -R $USER:$(id -gn $USER) /tmp/.config
+      chown -R nodejs:nodejs /tmp/.npm


### PR DESCRIPTION
node-gyp now fails to run with the file permissions on EB. This script will set ownership of /tmp
to allow node-gyp to run.

See https://stackoverflow.com/a/49986304