### PR TITLE
feat: add timeouts to outbound http requests

### DIFF
--- a/src/server/api/assignment.js
+++ b/src/server/api/assignment.js
@@ -535,6 +535,10 @@ async function notifyIfAllAssigned(type, user, organizationId) {
     if (assignmentTarget == null) {
       await request
         .post(config.ASSIGNMENT_COMPLETE_NOTIFICATION_URL)
+        .timeout({
+          response: 1000, // Wait 1 second for the server to start sending
+          deadline: 1000 // Allow 1 second for the response to finish loading
+        })
         .send({ type, user });
       logger.verbose(`Notified about out of ${type} to assign`);
     }

--- a/src/server/api/lib/alerts.js
+++ b/src/server/api/lib/alerts.js
@@ -108,6 +108,10 @@ async function notifyOnTagConversation(campaignContactId, userId, webhookUrls) {
     webhookUrls.map(url =>
       request
         .post(url)
+        .timeout({
+          response: 1000, // Wait 1 second for the server to start sending
+          deadline: 1000 // Allow 1 second for the response to finish loading
+        })
         .send({ mostRecentlyReceivedMessage, taggingUser, taggedContact })
     )
   );

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -631,6 +631,10 @@ async function sendMessage(
   if (badWordUrl) {
     request
       .post(badWordUrl)
+      .timeout({
+        response: 1000, // Wait 1 second for the server to start sending
+        deadline: 1000 // Allow 1 second for the response to finish loading
+      })
       .set("Authorization", `Token ${config.BAD_WORD_TOKEN}`)
       .send({ user_id: user.auth0_id, message: toInsert.text })
       .end((err, res) => {
@@ -2282,6 +2286,10 @@ const rootMutations = {
             if (config.ASSIGNMENT_REQUESTED_URL) {
               const response = await request
                 .post(config.ASSIGNMENT_REQUESTED_URL)
+                .timeout({
+                  response: 1000, // Wait 1 second for the server to start sending
+                  deadline: 1000 // Allow 1 second for the response to finish loading
+                })
                 .set(
                   "Authorization",
                   `Token ${config.ASSIGNMENT_REQUESTED_TOKEN}`


### PR DESCRIPTION
Making external HTTP requests within a PG transaction can lead to program deadlock if the remote
service does not respond in a timely manner.