### PR TITLE
feat: improve assignment request error handling

### DIFF
--- a/src/components/TexterRequest.jsx
+++ b/src/components/TexterRequest.jsx
@@ -38,12 +38,12 @@ class TexterRequest extends React.Component {
     const { count, email, submitting } = this.state;
     if (submitting) return;
 
-    this.setState({ submitting: true });
+    this.setState({ submitting: true, error: undefined });
     try {
-      const response = await this.props.mutations.requestTexts({
-        count,
-        email
-      });
+      const payload = { count, email };
+      const response = await this.props.mutations.requestTexts(payload);
+      if (response.errors) throw response.errors;
+
       const message = response.data.requestTexts;
 
       if (message.includes("Created")) {
@@ -63,9 +63,8 @@ class TexterRequest extends React.Component {
       } else {
         this.setState({ finished: true });
       }
-    } catch (e) {
-      console.error(e);
-      this.setState({ error: e });
+    } catch (err) {
+      this.setState({ error: err.message });
     } finally {
       this.setState({ submitting: false });
     }

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -2200,23 +2200,17 @@ const rootMutations = {
               amount: count
             });
 
-            /* This will just throw if it errors */
+            // This will just throw if it errors
             if (config.ASSIGNMENT_REQUESTED_URL) {
-              try {
-                const response = await request
-                  .post(config.ASSIGNMENT_REQUESTED_URL)
-                  .set(
-                    "Authorization",
-                    `Token ${config.ASSIGNMENT_REQUESTED_TOKEN}`
-                  )
-                  .send({ count, email });
+              const response = await request
+                .post(config.ASSIGNMENT_REQUESTED_URL)
+                .set(
+                  "Authorization",
+                  `Token ${config.ASSIGNMENT_REQUESTED_TOKEN}`
+                )
+                .send({ count, email });
 
-                logger.debug("TCL: response", response);
-              } catch (ex) {
-                logger.error("TCL: ex", ex);
-              }
-
-              return true;
+              logger.debug("Assignment requested response", { response });
             }
           });
 
@@ -2224,9 +2218,13 @@ const rootMutations = {
         }
 
         return "No texts available at the moment";
-      } catch (e) {
-        logger.error(e);
-        return e.response ? e.response.body.message : e;
+      } catch (err) {
+        logger.error("Error submitting external assignment request!", {
+          error: err
+        });
+        throw new GraphQLError(
+          err.response ? err.response.body.message : err.message
+        );
       }
     },
     releaseMessages: async (


### PR DESCRIPTION
Previously, we squashed errors from an external assignment request service. We now throw those
up the call stack. The client now handles GraphQL errors correctly as well.

![Spoke](https://user-images.githubusercontent.com/2145526/68792662-c8246980-0619-11ea-82da-ddacc1944a62.png)
