### PR TITLE
fix: messages export blank

### DIFF
--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -1222,6 +1222,11 @@ const processMessagesChunk = async (campaignId, lastContactId = 0) => {
         where
           campaign_id = ?
           and id > ?
+          and exists (
+            select 1
+            from message
+            where campaign_contact_id = campaign_contact.id
+          )
         order by
           id asc
         limit ?
@@ -1307,6 +1312,7 @@ export async function exportCampaign(job) {
     notificationEmail = undefined,
     interactionSteps = undefined,
     assignments = undefined;
+
   try {
     ({
       campaignId,


### PR DESCRIPTION
The messages export was turning up blank in situations where the first 1000 contacts, ordered by id, had not been messaged yet – the loop then returned 0 rows and thought it was time to stop.

This fixes the problem by ensuring we only look for messages for contacts that have been messaged