### PR TITLE
fix: contact_is_textable_now can return null

### DIFF
--- a/src/server/api/assignment.js
+++ b/src/server/api/assignment.js
@@ -74,16 +74,19 @@ export function getContacts(
     const validTimezone = contactsFilter.validTimezone;
     if (validTimezone !== null) {
       if (validTimezone === true) {
-        query = query.whereRaw("contact_is_textable_now(timezone, ?, ?, ?)", [
-          config.campaignTextingHours.textingHoursStart,
-          config.campaignTextingHours.textingHoursEnd,
-          defaultTimezoneIsBetweenTextingHours(config)
-        ]);
+        query = query.whereRaw(
+          "contact_is_textable_now(timezone, ?, ?, ?) = true",
+          [
+            config.campaignTextingHours.textingHoursStart,
+            config.campaignTextingHours.textingHoursEnd,
+            defaultTimezoneIsBetweenTextingHours(config)
+          ]
+        );
       } else if (validTimezone === false) {
         // validTimezone === false means we're looking for an invalid timezone,
         // which means the contact is NOT textable right now
         query = query.whereRaw(
-          "contact_is_textable_now(timezone, ?, ?, ?) = false",
+          "contact_is_textable_now(timezone, ?, ?, ?) != true",
           [
             config.campaignTextingHours.textingHoursStart,
             config.campaignTextingHours.textingHoursEnd,

--- a/src/server/api/assignment.js
+++ b/src/server/api/assignment.js
@@ -75,7 +75,7 @@ export function getContacts(
     if (validTimezone !== null) {
       if (validTimezone === true) {
         query = query.whereRaw(
-          "contact_is_textable_now(timezone, ?, ?, ?) = true",
+          "contact_is_textable_now(timezone, ?, ?, ?) is not distinct from true",
           [
             config.campaignTextingHours.textingHoursStart,
             config.campaignTextingHours.textingHoursEnd,
@@ -86,7 +86,7 @@ export function getContacts(
         // validTimezone === false means we're looking for an invalid timezone,
         // which means the contact is NOT textable right now
         query = query.whereRaw(
-          "contact_is_textable_now(timezone, ?, ?, ?) != true",
+          "contact_is_textable_now(timezone, ?, ?, ?) is distinct from true",
           [
             config.campaignTextingHours.textingHoursStart,
             config.campaignTextingHours.textingHoursEnd,


### PR DESCRIPTION
If we are outside of a campaign's texting hours, and a contact's zip is null, `contact_is_textable_now` will return null. 

This fixes it by checking for distinction with true

