### PR TITLE
feat(monitoring): add healthcheck endpoint

### DIFF
--- a/src/server/routes/utils.js
+++ b/src/server/routes/utils.js
@@ -34,7 +34,7 @@ router.post("/remove-number-from-campaign", async (req, res) => {
 // The health check endpoint should ensure that the database is reachable
 router.get("/health", async (req, res) => {
   try {
-    await r.knex.raw("select sd1;");
+    await r.knex.raw("select 1;");
     return res.sendStatus(200);
   } catch (err) {
     // Service Unavailable!

--- a/src/server/routes/utils.js
+++ b/src/server/routes/utils.js
@@ -31,4 +31,15 @@ router.post("/remove-number-from-campaign", async (req, res) => {
   return res.sendStatus(200);
 });
 
+// The health check endpoint should ensure that the database is reachable
+router.get("/health", async (req, res) => {
+  try {
+    await r.knex.raw("select sd1;");
+    return res.sendStatus(200);
+  } catch (err) {
+    // Service Unavailable!
+    return res.sendStatus(503);
+  }
+});
+
 export default router;


### PR DESCRIPTION
Currently, Datadog network availability monitors do not catch application errors due to database inaccessibility as `/` does not require any database queries if there is no user session.