### PR TITLE
feat: team scoped assignment complete notifications

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -73,6 +73,11 @@ if (isClient()) {
         "Webhook URL to notify when there are no more assignable campaign contacts.",
       default: undefined
     }),
+    ASSIGNMENT_COMPLETE_NOTIFICATION_TEAM_IDS: str({
+      desc:
+        "Comma separated list of team IDs to restrict 'assignment complete' notifications to.",
+      default: ""
+    }),
     AUTH0_DOMAIN: host({
       desc: "Domain name on Auth0 account",
       example: "example.auth0.com",

--- a/src/server/api/assignment.js
+++ b/src/server/api/assignment.js
@@ -542,19 +542,36 @@ export async function myCurrentAssignmentTarget(
   return options ? options[0] : null;
 }
 
-async function notifyIfAllAssigned(type, user, organizationId) {
+async function notifyIfAllAssigned(
+  organizationId,
+  teamsAssignedTo,
+  parentTrx = r.reader
+) {
   if (config.ASSIGNMENT_COMPLETE_NOTIFICATION_URL) {
-    const assignmentTarget = await currentAssignmentTarget(organizationId);
-    if (assignmentTarget == null) {
-      await request
-        .post(config.ASSIGNMENT_COMPLETE_NOTIFICATION_URL)
-        .timeout(30000)
-        .send({ type, user })
-        .catch(err =>
-          logger.error("Encountered error notifying assignment complete: ", err)
-        );
-      logger.verbose(`Notified about out of ${type} to assign`);
+    const assignmentTargets = await allCurrentAssignmentTargets(
+      organizationId,
+      parentTrx
+    );
+    const existingTeamIds = assignmentTargets.map(cat => cat.team_id);
+
+    const isEmptiedTeam = ([id, _title]) => !existingTeamIds.includes(id);
+    let emptiedTeams = [...teamsAssignedTo.entries()].filter(isEmptiedTeam);
+
+    let notificationTeamIds = config.ASSIGNMENT_COMPLETE_NOTIFICATION_TEAM_IDS;
+    if (notificationTeamIds.length > 0) {
+      notificationTeamIds = notificationTeamIds.split(",").map(parseInt);
+      const isANotifyTeam = ([id, _title]) => notificationTeamIds.includes(id);
+      emptiedTeams = emptiedTeams.filter(isANotifyTeam);
     }
+
+    await Promise.all(
+      emptiedTeams.map(([_id, title]) =>
+        request
+          .post(config.ASSIGNMENT_COMPLETE_NOTIFICATION_URL)
+          .timeout(30000)
+          .send({ team: title })
+      )
+    );
   } else {
     logger.verbose(
       "Not checking if assignments are available – ASSIGNMENT_COMPLETE_NOTIFICATION_URL is unset"
@@ -648,12 +665,14 @@ export async function giveUserMoreTexts(
     );
   }
 
+  // Use a Map to de-duplicate and support integer-type keys
+  const teamsAssignedTo = new Map();
   let countUpdated = 0;
   let countLeftToUpdate = count;
 
   const updated_result = await parentTrx.transaction(async trx => {
     while (countLeftToUpdate > 0) {
-      const countUpdatedInLoop = await assignLoop(
+      const { count: countUpdatedInLoop, team } = await assignLoop(
         user,
         organizationId,
         countLeftToUpdate,
@@ -673,13 +692,18 @@ export async function giveUserMoreTexts(
           return countUpdated;
         }
       }
+
+      const { teamId, teamTitle } = team;
+      teamsAssignedTo.set(teamId, teamTitle);
     }
 
     return countUpdated;
   });
 
   // Async function, not awaiting because response to external assignment tool does not depend on it
-  notifyIfAllAssigned(assignmentInfo.type, auth0Id, organizationId);
+  notifyIfAllAssigned(organizationId, teamsAssignedTo, parentTrx).catch(err =>
+    logger.error("Encountered error notifying assignment complete: ", err)
+  );
 
   return updated_result;
 }
@@ -698,7 +722,7 @@ export async function assignLoop(
   );
 
   if (assignmentOptions.length === 0) {
-    return 0;
+    return { count: 0 };
   }
 
   const preferredAssignment = assignmentOptions.find(
@@ -787,7 +811,11 @@ export async function assignLoop(
   );
 
   logger.verbose(`Updated ${ccUpdateCount} campaign contacts`);
-  return ccUpdateCount;
+  const team = {
+    teamId: assignmentInfo.team_id,
+    teamTitle: assignmentInfo.team_title
+  };
+  return { count: ccUpdateCount, team };
 }
 
 export const resolvers = {

--- a/src/server/api/assignment.js
+++ b/src/server/api/assignment.js
@@ -130,9 +130,11 @@ export function getContacts(
 }
 
 // Returns either "replies", "initials", or null
-export async function getCurrentAssignmentType(organizationId) {
-  const organization = await r
-    .reader("organization")
+export async function getCurrentAssignmentType(
+  organizationId,
+  parentTrx = r.reader
+) {
+  const organization = await parentTrx("organization")
     .select("features")
     .where({ id: parseInt(organizationId) })
     .first();
@@ -152,9 +154,13 @@ export async function getCurrentAssignmentType(organizationId) {
   };
 }
 
-export async function allCurrentAssignmentTargets(organizationId) {
+export async function allCurrentAssignmentTargets(
+  organizationId,
+  parentTrx = r.reader
+) {
   const { assignmentType, generalEnabled } = await getCurrentAssignmentType(
-    organizationId
+    organizationId,
+    parentTrx
   );
 
   const campaignView = {
@@ -178,7 +184,7 @@ export async function allCurrentAssignmentTargets(organizationId) {
    * so that the limit applies only to it and not the whole
    * query
    */
-  const { rows: teamToCampaigns } = await r.reader.raw(
+  const { rows: teamToCampaigns } = await parentTrx.raw(
     /**
      * What a query!
      *

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -2473,6 +2473,7 @@ const rootMutations = {
           auth0_id,
           assignmentRequest.amount,
           assignmentRequest.organization_id,
+          null,
           trx
         );
 


### PR DESCRIPTION
This:

- adds missing `preferredTeamId` argument in `schema.js`
- allows knex context to be passed to `allCurrentAssignmentTargets()` to ensure we are looking at current state
- adds team-scoped assignment complete notifications