### PR TITLE
fix: prevent empty tagConversation mutations

### DIFF
--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -368,7 +368,9 @@ export class AssignmentTexterContact extends React.Component {
       removedTagIds: removedTags.map(tag => tag.id)
     };
 
-    if (tag.addedTagIds || tag.removedTagIds) changes.tag = tag;
+    if (tag.addedTagIds.length > 0 || tag.removedTagIds.length > 0) {
+      changes.tag = tag;
+    }
 
     // Return aggregate changes
     return changes;


### PR DESCRIPTION
Commit ecb2280f535ba7c47bc9d809f35b54ad2a131310 had a typo, using `lenth` instead of `length`.