### PR TITLE
feat: include archived condition on incoming message review query

### DIFF
--- a/src/server/api/conversations.js
+++ b/src/server/api/conversations.js
@@ -54,6 +54,14 @@ async function getConversationsJoinsAndWhereClause(
       );
   }
 
+  if (campaignsFilter) {
+    if ("isArchived" in campaignsFilter) {
+      query = query.whereRaw(
+        `campaign_contact.archived = ${campaignsFilter.isArchived}`
+      );
+    }
+  }
+
   query = addWhereClauseForContactsFilterMessageStatusIrrespectiveOfPastDue(
     query,
     contactsFilter && contactsFilter.messageStatus


### PR DESCRIPTION
This shows some modest but not really enough improvements – although it's now using the partial index, it's running that large partial index scan `n` times, where `n` is the number of campaigns that match the campaign criteria

We can figure out more substantial improvements later