### PR TITLE
Fix texter tags ui

### DIFF
--- a/src/containers/AssignmentTexterContact/ApplyTagButton.jsx
+++ b/src/containers/AssignmentTexterContact/ApplyTagButton.jsx
@@ -128,6 +128,7 @@ class ApplyTagButton extends Component {
             dataSourceConfig={{ text: "title", value: "id" }}
             dataSource={allTags}
             fullWidth={true}
+            openOnFocus={true}
             onBeforeRequestAdd={this.handleBeforeRequestAdd}
             onRequestAdd={this.handleAddTag}
             onRequestDelete={this.handleRemoveTag}

--- a/src/containers/AssignmentTexterContact/ApplyTagButton.jsx
+++ b/src/containers/AssignmentTexterContact/ApplyTagButton.jsx
@@ -18,6 +18,10 @@ class ApplyTagButton extends Component {
     confirmStepIndex: -1
   };
 
+  componentWillMount() {
+    this.selectedTags = this.props.pendingNewTags;
+  }
+
   resetTags = () =>
     this.setState({ selectedTags: this.props.contactTags.slice() });
 
@@ -172,6 +176,7 @@ class ApplyTagButton extends Component {
 ApplyTagButton.propTypes = {
   contactTags: PropTypes.arrayOf(PropTypes.string).isRequired,
   allTags: PropTypes.arrayOf(PropTypes.object).isRequired,
+  pendingNewTags: PropTypes.arrayOf(PropTypes.object).isRequired,
   onApplyTag: PropTypes.func.isRequired
 };
 

--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -475,7 +475,7 @@ export class AssignmentTexterContact extends React.Component {
     this.setState({ dialogType: TexterDialogType.OptOut });
   };
 
-  handleApplyTags = (addedTags, removedTags) => {
+  handleApplyTags = (addedTags, removedTags, callback) => {
     const pendingNewTags = this.props.contact.contactTags || [];
 
     addedTags.forEach(addedTag => {
@@ -498,12 +498,25 @@ export class AssignmentTexterContact extends React.Component {
       }
     });
 
-    this.setState({ addedTags, removedTags, pendingNewTags });
-    if (addedTags.length > 0) {
+    if (callback) {
+      this.setState({ addedTags, removedTags, pendingNewTags }, callback);
+    } else {
+      this.setState({ addedTags, removedTags, pendingNewTags });
+    }
+
+    if (!callback && addedTags.length > 0) {
       const mostImportantTag = sortBy(addedTags, "id")[0];
       const tagMessageText = mostImportantTag.onApplyScript;
       this.handleChangeScript(tagMessageText);
     }
+  };
+
+  handleApplyTagsAndMoveOn = (addedTags, removedTags) => {
+    this.handleApplyTags(addedTags, removedTags, async () => {
+      const { contact } = this.props;
+      const payload = this.gatherSurveyAndTagChanges();
+      await this.props.sendMessage(contact.id, payload);
+    });
   };
 
   handleCloseDialog = () => {
@@ -737,6 +750,7 @@ export class AssignmentTexterContact extends React.Component {
                 pendingNewTags={pendingNewTags}
                 allTags={tags}
                 onApplyTag={this.handleApplyTags}
+                onApplyTagsAndMoveOn={this.handleApplyTagsAndMoveOn}
               />
               <div style={{ float: "right", marginLeft: 20 }}>
                 {navigationToolbarChildren}

--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -207,6 +207,7 @@ export class AssignmentTexterContact extends React.Component {
       tagMessageText: "",
       addedTags: [],
       removedTags: [],
+      pendingNewTags: [],
       responsePopoverOpen: false,
       messageText: this.getStartingMessageText(),
       dialogType: TexterDialogType.None,
@@ -472,7 +473,29 @@ export class AssignmentTexterContact extends React.Component {
   };
 
   handleApplyTags = (addedTags, removedTags) => {
-    this.setState({ addedTags, removedTags });
+    const pendingNewTags = this.props.contact.contactTags || [];
+
+    addedTags.forEach(addedTag => {
+      const tagDoesNotExist = !pendingNewTags.find(
+        currentTag => currentTag.id === addedTag.id
+      );
+
+      if (tagDoesNotExist) {
+        pendingNewTags.push(addedTag);
+      }
+    });
+
+    removedTags.forEach(removedTag => {
+      const idxOfExistingTag = pendingNewTags.findIndex(
+        currentTag => currentTag.id === removedTag.id
+      );
+
+      if (idxOfExistingTag > -1) {
+        pendingNewTags.splice(idxOfExistingTag, 1);
+      }
+    });
+
+    this.setState({ addedTags, removedTags, pendingNewTags });
     if (addedTags.length > 0) {
       const mostImportantTag = sortBy(addedTags, "id")[0];
       const tagMessageText = mostImportantTag.onApplyScript;
@@ -614,7 +637,7 @@ export class AssignmentTexterContact extends React.Component {
     const { userCannedResponses, campaignCannedResponses } = assignment;
     const isCannedResponseEnabled =
       userCannedResponses.length + campaignCannedResponses.length > 0;
-    const { justSentNew, alreadySent } = this.state;
+    const { justSentNew, alreadySent, pendingNewTags } = this.state;
     const { messageStatus } = contact;
     const size = document.documentElement.clientWidth;
 
@@ -708,6 +731,7 @@ export class AssignmentTexterContact extends React.Component {
               />
               <ApplyTagButton
                 contactTags={contact.contactTags}
+                pendingNewTags={pendingNewTags}
                 allTags={tags}
                 onApplyTag={this.handleApplyTags}
               />

--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -423,6 +423,7 @@ export class AssignmentTexterContact extends React.Component {
       addedTagIds: addedTags.map(tag => tag.id),
       removedTagIds: removedTags.map(tag => tag.id)
     };
+
     if (tag.addedTagIds || tag.removedTagIds) changes.tag = tag;
 
     // Return aggregate changes
@@ -430,8 +431,10 @@ export class AssignmentTexterContact extends React.Component {
   };
 
   handleClickCloseContactButton = async () => {
+    const { contact } = this.props;
     await this.handleEditMessageStatus("closed");
-    this.props.onFinishContact();
+    const payload = this.gatherSurveyAndTagChanges();
+    await this.props.sendMessage(contact.id, payload);
   };
 
   handleEditMessageStatus = async messageStatus => {


### PR DESCRIPTION
Changes:

- Automatically open tags dropdown on focus so texter can see available tags
- Add an escalate button that adds the Escalate tag, identified via title = 'Escalate(d)'
- Persist tag state between dialog open and closes
- Apply tags when skip reply is clicked
- Add option to apply tags without sending the message if a not assignable tag is added