### PR TITLE
feat(twilio): add defensive fix for null characters in database

### DIFF
--- a/src/server/api/lib/twilio.js
+++ b/src/server/api/lib/twilio.js
@@ -89,7 +89,7 @@ async function convertMessagePartsToMessage(messageParts) {
       user_number: userNumber,
       is_from_contact: true,
       text: textIncludingMms(text, serviceMessages),
-      service_response: JSON.stringify(serviceMessages),
+      service_response: JSON.stringify(serviceMessages).replace(/\0/g, ""),
       service_id: serviceMessages[0].MessagingServiceSid,
       assignment_id: ccInfo && ccInfo.assignment_id,
       service: "twilio",


### PR DESCRIPTION
Null characters are [already stripped from the message text itself](https://github.com/politics-rewired/Spoke/commit/26bbe6007fee737bb03ae4b2aaeaaa80d9cb6e2d), but not the raw service response. Add a
defensive fix to remove null characters there as well.