### PR TITLE
fix: bail on submit if already submitting

### DIFF
--- a/src/components/TexterRequest.jsx
+++ b/src/components/TexterRequest.jsx
@@ -35,7 +35,9 @@ class TexterRequest extends React.Component {
   }
 
   submit = async () => {
-    const { count, email } = this.state;
+    const { count, email, submitting } = this.state;
+    if (submitting) return;
+
     this.setState({ submitting: true });
     try {
       const response = await this.props.mutations.requestTexts({


### PR DESCRIPTION
This is a defensive fix for multiple requests. The disabled state may not be updated in the UI
quickly enough to prevent additional submissions so we should return from this.submit as a
backstop if submitting is true.