### PR TITLE
feat: improve release all unnhandled replies

### DIFF
--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -299,9 +299,9 @@ const rootSchema = `
     megaReassignCampaignContacts(organizationId:String!, campaignIdsContactIds:[CampaignIdContactId]!, newTexterUserIds:[String]):[CampaignIdAssignmentId]
     megaBulkReassignCampaignContacts(organizationId:String!, campaignsFilter:CampaignsFilter, assignmentsFilter:AssignmentsFilter, tagsFilter: TagsFilter, contactsFilter:ContactsFilter, newTexterUserIds:[String]):[CampaignIdAssignmentId]
     requestTexts(count: Int!, email: String!, organizationId: String!, preferredTeamId: Int!): String!
-    releaseMessages(campaignId: String!, target: ReleaseActionTarget!, ageInHours: Int): String!
-    releaseAllUnhandledReplies(organizationId: String!, ageInHours: Int): String!
-    markForSecondPass(campaignId: String!, excludeAgeInHours: Int): String!
+    releaseMessages(campaignId: String!, target: ReleaseActionTarget!, ageInHours: Float): String!
+    releaseAllUnhandledReplies(organizationId: String!, ageInHours: Float, releaseOnRestricted: Boolean): String!
+    markForSecondPass(campaignId: String!, excludeAgeInHours: Float): String!
     unMarkForSecondPass(campaignId: String!): String!
     deleteNeedsMessage(campaignId: String!): String!
     insertLinkDomain(organizationId: String!, domain: String!, maxUsageCount: Int!): LinkDomain!

--- a/src/containers/AdminCampaignList.jsx
+++ b/src/containers/AdminCampaignList.jsx
@@ -115,6 +115,13 @@ class AdminCampaignList extends React.Component {
         releaseOnRestricted
       )
       .then(result => {
+        if (result.errors) {
+          return this.setState({
+            releaseAllRepliesError: errors,
+            releasingInProgress: false
+          });
+        }
+
         this.setState({
           releaseAllRepliesResult: result.data.releaseAllUnhandledReplies,
           releasingInProgress: false
@@ -242,7 +249,10 @@ class AdminCampaignList extends React.Component {
                 Error: {JSON.stringify(this.state.releaseAllRepliesError)}
               </span>
             ) : this.state.releaseAllRepliesResult ? (
-              <span>Released {this.state.releaseAllRepliesResult} replies</span>
+              <span>
+                Released replies on {this.state.releaseAllRepliesResult}
+                campaigns
+              </span>
             ) : !doneReleasingReplies ? (
               <div>
                 How many hours ago should a conversation have been idle for it

--- a/src/containers/AdminCampaignList.jsx
+++ b/src/containers/AdminCampaignList.jsx
@@ -15,7 +15,7 @@ import { MenuItem } from "material-ui/Menu";
 import { dataTest } from "../lib/attributes";
 import RaisedButton from "material-ui/RaisedButton";
 import Dialog from "material-ui/Dialog";
-import { TextField } from "material-ui";
+import { TextField, Toggle } from "material-ui";
 
 const styles = {
   flexContainer: {
@@ -37,6 +37,7 @@ class AdminCampaignList extends React.Component {
     campaignsFilter: {
       isArchived: false
     },
+    releasingInProgress: false,
     releasingAllReplies: false,
     releaseAllRepliesError: undefined,
     releaseAllRepliesResult: undefined
@@ -93,20 +94,38 @@ class AdminCampaignList extends React.Component {
   };
 
   closeReleasingAllReplies = () => {
-    this.setState({ releasingAllReplies: false });
+    this.setState({
+      releasingInProgress: false,
+      releasingAllReplies: false,
+      releaseAllRepliesError: undefined,
+      releaseAllRepliesResult: undefined
+    });
   };
 
   releaseAllReplies = () => {
     const ageInHours = this.refs.numberOfHoursToRelease.input.value;
+    const releaseOnRestricted = this.refs.releaseOnRestricted.state.switched;
+
+    this.setState({ releasingInProgress: true });
 
     this.props.mutations
-      .releaseAllUnhandledReplies(this.props.params.organizationId, ageInHours)
+      .releaseAllUnhandledReplies(
+        this.props.match.params.organizationId,
+        ageInHours,
+        releaseOnRestricted
+      )
       .then(result => {
         this.setState({
-          releaseAllRepliesResult: result.data.releaseAllUnhandledReplies
+          releaseAllRepliesResult: result.data.releaseAllUnhandledReplies,
+          releasingInProgress: false
         });
       })
-      .catch(error => this.setState({ releaseAllRepliesError: error }));
+      .catch(error =>
+        this.setState({
+          releaseAllRepliesError: error,
+          releasingInProgress: false
+        })
+      );
   };
 
   renderPageSizeOptions() {
@@ -167,7 +186,8 @@ class AdminCampaignList extends React.Component {
       pageSize,
       currentPageIndex,
       campaignsFilter,
-      releasingAllReplies
+      releasingAllReplies,
+      releasingInProgress
     } = this.state;
 
     const doneReleasingReplies =
@@ -193,35 +213,37 @@ class AdminCampaignList extends React.Component {
             open={true}
             onRequestClose={this.closeReleasingAllReplies}
             actions={
-              doneReleasingReplies
-                ? [
-                    <RaisedButton
-                      label="Done"
-                      onClick={this.closeReleasingAllReplies}
-                    />
-                  ]
-                : [
-                    <RaisedButton
-                      label="Cancel"
-                      onClick={this.closeReleasingAllReplies}
-                    />,
-                    <RaisedButton
-                      label="Release"
-                      onClick={this.releaseAllReplies}
-                      primary={true}
-                    />
-                  ]
+              releasingInProgress
+                ? []
+                : doneReleasingReplies
+                  ? [
+                      <RaisedButton
+                        label="Done"
+                        onClick={this.closeReleasingAllReplies}
+                      />
+                    ]
+                  : [
+                      <RaisedButton
+                        label="Cancel"
+                        onClick={this.closeReleasingAllReplies}
+                      />,
+                      <RaisedButton
+                        label="Release"
+                        onClick={this.releaseAllReplies}
+                        primary={true}
+                      />
+                    ]
             }
           >
-            {this.state.releaseAllRepliesError && (
+            {releasingInProgress ? (
+              <LoadingIndicator />
+            ) : this.state.releaseAllRepliesError ? (
               <span>
                 Error: {JSON.stringify(this.state.releaseAllRepliesError)}
               </span>
-            )}
-            {this.state.releaseAllRepliesResult && (
+            ) : this.state.releaseAllRepliesResult ? (
               <span>Released {this.state.releaseAllRepliesResult} replies</span>
-            )}
-            {!doneReleasingReplies && (
+            ) : !doneReleasingReplies ? (
               <div>
                 How many hours ago should a conversation have been idle for it
                 to be unassigned?
@@ -231,7 +253,15 @@ class AdminCampaignList extends React.Component {
                   ref="numberOfHoursToRelease"
                   defaultValue={1}
                 />
+                <br />
+                <br />
+                Should we release replies on campaigns that are restricted to
+                teams? If unchecked, replies on campaigns restricted to team
+                members will stay assigned to their current texter.
+                <Toggle ref="releaseOnRestricted" defaultValue={false} />
               </div>
+            ) : (
+              <div />
             )}
           </Dialog>
         )}
@@ -282,19 +312,25 @@ const mapMutationsToProps = () => ({
     `,
     variables: { campaign }
   }),
-  releaseAllUnhandledReplies: (organizationId, ageInHours) => ({
+  releaseAllUnhandledReplies: (
+    organizationId,
+    ageInHours,
+    releaseOnRestricted
+  ) => ({
     mutation: gql`
       mutation releaseAllUnhandledReplies(
         $organizationId: String!
-        $ageInHours: Int
+        $ageInHours: Float
+        $releaseOnRestricted: Boolean
       ) {
         releaseAllUnhandledReplies(
           organizationId: $organizationId
           ageInHours: $ageInHours
+          releaseOnRestricted: $releaseOnRestricted
         )
       }
     `,
-    variables: { organizationId, ageInHours }
+    variables: { organizationId, ageInHours, releaseOnRestricted }
   })
 });
 

--- a/src/containers/CampaignList/index.jsx
+++ b/src/containers/CampaignList/index.jsx
@@ -153,7 +153,7 @@ const mapMutationsToProps = () => ({
     mutation: gql`
       mutation markForSecondPass(
         $campaignId: String!
-        $excludeAgeInHours: Int
+        $excludeAgeInHours: Float
       ) {
         markForSecondPass(
           campaignId: $campaignId
@@ -171,7 +171,7 @@ const mapMutationsToProps = () => ({
       mutation releaseUnrepliedMessages(
         $campaignId: String!
         $target: ReleaseActionTarget!
-        $ageInHours: Int!
+        $ageInHours: Float!
       ) {
         releaseMessages(
           campaignId: $campaignId

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -2669,7 +2669,7 @@ const rootMutations = {
             returning 1, campaign_id
           )
           select
-            count(*) as count, campaign_id
+            1, campaign_id
           from
             update_result
           group by 2

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -2061,7 +2061,7 @@ const rootMutations = {
 
       const queryArgs = [parseInt(campaignId)];
       if (excludeAgeInHours) {
-        queryArgs.push(parseInt(excludeAgeInHours));
+        queryArgs.push(parseFloat(excludeAgeInHours));
       }
 
       /**
@@ -2625,19 +2625,12 @@ const rootMutations = {
     },
     releaseAllUnhandledReplies: async (
       _,
-      { organizationId, ageInHours },
+      { organizationId, ageInHours, releaseOnRestricted },
       { user }
     ) => {
       await accessRequired(user, organizationId, "ADMIN", true);
-      let ageInHoursAgo;
-      if (!!ageInHours) {
-        ageInHoursAgo = new Date();
-        ageInHoursAgo.setHours(new Date().getHours() - ageInHours);
-        ageInHoursAgo = ageInHoursAgo.toISOString();
-      }
 
-      const queryArgs = [parseInt(organizationId)];
-      if (ageInHours) queryArgs.push(ageInHoursAgo);
+      const releaseOnLimitAssignmentToTeams = releaseOnRestricted || false;
 
       /*
        * Using SQL injection to avoid passing archived as a binding
@@ -2645,30 +2638,47 @@ const rootMutations = {
        */
       const rawResult = await r.knex.raw(
         `
-          update
-            campaign_contact
-          set
-            assignment_id = null
-          where
-            exists (
-              select 1
-              from campaign
-              where campaign_contact.campaign_id = campaign.id
-                and campaign.organization_id = ?
-            )
-            and is_opted_out = false
-            and message_status = 'needsResponse'
-            and archived = false
-            and not exists (
-              select 1 
-              from campaign_contact_tag
-              join tag on tag.id = campaign_contact_tag.tag_id
-              where tag.is_assignable = false
-                and campaign_contact_tag.campaign_contact_id = campaign_contact.id
-            )
-            ${ageInHours ? "and campaign_contact.updated_at < ?" : ""}
+          with update_result as (
+            update
+              campaign_contact
+            set
+              assignment_id = null
+            from
+              campaign
+            where
+              campaign_contact.campaign_id = campaign.id
+              and campaign.organization_id = ?
+              and (? or campaign.limit_assignment_to_teams = false)
+              and not exists (
+                select 1
+                from message
+                where is_from_contact = false
+                  and campaign_contact_id = campaign_contact.id
+                  and created_at > now() - (? * interval '1 hours')
+              )
+              and is_opted_out = false
+              and message_status = 'needsResponse'
+              and archived = false
+              and not exists (
+                select 1 
+                from campaign_contact_tag
+                join tag on tag.id = campaign_contact_tag.tag_id
+                where tag.is_assignable = false
+                  and campaign_contact_tag.campaign_contact_id = campaign_contact.id
+              )
+            returning 1, campaign_id
+          )
+          select
+            count(*) as count, campaign_id
+          from
+            update_result
+          group by 2
         `,
-        queryArgs
+        [
+          parseInt(organizationId),
+          releaseOnLimitAssignmentToTeams,
+          ageInHours || 0
+        ]
       );
 
       return rawResult.rowCount;


### PR DESCRIPTION
This PR
– adds an option to releasing all replies that toggles whether to include campaigns that have have limit assignment to teams on or not
– adds loading indicators to releasing all replies, since it could take a bit
– makes ageInHours accept decimal hour interfaces!