### PR TITLE
refactor: use named timezone field instead of timezone_offset

### DIFF
--- a/dev-tools/backfill-timezones.js
+++ b/dev-tools/backfill-timezones.js
@@ -1,0 +1,57 @@
+require("dotenv").config();
+const knex = require("knex");
+const zipCodeToTimeZone = require("zipcode-to-timezone");
+
+const config = {
+  client: "postgresql",
+  connection: process.env.DATABASE_URL,
+  pool: {
+    min: process.env.ROW_CONCURRENCY,
+    min: process.env.ROW_CONCURRENCY
+  }
+};
+
+const db = knex(config);
+const BATCH_SIZE = 10000;
+
+async function doBatch() {
+  // Index on timezone will make this fast
+  const someZipCodesToFill = await db.raw(
+    `select distinct(zip) from (
+      select zip
+      from campaign_contact
+      where timezone is null and zip <> ''
+      limit ?
+    ) some_ccs`,
+    [BATCH_SIZE]
+  );
+
+  const zips = someZipCodesToFill.rows.map(r => r.zip);
+
+  let totalUpdateCount = 0;
+  // Run it sequentially to avoid any too large update, which could row level lock
+  // This will run 44k times, so it could probably be sped up a bit after a few runs
+  for (let zip of zips) {
+    const timezone = zipCodeToTimeZone.lookup(zip);
+    const updateCount = await db("campaign_contact")
+      .update({ timezone })
+      .where({ zip });
+
+    totalUpdateCount += updateCount;
+  }
+
+  // if totalUpdateCount > 0, we're not done, so return false
+  console.log(`Updated ${totalUpdateCount} in batch`);
+  return totalUpdateCount === 0;
+}
+
+async function main() {
+  let done = false;
+  while (!done) {
+    done = await doBatch();
+  }
+}
+
+main()
+  .then(console.log)
+  .catch(console.error);

--- a/migrations/20191001111008_add_contact_timezone.js
+++ b/migrations/20191001111008_add_contact_timezone.js
@@ -6,9 +6,11 @@ exports.up = function(knex, Promise) {
     .then(() =>
       knex.schema.raw(`
         create or replace function contact_is_textable_now(timezone text, start integer, stop integer, allow_null boolean) returns boolean as $$
-          select allow_null
-            or extract(hour from (CURRENT_TIMESTAMP at time zone timezone)) > start
-            and extract(hour from (CURRENT_TIMESTAMP at time zone timezone)) < stop
+          select (timezone is null and allow_null)
+            or (
+              extract(hour from (CURRENT_TIMESTAMP at time zone timezone)) > start
+              and extract(hour from (CURRENT_TIMESTAMP at time zone timezone)) < stop
+            )
         $$ language sql;
       `)
     );

--- a/migrations/20191001111008_add_contact_timezone.js
+++ b/migrations/20191001111008_add_contact_timezone.js
@@ -1,0 +1,21 @@
+exports.up = function(knex, Promise) {
+  return knex.schema
+    .alterTable("campaign_contact", table => {
+      table.string("timezone").index(); // indexing it makes the backfill script much faster
+    })
+    .then(() =>
+      knex.schema.raw(`
+        create or replace function contact_is_textable_now(timezone text, start integer, stop integer, allow_null boolean) returns boolean as $$
+          select allow_null
+            or extract(hour from (CURRENT_TIMESTAMP at time zone timezone)) > start
+            and extract(hour from (CURRENT_TIMESTAMP at time zone timezone)) < stop
+        $$ language sql;
+      `)
+    );
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.alterTable("campaign_contact", table => {
+    table.dropColumn("timezone");
+  });
+};

--- a/migrations/20191001115601_use_timezone_for_assigment.js
+++ b/migrations/20191001115601_use_timezone_for_assigment.js
@@ -1,0 +1,63 @@
+exports.up = function(knex, Promise) {
+  return knex.schema
+    .raw(
+      `
+      create or replace view assignable_campaign_contacts as (
+        select
+          campaign_contact.id, campaign_contact.campaign_id,
+          campaign_contact.message_status, campaign.texting_hours_end,
+          campaign_contact.timezone::text as contact_timezone
+        from campaign_contact
+        join campaign on campaign_contact.campaign_id = campaign.id
+        where assignment_id is null
+          and is_opted_out = false
+          and not exists (
+            select 1
+            from campaign_contact_tag
+            join tag on campaign_contact_tag.tag_id = tag.id
+            where tag.is_assignable = false
+              and campaign_contact_tag.campaign_contact_id = campaign_contact.id
+          )
+    )
+  `
+    )
+    .then(() => {
+      return knex.schema.alterTable("campaign_contact", table => {
+        table.dropColumn("timezone_offset");
+      });
+    });
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema
+    .raw(
+      `
+      create or replace view assignable_campaign_contacts as (
+        select
+          campaign_contact.id, campaign_contact.campaign_id,
+          campaign_contact.message_status, campaign.texting_hours_end,
+          spoke_tz_to_iso_tz(campaign_contact.timezone_offset) as contact_timezone
+        from campaign_contact
+        join campaign on campaign_contact.campaign_id = campaign.id
+        where assignment_id is null
+          and is_opted_out = false
+          and not exists (
+            select 1
+            from campaign_contact_tag
+            join tag on campaign_contact_tag.tag_id = tag.id
+            where tag.is_assignable = false
+              and campaign_contact_tag.campaign_contact_id = campaign_contact.id
+          )
+      );
+    `
+    )
+    .then(() => {
+      return knex.schema.alterTable("campaign_contact", table => {
+        table.text("timezone_offset").defaultTo("");
+        table.index(
+          ["assignment_id", "timezone_offset"],
+          "campaign_contact_assignment_id_timezone_offset_index"
+        );
+      });
+    });
+};

--- a/package.json
+++ b/package.json
@@ -153,7 +153,8 @@
     "webpack-manifest-plugin": "^1.3.2",
     "winston": "^3.2.1",
     "winston-mongodb": "^4.0.3",
-    "yup": "^0.27.0"
+    "yup": "^0.27.0",
+    "zipcode-to-timezone": "0.0.9"
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",

--- a/src/server/api/assignment.js
+++ b/src/server/api/assignment.js
@@ -80,6 +80,8 @@ export function getContacts(
           defaultTimezoneIsBetweenTextingHours(config)
         ]);
       } else if (validTimezone === false) {
+        // validTimezone === false means we're looking for an invalid timezone,
+        // which means the contact is NOT textable right now
         query = query.whereRaw(
           "contact_is_textable_now(timezone, ?, ?, ?) = false",
           [

--- a/src/server/api/campaign-contact.js
+++ b/src/server/api/campaign-contact.js
@@ -165,6 +165,7 @@ export const resolvers = {
           timezone_offset: offset,
           has_dst: false
         };
+        return loc;
       }
       const mainZip = campaignContact.zip.split("-")[0];
       const calculated = zipToTimeZone(mainZip);

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -462,7 +462,7 @@ async function sendMessage(
       "campaign.texting_hours_enforced as c_texting_hours_enforced",
       "assignment.user_id as a_assignment_user_id",
       "opt_out.id as is_opted_out",
-      "campaign_contact.timezone_offset as contact_timezone_offset"
+      "campaign_contact.timezone as contact_timezone"
     );
 
   // If the conversation is unassigned, create an assignment. This assignment will be applied to
@@ -559,12 +559,13 @@ async function sendMessage(
   );
 
   let contactTimezone = {};
-  if (record.contact_timezone_offset) {
+  if (record.contact_timezone) {
     // couldn't look up the timezone by zip record, so we load it
     // from the campaign_contact directly if it's there
-    const [offset, hasDST] = record.contact_timezone_offset.split("_");
-    contactTimezone.offset = parseInt(offset, 10);
-    contactTimezone.hasDST = hasDST === "1";
+    const offset =
+      moment.tz(record.contact_timezone).utcOffset(Date.now()) / 60;
+    contactTimezone.offset = offset;
+    contactTimezone.hasDST = false;
   }
 
   const {

--- a/src/server/knex.js
+++ b/src/server/knex.js
@@ -49,9 +49,6 @@ const knexConfig = {
     idleTimeoutMillis: config.DB_IDLE_TIMEOUT_MS,
     reapIntervalMillis: config.DB_REAP_INTERVAL_MS,
     afterCreate
-  },
-  seeds: {
-    directory: "./seeds"
   }
 };
 

--- a/src/server/models/campaign-contact.js
+++ b/src/server/models/campaign-contact.js
@@ -32,10 +32,7 @@ const CampaignContact = thinky.createModel(
         ])
         .default("needsMessage"),
       is_opted_out: type.boolean().default(false),
-      timezone_offset: type
-        .string()
-        .default("")
-        .required()
+      timezone: type.string()
     })
     .allowExtra(false),
   { noAutoCreation: true }

--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -464,7 +464,9 @@ export async function loadContactsFromDataWarehouseFragment(jobEvent) {
         contact.timezone = zipCodeToTimeZone.lookup(contact.zip);
       }
       if (contactCustomFields.hasOwnProperty("timezone")) {
-        contact.timezone = contactCustomFields["timezone"];
+        const zone = moment.tz.zone(contactCustomFields.timezone);
+        if (zone) contact.timezone = contactCustomFields.timezone;
+        else contact.timezone = zipCodeToTimeZone.lookup(contact.zip);
       }
       return contact;
     })


### PR DESCRIPTION
Replace use of timezone_offset with named timezone, moving offset computation to trusted, DST aware implementations like Postgres's time zone functions and `moment-timezone`.

This one is a bit tricky to migrate – in order to be deployed without downtime, the first migration needs to be run (add the new column), then the backfill script, and then the code deploy, and then the second migration (remove the old column).

The backfill script could take a while if campaign_contacts is large, and several things could be done to make it faster. Specifically, `zip` is currently unindexed on `campaign_contact`, which means that each update as written will require a full table scan on `campaign_contact`.

Does that merit adding an index on zip concurrently and removing it when the backfill script is done?