### PR TITLE
fix: make insert-invite idempotent

### DIFF
--- a/dev-tools/insert-invite.js
+++ b/dev-tools/insert-invite.js
@@ -67,6 +67,13 @@ Usage: insert-invite HASH [--include-env]
     }
   }
 
+  const existingRecord = await r
+    .knex("invite")
+    .where({ hash })
+    .first("id");
+  if (existingRecord)
+    throw new Error(`An invite with hash '${hash}' already exists!`);
+
   await r.knex("invite").insert({
     is_valid: true,
     hash,


### PR DESCRIPTION
There is no unique constraint on `invite.hash` (and I'm not sure there has to be) so for k8s jobs we want to explicitly check for an existing invite with the same hash as `insert-invite` Jobs may be re-run