### PR TITLE
fix: return null rather than undefined

### DIFF
--- a/src/server/api/interaction-step.js
+++ b/src/server/api/interaction-step.js
@@ -26,5 +26,6 @@ export const resolvers = {
           interaction_step_id: interactionStep.id
         })
         .first()
+        .then(qr => qr || null)
   }
 };


### PR DESCRIPTION
GraphQL wants `null`, not `undefined`