### PR TITLE
chore: support only postgres

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -164,13 +164,26 @@ if (isClient()) {
       example: "postgres://username:password@127.0.0.1:5432/db_name",
       default: undefined
     }),
-    DB_JSON: str({
-      desc: "JSON string containing database configuration options.",
-      default: undefined
-    }),
     DB_HOST: host({
       desc: "Domain or IP address of database host.",
       example: "pg-db.example.org",
+      default: undefined
+    }),
+    DB_PORT: num({
+      desc: "Database port number.",
+      default: 5432
+    }),
+    DB_NAME: str({
+      desc: "Database name.",
+      example: "spoke_prod",
+      default: undefined
+    }),
+    DB_USER: str({
+      desc: "Database username.",
+      default: undefined
+    }),
+    DB_PASSWORD: str({
+      desc: "Database password.",
       default: undefined
     }),
     DB_MIN_POOL: num({
@@ -188,16 +201,6 @@ if (isClient()) {
     DB_REAP_INTERVAL_MS: num({
       desc: "How often to check for idle resources to destroy",
       default: 1000
-    }),
-    DB_NAME: str({
-      desc: "Database connection name.",
-      example: "spoke_prod",
-      default: undefined
-    }),
-    DB_TYPE: str({
-      desc: "Database connection type for Knex.",
-      choices: ["mysql", "pg", "sqlite3"],
-      default: undefined
     }),
     DB_USE_SSL: bool({
       desc:

--- a/src/server/knex.js
+++ b/src/server/knex.js
@@ -9,87 +9,50 @@ const pg = require("pg");
 // see https://github.com/tgriesser/knex/issues/852
 pg.defaults.ssl = config.DB_USE_SSL;
 
-// Default to SQLite
-let knexConfig = {
-  client: "sqlite3",
-  connection: { filename: "./mydb.sqlite" },
-  defaultsUnsupported: true
-};
-
 // https://dba.stackexchange.com/questions/164419/is-it-possible-to-limit-timeout-on-postgres-server
-const pgAfterCreate = (conn, done) =>
+const afterCreate = (conn, done) =>
   conn.query(
     `SET idle_in_transaction_session_timeout = ${config.DB_IDLE_TIMEOUT_MS};`,
     (error, _results, _fields) => done(error, conn)
   );
 
-// Set connection to utf8mb4 collation
-const mySqlAfterCreate = (conn, done) =>
-  conn.query(
-    "SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci;",
-    (error, _results, _fields) => done(error, conn)
-  );
+let connection = {};
 
 if (config.isTest) {
-  knexConfig = {
-    client: "pg",
-    connection: {
-      host: config.DB_HOST,
-      port: config.DB_PORT,
-      database: "spoke_test",
-      password: "spoke_test",
-      user: "spoke_test",
-      ssl: config.DB_USE_SSL
-    }
-  };
-} else if (config.DB_JSON) {
-  knexConfig = JSON.parse(config.DB_JSON);
-} else if (config.DATABASE_URL) {
-  let dbType = config.DATABASE_URL.match(/^\w+/)[0];
-  dbType = /postgres/.test(dbType) ? "pg" : dbType;
-  const afterCreate = /mysql/.test(dbType) ? mySqlAfterCreate : pgAfterCreate;
-  knexConfig = {
-    client: dbType,
-    connection: config.DATABASE_URL,
-    pool: {
-      min: config.DB_MAX_POOL,
-      max: config.DB_MAX_POOL,
-      idleTimeoutMillis: config.DB_IDLE_TIMEOUT_MS,
-      reapIntervalMillis: config.DB_REAP_INTERVAL_MS,
-      afterCreate
-    },
+  connection = {
+    host: config.DB_HOST,
+    port: config.DB_PORT,
+    database: "spoke_test",
+    password: "spoke_test",
+    user: "spoke_test",
     ssl: config.DB_USE_SSL
   };
-} else if (config.DB_TYPE && config.DB_TYPE !== "sqlite3") {
-  const afterCreate = /mysql/.test(config.DB_TYPE)
-    ? mySqlAfterCreate
-    : pgAfterCreate;
-  knexConfig = {
-    client: config.DB_TYPE,
-    connection: {
-      host: config.DB_HOST,
-      port: config.DB_PORT,
-      database: config.DB_NAME,
-      password: config.DB_PASSWORD,
-      user: config.DB_USER,
-      ssl: config.DB_USE_SSL
-    },
-    pool: {
-      min: config.DB_MAX_POOL,
-      max: config.DB_MAX_POOL,
-      idleTimeoutMillis: config.DB_IDLE_TIMEOUT_MS,
-      reapIntervalMillis: config.DB_REAP_INTERVAL_MS,
-      afterCreate
-    }
+} else if (config.DATABASE_URL) {
+  connection = config.DATABASE_URL;
+} else {
+  connection = {
+    host: config.DB_HOST,
+    port: config.DB_PORT,
+    database: config.DB_NAME,
+    password: config.DB_PASSWORD,
+    user: config.DB_USER,
+    ssl: config.DB_USE_SSL
   };
 }
 
-const seedSettings = {
+const knexConfig = {
+  client: "pg",
+  connection,
+  pool: {
+    min: config.DB_MAX_POOL,
+    max: config.DB_MAX_POOL,
+    idleTimeoutMillis: config.DB_IDLE_TIMEOUT_MS,
+    reapIntervalMillis: config.DB_REAP_INTERVAL_MS,
+    afterCreate
+  },
   seeds: {
     directory: "./seeds"
   }
 };
-
-knexConfig = Object.assign(knexConfig, seedSettings);
 
 module.exports = knexConfig;


### PR DESCRIPTION
This officially drops support for other database engines. It has been tested with DATABASE_URL as
well as DB_HOST, DB_PORT, DB_NAME, DB_USER, and DB_PASSWORD.