### PR TITLE
fix(s3): use async method to support role-based auth

### DIFF
--- a/src/workers/exports/s3.js
+++ b/src/workers/exports/s3.js
@@ -40,7 +40,12 @@ const getDownloadUrl = async (bucket, key) => {
   const s3Client = createS3(bucket);
   const expiresSeconds = 60 * 60 * 24;
   const options = { Key: key, Expires: expiresSeconds };
-  return s3Client.getSignedUrl("getObject", options);
+  return new Promise((resolve, reject) => {
+    s3Client.getSignedUrl("getObject", options, (err, url) => {
+      if (err) reject(err);
+      resolve(url);
+    });
+  });
 };
 
 module.exports = {


### PR DESCRIPTION
When using AWS S3 exports authenticated by an EC2 role (as is the case with Elastic Beanstalk), we
need to use the async version of getSignedUrl. The sync version does not wait for credentials to be
fetched asynchronously (as is the case when assuming a role) and the operation fails.

See aws/aws-sdk-js#2166 for more information.