### PR TITLE
fix(twilio): pass emtpy array rather than undefined to twilio

### DIFF
--- a/src/server/api/lib/twilio.js
+++ b/src/server/api/lib/twilio.js
@@ -193,7 +193,7 @@ async function sendMessage(message, organizationId, trx) {
     const { body, mediaUrl } = messageComponents(message.text);
     const messageParams = {
       body,
-      mediaUrl,
+      mediaUrl: mediaUrl || [],
       to: message.contact_number,
       messagingServiceSid: messagingServiceSid,
       statusCallback: config.TWILIO_STATUS_CALLBACK_URL


### PR DESCRIPTION
Fixes error:

```json
{"status":400,"message":"Error sending message 32Media urls:  are invalid. Please use only valid http and https urls","code":21620,"moreInfo":"https://www.twilio.com/docs/errors/21620","level":"error","timestamp":"2019-10-11T19:03:13.550Z"}
```

https://www.twilio.com/docs/sms/send-messages#include-media-in-your-messages