### PR TITLE
feat: include texter email address in search UI/params

### DIFF
--- a/src/components/IncomingMessageActions.jsx
+++ b/src/components/IncomingMessageActions.jsx
@@ -28,6 +28,12 @@ const styles = StyleSheet.create({
   }
 });
 
+const formatTexter = texter => {
+  const { displayName, email, roles } = texter;
+  const highestRole = getHighestRole(roles);
+  return `${displayName} (${email}) ${highestRole}`;
+};
+
 class IncomingMessageActions extends Component {
   state = {
     selectedTexters: [],
@@ -76,7 +82,7 @@ class IncomingMessageActions extends Component {
     let texters = this.props.people || [];
     texters = texters.map(texter => ({
       value: parseInt(texter.id, 10),
-      label: texter.displayName + " " + getHighestRole(texter.roles)
+      label: formatTexter(texter)
     }));
 
     const confirmDialogActions = (actionVerb, confirmAction) => [

--- a/src/containers/PaginatedUsersRetriever.jsx
+++ b/src/containers/PaginatedUsersRetriever.jsx
@@ -82,6 +82,7 @@ const mapQueriesToProps = ({ ownProps }) => ({
             users {
               id
               displayName
+              email
               roles(organizationId: $organizationId)
             }
           }


### PR DESCRIPTION
<img width="607" alt="email-search" src="https://user-images.githubusercontent.com/2145526/68027501-8f32df00-fc80-11e9-9378-0a2f99dc0b71.png">
