### PR TITLE
fix: exit the process when script has completed

### DIFF
--- a/src/workers/cron/update-sms-spanish-speakers.js
+++ b/src/workers/cron/update-sms-spanish-speakers.js
@@ -45,5 +45,11 @@ const main = async () => {
 };
 
 main()
-  .then(console.log)
-  .catch(console.error);
+  .then(result => {
+    console.log(result);
+    process.exit(0);
+  })
+  .catch(err => {
+    console.error("Update SMS Spanish Speakers failed", err);
+    process.exit(1);
+  });


### PR DESCRIPTION
The CronJob just hangs otherwise