### PR TITLE
feat: silence expected errors

### DIFF
--- a/src/server/api/lib/assemble-numbers.js
+++ b/src/server/api/lib/assemble-numbers.js
@@ -256,8 +256,10 @@ const convertInboundMessage = async assembleMessage => {
 
   if (!ccInfo) {
     logger.error(
-      `No ccInfo for ${contactNumber} with messaging service sid ${profileId}`
+      "Could not match inbound assemble message to existing conversation",
+      { payload: assembleMessage }
     );
+    return;
   }
 
   const spokeMessage = {
@@ -291,7 +293,10 @@ export const convertMessagePartsToMessage = async messageParts =>
 export const handleIncomingMessage = async message => {
   if (config.JOBS_SAME_PROCESS) {
     const inboundMessage = await convertInboundMessage(message);
-    await saveNewIncomingMessage(inboundMessage);
+    // Only persist the message if it was matched to an existing conversation
+    if (inboundMessage) {
+      await saveNewIncomingMessage(inboundMessage);
+    }
   } else {
     const { id: serviceId, from, to } = message;
     const contactNumber = getFormattedPhoneNumber(from);


### PR DESCRIPTION
Spoke should return a 200 for inbound messages it successfully processes, even if that message
could not be matched to an existing conversation and is dropped. For a large campaign it is fairly
common to receive unsolicited texts.