### PR TITLE
fix: fix service selection behavior

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -232,8 +232,8 @@ if (isClient()) {
     }),
     DEFAULT_SERVICE: str({
       desc: "Default SMS service.",
-      choices: ["twilio", "nexmo", "fakeservice"],
-      default: "fakeservice"
+      choices: ["assemble-numbers", "twilio", "nexmo", "fakeservice"],
+      default: undefined
     }),
     DEFAULT_ORG: num({
       desc:

--- a/src/server/api/lib/message-sending.js
+++ b/src/server/api/lib/message-sending.js
@@ -100,7 +100,7 @@ export const getMessagingServiceById = async messagingServiceId =>
  */
 export const getContactMessagingService = async campaignContactId => {
   if (config.DEFAULT_SERVICE === "fakeservice")
-    return { service: "fakeservice" };
+    return { service_type: "fakeservice" };
 
   const {
     rows: [lookupResult]


### PR DESCRIPTION
This addresses two problems:

1. fakeservice was being used whenever DEFAULT_SERVICE was unset
2. fakeservice was returning an incorrectly formed service record

For clients with DEFAULT_SERVICE unset, fakeservice was being used and was failing.