### PR TITLE
fix: assignment notifications

### DIFF
--- a/src/server/notifications.js
+++ b/src/server/notifications.js
@@ -65,7 +65,7 @@ const sendAssignmentUserNotification = async (assignment, notification) => {
       text
     });
   } catch (e) {
-    logger.error("Error sending assignment notification email", e);
+    logger.error("Error sending assignment notification email: ", e);
   }
 };
 
@@ -134,7 +134,10 @@ export const sendUserNotification = async notification => {
           }/reply`
         });
       } catch (e) {
-        logger.error("Error sending conversation reply notification email", e);
+        logger.error(
+          "Error sending conversation reply notification email: ",
+          e
+        );
       }
     }
   } else if (type === Notifications.ASSIGNMENT_CREATED) {

--- a/src/server/notifications.js
+++ b/src/server/notifications.js
@@ -36,7 +36,7 @@ const sendAssignmentUserNotification = async (assignment, notification) => {
     .where({ id: campaign.organization_id })
     .first();
   const user = await r
-    .reader("organization")
+    .reader("user")
     .where({ id: assignment.user_id })
     .first();
   const orgOwner = await getOrganizationOwner(organization.id);


### PR DESCRIPTION
This resolves the error:

```
Error sending assignment notification emailCannot read property 'email' of undefined
```

It does not address a potential issue where notifications are sent from within a transaction and thus before `r.reader` will have access to any modified/created data. In this case it is a non-issue as the `assignment` insert payload is passed with the notification.