### PR TITLE
build: add missing slack entries to yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9841,6 +9841,13 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
+slack@^11.0.2:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/slack/-/slack-11.0.2.tgz#30f68527c5d1712b7faa3141db7716f89ac6e911"
+  integrity sha512-rv842+S+AGyZCmMMd8xPtW5DvJ9LzWTAKfxi8Gw57oYlXgcKtFuHd4nqk6lTPpRKdUGn3tx/Drd0rjQR3dQPqw==
+  dependencies:
+    tiny-json-http "^7.0.2"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -10499,6 +10506,11 @@ timezonecomplete@^5.5.0:
   resolved "https://registry.yarnpkg.com/timezonecomplete/-/timezonecomplete-5.8.1.tgz#e6633d65d387e6b80dad46704c715fd85fb11aea"
   dependencies:
     tzdata "^1.0.11"
+
+tiny-json-http@^7.0.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/tiny-json-http/-/tiny-json-http-7.1.2.tgz#620e189849bab08992ec23fada7b48c7c61637b4"
+  integrity sha512-XB9Bu+ohdQso6ziPFNVqK+pcTt0l8BSRkW/CCBq0pUVlLxcYDsorpo7ae5yPhu2CF1xYgJuKVLF7cfOGeLCTlA==
 
 tinycolor2@^1.4.1:
   version "1.4.1"


### PR DESCRIPTION
This was missed in 9701d1ebc30287c96f74eb404106adde95c20b21