### PR TITLE
refactor: use pluck over mapping the result

### DIFF
--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -731,13 +731,13 @@ const rootMutations = {
       { user, loaders }
     ) => {
       // TODO: wrap in transaction
-      const currentRoles = (await r
+      const currentRoles = await r
         .knex("user_organization")
         .where({
           organization_id: organizationId,
           user_id: userId
         })
-        .select("role")).map(res => res.role);
+        .pluck("role");
       const oldRoleIsOwner = currentRoles.indexOf("OWNER") !== -1;
       const newRoleIsOwner = roles.indexOf("OWNER") !== -1;
       const roleRequired = oldRoleIsOwner || newRoleIsOwner ? "OWNER" : "ADMIN";


### PR DESCRIPTION
Made this change this while debugging a reported bug of role not updating in the list. The bug turned out to be operator error but might as well clean up knex usage.