### PR TITLE
fix: timezone issues

### DIFF
--- a/src/lib/timezones.js
+++ b/src/lib/timezones.js
@@ -161,6 +161,7 @@ export const isBetweenTextingHours = (offsetData, config) => {
     return true;
   }
 
+  // This should always exist/be true for Spoke Rewired
   if (config.campaignTextingHours) {
     const { campaignTextingHours } = config;
     const missingTimezoneConfig = {

--- a/src/server/api/assignment.js
+++ b/src/server/api/assignment.js
@@ -75,7 +75,7 @@ export function getContacts(
     if (validTimezone !== null) {
       if (validTimezone === true) {
         query = query.whereRaw(
-          "contact_is_textable_now(timezone, ?, ?, ?) is not distinct from true",
+          "contact_is_textable_now(timezone, ?, ?, ?) = true",
           [
             config.campaignTextingHours.textingHoursStart,
             config.campaignTextingHours.textingHoursEnd,
@@ -90,7 +90,7 @@ export function getContacts(
           [
             config.campaignTextingHours.textingHoursStart,
             config.campaignTextingHours.textingHoursEnd,
-            !defaultTimezoneIsBetweenTextingHours(config)
+            defaultTimezoneIsBetweenTextingHours(config)
           ]
         );
       }


### PR DESCRIPTION
For test campaign:

```
spoke_prod=> select count(*), timezone, message_status from campaign_contact where assignment_id = 75689 group by 2, 3;
┌───────┬─────────────────┬────────────────┐
│ count │    timezone     │ message_status │
├───────┼─────────────────┼────────────────┤
│    14 │                 │ needsMessage   │
│     1 │ America/Chicago │ messaged       │
│     9 │ America/Chicago │ needsMessage   │
└───────┴─────────────────┴────────────────┘
(3 rows)
```

On production, `Send Later: 9`
With changes, `Send Later: 23`