### PR TITLE
feat(sweeping): add previous/next conversation navigation

### DIFF
--- a/src/components/IncomingMessageList/ConversationPreviewModal.jsx
+++ b/src/components/IncomingMessageList/ConversationPreviewModal.jsx
@@ -3,11 +3,22 @@ import PropTypes from "prop-types";
 import { StyleSheet, css } from "aphrodite";
 import Dialog from "material-ui/Dialog";
 import FlatButton from "material-ui/FlatButton";
+import IconButton from "material-ui/IconButton";
+import ChevronLeft from "material-ui/svg-icons/navigation/chevron-left";
+import ChevronRight from "material-ui/svg-icons/navigation/chevron-right";
 
 import MessageColumn from "./MessageColumn";
 import SurveyColumn from "./SurveyColumn";
 
-const styles = StyleSheet.create({
+const headerStyles = {
+  container: {
+    display: "flex",
+    alignItems: "baseline"
+  },
+  heading: { flex: "1" }
+};
+
+const columnStyles = StyleSheet.create({
   container: {
     display: "flex"
   },
@@ -27,14 +38,14 @@ const ConversationPreviewBody = props => {
   const { conversation, organizationId } = props,
     { contact, campaign } = conversation;
   return (
-    <div className={css(styles.container)}>
-      <div className={css(styles.column)}>
+    <div className={css(columnStyles.container)}>
+      <div className={css(columnStyles.column)}>
         <MessageColumn
           conversation={conversation}
           organizationId={organizationId}
         />
       </div>
-      <div className={css(styles.column)}>
+      <div className={css(columnStyles.column)}>
         <SurveyColumn
           contact={contact}
           campaign={campaign}
@@ -51,7 +62,13 @@ ConversationPreviewBody.propTypes = {
 };
 
 const ConversationPreviewModal = props => {
-  const { conversation, onRequestClose } = props,
+  const {
+      conversation,
+      navigation,
+      onRequestPrevious,
+      onRequestNext,
+      onRequestClose
+    } = props,
     isOpen = conversation !== undefined;
 
   const primaryActions = [
@@ -63,13 +80,25 @@ const ConversationPreviewModal = props => {
     maxWidth: "none"
   };
 
+  const title = (
+    <div style={headerStyles.container}>
+      <div style={headerStyles.heading}>
+        {conversation
+          ? `Conversation Review: ${conversation.campaign.title}`
+          : "Conversation Review"}
+      </div>
+      <IconButton disabled={!navigation.previous} onClick={onRequestPrevious}>
+        <ChevronLeft />
+      </IconButton>
+      <IconButton disabled={!navigation.next} onClick={onRequestNext}>
+        <ChevronRight />
+      </IconButton>
+    </div>
+  );
+
   return (
     <Dialog
-      title={
-        conversation
-          ? `Conversation Review: ${conversation.campaign.title}`
-          : "Conversation Review"
-      }
+      title={title}
       open={isOpen}
       actions={primaryActions}
       modal={false}
@@ -88,12 +117,21 @@ const ConversationPreviewModal = props => {
 };
 
 ConversationPreviewModal.defaultProps = {
+  navigation: { previous: false, next: false },
+  onRequestPrevious: () => {},
+  onRequestNext: () => {},
   onRequestClose: () => {}
 };
 
 ConversationPreviewModal.propTypes = {
   organizationId: PropTypes.string.isRequired,
   conversation: PropTypes.object,
+  navigation: PropTypes.shape({
+    previous: PropTypes.bool.isRequired,
+    next: PropTypes.bool.isRequired
+  }),
+  onRequestPrevious: PropTypes.func,
+  onRequestNext: PropTypes.func,
   onRequestClose: PropTypes.func
 };
 

--- a/src/components/IncomingMessageList/index.jsx
+++ b/src/components/IncomingMessageList/index.jsx
@@ -48,7 +48,7 @@ function prepareSelectedRowsData(conversations, rowsSelected) {
 
 export class IncomingMessageList extends Component {
   state = {
-    activeConversation: undefined
+    activeConversationIndex: -1
   };
 
   componentDidUpdate(prevProps) {
@@ -212,16 +212,26 @@ export class IncomingMessageList extends Component {
     this.props.onConversationSelected(rowsSelected, selectedConversations);
   };
 
-  handleOpenConversation = index => {
-    const conversation = this.props.conversations.conversations.conversations[
-      index
-    ];
-    this.setState({ activeConversation: conversation });
+  handleOpenConversation = index =>
+    this.setState({ activeConversationIndex: index });
+
+  handleRequestPreviousConversation = () => {
+    const { activeConversationIndex: oldIndex } = this.state;
+    const newIndex = oldIndex - 1;
+    if (newIndex < 0) return;
+    this.setState({ activeConversationIndex: newIndex });
   };
 
-  handleCloseConversation = () => {
-    this.setState({ activeConversation: undefined });
+  handleRequestNextConversation = () => {
+    const { activeConversationIndex: oldIndex } = this.state;
+    const { conversations } = this.props.conversations.conversations;
+    const newIndex = oldIndex + 1;
+    if (newIndex >= conversations.length) return;
+    this.setState({ activeConversationIndex: newIndex });
   };
+
+  handleCloseConversation = () =>
+    this.setState({ activeConversationIndex: -1 });
 
   render() {
     if (this.props.conversations.loading) {
@@ -232,6 +242,13 @@ export class IncomingMessageList extends Component {
     const { limit, offset, total } = pageInfo;
     const displayPage = Math.floor(offset / limit) + 1;
     const tableData = prepareDataTableData(conversations);
+
+    const { activeConversationIndex } = this.state;
+    const activeConversation = conversations[activeConversationIndex];
+    const navigation = {
+      previous: conversations[activeConversationIndex - 1] !== undefined,
+      next: conversations[activeConversationIndex + 1] !== undefined
+    };
     return (
       <div>
         <DataTables
@@ -252,8 +269,11 @@ export class IncomingMessageList extends Component {
           selectedRows={this.props.selectedRows}
         />
         <ConversationPreviewModal
-          conversation={this.state.activeConversation}
+          conversation={activeConversation}
           organizationId={this.props.organizationId}
+          navigation={navigation}
+          onRequestPrevious={this.handleRequestPreviousConversation}
+          onRequestNext={this.handleRequestNextConversation}
           onRequestClose={this.handleCloseConversation}
         />
       </div>


### PR DESCRIPTION
This allows a sweeper to navigate to the previous/next conversation without closing the current
conversation and opening the next one. It will only go forward/backward on the current page of
results, however; navigating to the next page of results manually is still required.

![Spoke](https://user-images.githubusercontent.com/2145526/65336303-2261fa80-db94-11e9-9d70-c4d25c79c474.png)
