### PR TITLE
fix: pass error object to winston correctly

### DIFF
--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -2398,9 +2398,7 @@ const rootMutations = {
 
         return "No texts available at the moment";
       } catch (err) {
-        logger.error("Error submitting external assignment request!", {
-          error: err
-        });
+        logger.error("Error submitting external assignment request: ", err);
 
         if (assignmentRequestId !== undefined) {
           logger.debug("Deleting assignment request ", { assignmentRequestId });


### PR DESCRIPTION
I'm not sure why passing the error like we were wasn't working, but this should.