### PR TITLE
feat: optimize get todos

### DIFF
--- a/migrations/20200210161722_better-todos-index.js
+++ b/migrations/20200210161722_better-todos-index.js
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema.raw(`
+    create index new_todos_partial_idx on campaign_contact (assignment_id, message_status, timezone, is_opted_out) where archived = false;
+    drop index todos_partial_idx;
+  `);
+};
+
+exports.down = function(knex) {
+  return knex.schema.raw(`
+    create index todos_partial_idx on campaign_contact (campaign_id, assignment_id, message_status, is_opted_out) where (archived = false);
+    drop index todos_partial_idx;
+  `);
+};

--- a/src/server/api/assignment.js
+++ b/src/server/api/assignment.js
@@ -70,7 +70,6 @@ export function getContacts(
   let query = r
     .reader("campaign_contact")
     .where({
-      campaign_id: campaign.id,
       assignment_id: assignment.id
     })
     .whereRaw(`archived = ${campaign.is_archived}`); // partial index friendly


### PR DESCRIPTION
This should allow this query:

```
select 
          count(*), 
          assignment_id,
          campaign_id,
          message_status,
          is_opted_out,
          coalesce(
            contact_is_textable_now(
              campaign_contact.timezone,
              campaign.texting_hours_start,
              campaign.texting_hours_end,
              extract('hour' from current_timestamp at time zone campaign.timezone) < campaign.texting_hours_end
              and 
              extract('hour' from current_timestamp at time zone campaign.timezone) > campaign.texting_hours_start
            ),
            false
          ) as contact_is_textable_now
        from campaign_contact
        join campaign on campaign.id = campaign_contact.campaign_id
        where archived = false
          and assignment_id in (
            select id
            from assignment
            where user_id = ?
              and campaign_id in (
                select id
                from campaign
                where campaign.is_started = true
                  and organization_id = ?
                  and is_archived = false 
              )
          )
          group by 2, 3, 4, 5, 6;
```

to do an index only scan!

Right now it scans the index but has to fetch the main campaign contact record to do a recheck on the timezone