### PR TITLE
feat: display local login errors

### DIFF
--- a/src/containers/UserEdit.jsx
+++ b/src/containers/UserEdit.jsx
@@ -78,6 +78,12 @@ class UserEdit extends React.Component {
           this.props.router.replace(url);
         } else if (status === 401) {
           throw new Error(headers.get("www-authenticate") || "");
+        } else if (status === 400) {
+          const body = await loginRes.json();
+          throw new Error(body.message);
+        } else {
+          const body = await loginRes.text();
+          throw new Error(`Unknown error:\n\n${body}`);
         }
         break;
     }

--- a/src/containers/UserEdit.jsx
+++ b/src/containers/UserEdit.jsx
@@ -157,12 +157,13 @@ class UserEdit extends React.Component {
   };
 
   render() {
+    // Data may be `undefined` here due to refetch in child UserEdit component in change password dialog
     const { authType, editUser, style, userId, data, saveLabel } = this.props;
     const user = (editUser && editUser.editUser) || {};
 
     const formSchema = this.buildFormSchema(authType);
     const isLocalAuth = window.PASSPORT_STRATEGY === "local";
-    const isCurrentUser = userId && userId === data.currentUser.id;
+    const isCurrentUser = userId && data && userId === data.currentUser.id;
     const isAlreadyChangePassword = authType === UserEditMode.Change;
     const canChangePassword =
       isLocalAuth && isCurrentUser && !isAlreadyChangePassword;

--- a/src/server/auth-passport.js
+++ b/src/server/auth-passport.js
@@ -7,7 +7,7 @@ import { Strategy as LocalStrategy } from "passport-local";
 import { config } from "../config";
 import { r } from "./models";
 import { userLoggedIn } from "./models/cacheable_queries";
-import localAuthHelpers from "./local-auth-helpers";
+import localAuthHelpers, { LocalAuthError } from "./local-auth-helpers";
 import { capitalizeWord } from "./api/lib/utils";
 
 const {
@@ -216,7 +216,9 @@ function setupLocalAuthPassport() {
         .first();
 
       // Run login, signup, or reset functions based on request data
-      if (authType && !localAuthHelpers[authType]) return done(null, false);
+      if (authType && !localAuthHelpers[authType]) {
+        return done(new LocalAuthError("Unknown auth type"));
+      }
 
       try {
         const user = await localAuthHelpers[authType]({
@@ -229,8 +231,7 @@ function setupLocalAuthPassport() {
         });
         return done(null, user);
       } catch (error) {
-        // TODO - this should differentiate between invalid login and actual server error
-        return done(null, false);
+        return done(error);
       }
     }
   );

--- a/src/server/local-auth-helpers.js
+++ b/src/server/local-auth-helpers.js
@@ -7,6 +7,7 @@ export class LocalAuthError extends Error {
   constructor(message) {
     super(message);
     this.name = this.constructor.name;
+    this.errorType = "LocalAuthError";
   }
 }
 


### PR DESCRIPTION
There are two differences between this PR and #334 

- Use `reject(new Error(...))` within the `AuthHasher` callbacks rather than throwing the error.
- Fix "Change Password" functionality from user's profile page. The change password dialog contains a nested `UserEdit` component that causes a previously-unaccounted-for `props.data` refresh in the parent

I have tested this locally with as many combinations of login, signup, password reset, and change password as I can think of.