### PR TITLE
fix: standardize service_response

### DIFF
--- a/migrations/20190918124706_fix_default_service_response.js
+++ b/migrations/20190918124706_fix_default_service_response.js
@@ -1,0 +1,19 @@
+exports.up = function(knex, Promise) {
+  // Add stringified empty array as default
+  return knex.schema.alterTable("message", table => {
+    table
+      .text("service_response")
+      .defaultTo("[]")
+      .alter();
+  });
+};
+
+exports.down = function(knex, Promise) {
+  // Revert to default of empty string
+  return knex.schema.alterTable("message", table => {
+    table
+      .text("service_response")
+      .defaultTo("")
+      .alter();
+  });
+};

--- a/src/server/api/lib/message-sending.js
+++ b/src/server/api/lib/message-sending.js
@@ -133,7 +133,7 @@ export const appendServiceResponse = (responsesString, newResponse) => {
 
   let existingResponses = [];
   try {
-    existingResponses = JSON.parse(serviceResponses);
+    existingResponses = JSON.parse(responsesString);
   } catch (error) {}
 
   // service_response should be an array of responses (although this is usually of length 1)

--- a/src/server/api/lib/message-sending.js
+++ b/src/server/api/lib/message-sending.js
@@ -116,3 +116,29 @@ export async function saveNewIncomingMessage(messageInstance) {
 
   await updateQuery;
 }
+
+/**
+ * Safely append a new service response to an existing service_response value.
+ * The existing value should be a stringified array but may not be so handle those cases.
+ * @param {string} responsesString stringified array of service responses
+ * @param {object} newResponse a new service response object to append
+ */
+export const appendServiceResponse = (responsesString, newResponse) => {
+  // Account for service responses stored incorrectly prior to fix
+  if (responsesString.indexOf("undefined") === 0) {
+    responsesString = responsesString.slice(9);
+  }
+
+  let existingResponses = [];
+  try {
+    existingResponses = JSON.parse(serviceResponses);
+  } catch (error) {}
+
+  // service_response should be an array of responses (although this is usually of length 1)
+  if (!Array.isArray(existingResponses)) {
+    existingResponses = [existingResponses];
+  }
+
+  existingResponses.push(newResponse);
+  return JSON.stringify(existingResponses);
+};

--- a/src/server/api/lib/message-sending.js
+++ b/src/server/api/lib/message-sending.js
@@ -124,6 +124,8 @@ export async function saveNewIncomingMessage(messageInstance) {
  * @param {object} newResponse a new service response object to append
  */
 export const appendServiceResponse = (responsesString, newResponse) => {
+  responsesString = responsesString !== undefined ? responsesString : "[]";
+
   // Account for service responses stored incorrectly prior to fix
   if (responsesString.indexOf("undefined") === 0) {
     responsesString = responsesString.slice(9);

--- a/src/server/api/lib/nexmo.js
+++ b/src/server/api/lib/nexmo.js
@@ -3,7 +3,7 @@ import logger from "../../../logger";
 import Nexmo from "nexmo";
 import { getFormattedPhoneNumber } from "../../../lib/phone-format";
 import { Message, PendingMessagePart } from "../../models";
-import { getLastMessage } from "./message-sending";
+import { getLastMessage, appendServiceResponse } from "./message-sending";
 
 let nexmo = null;
 const MAX_SEND_ATTEMPTS = 5;
@@ -119,7 +119,10 @@ async function sendMessage(message, trx) {
               hasError = true;
             }
           });
-          messageToSave.service_response += JSON.stringify(response);
+          messageToSave.service_response = appendServiceResponse(
+            messageToSave.service_response,
+            response
+          );
         }
 
         messageToSave.service = "nexmo";
@@ -165,7 +168,10 @@ async function sendMessage(message, trx) {
 async function handleDeliveryReport(report) {
   if (report.hasOwnProperty("client-ref")) {
     const message = await Message.get(report["client-ref"]);
-    message.service_response += JSON.stringify(report);
+    message.service_response = appendServiceResponse(
+      message.service_response,
+      report
+    );
     if (report.status === "delivered" || report.status === "accepted") {
       message.send_status = "DELIVERED";
     } else if (

--- a/src/server/api/lib/twilio.js
+++ b/src/server/api/lib/twilio.js
@@ -6,6 +6,7 @@ import moment from "moment-timezone";
 import { getFormattedPhoneNumber } from "../../../lib/phone-format";
 import { Log, Message, PendingMessagePart, r } from "../../models";
 import { sleep } from "../../../lib/utils";
+import { appendServiceResponse } from "./message-sending";
 import {
   getCampaignContactAndAssignmentForIncomingMessage,
   saveNewIncomingMessage
@@ -306,12 +307,19 @@ async function sendMessage(message, organizationId, trx) {
       if (err) {
         hasError = true;
         logger.error(`Error sending message ${message.id}`, err);
-        messageToSave.service_response += JSON.stringify(err);
+        const jsonErr = typeof err === "object" ? err : { error: err };
+        messageToSave.service_response = appendServiceResponse(
+          messageToSave.service_response,
+          jsonErr
+        );
       }
       if (response) {
         messageToSave.service_id = response.sid;
         hasError = !!response.error_code;
-        messageToSave.service_response += JSON.stringify(response);
+        messageToSave.service_response = appendServiceResponse(
+          messageToSave.service_response,
+          response
+        );
       }
 
       if (hasError) {

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -709,11 +709,13 @@ const rootMutations = {
         user_number: userNumber,
         is_from_contact: true,
         text: message,
-        service_response: JSON.stringify({
-          fakeMessage: true,
-          userId: user.id,
-          userFirstName: user.first_name
-        }),
+        service_response: JSON.stringify([
+          {
+            fakeMessage: true,
+            userId: user.id,
+            userFirstName: user.first_name
+          }
+        ]),
         service_id: mockId,
         assignment_id: lastMessage.assignment_id,
         service: lastMessage.service,


### PR DESCRIPTION
The `service_response` field should be a stringified array of service response payloads (each a JSON
object itself). However, this field is used differently throughout the codebase. This standardizes
its usage.

Query to find find sent messages:

```sql
select
    REGEXP_REPLACE(service_response, 'undefined(.*)', '[\1]') as new_response_array
from message
    where service_response like 'undefined%'
limit 1;
```

Query to fix sent messages:

```sql
update message
set service_response = REGEXP_REPLACE(service_response, 'undefined(.*)', '[\1]')
where service_response like 'undefined%';
```

Untested query to fix single-element records (only happens if using the `/send-replies` admin debug route):

```sql
update message
set service_response = REGEXP_REPLACE(service_response, '{(.*)}', '[{\1}]')
where service_response like '{%}'
limit 1;
```