### PR TITLE
fix(ux): make pencil icon size dynamic (take 2)

### DIFF
--- a/src/components/Empty.jsx
+++ b/src/components/Empty.jsx
@@ -1,34 +1,37 @@
 import PropTypes from "prop-types";
 import React from "react";
 import { StyleSheet, css } from "aphrodite";
+
 import theme from "../styles/theme";
 import { dataTest } from "../lib/attributes";
 
 const inlineStyles = {
   icon: {
-    width: 200,
-    height: 200,
+    position: "absolute",
+    height: "100%",
+    width: "100%",
+    top: 0,
+    left: 0,
     opacity: 0.2
   }
 };
 
-// removing pencil image for mobile widths smaller than 450px
-
 const styles = StyleSheet.create({
   container: {
-    marginTop: "10px",
-    width: 200,
-    marginLeft: "auto",
-    marginRight: "auto"
+    display: "flex",
+    flexDirection: "column",
+    height: "100%",
+    marginLeft: "20px",
+    marginRight: "20px"
   },
-  hideMobile: {
-    marginTop: "10px",
-    width: 200,
-    marginLeft: "auto",
-    marginRight: "auto",
-    "@media(maxWidth: 450px)": {
-      display: "none"
-    }
+  paddingBlock: {
+    flexGrow: "1"
+  },
+  iconWrapper: {
+    flexGrow: "10",
+    position: "relative",
+    maxHeight: "200px",
+    overflow: "hidden"
   },
   title: {
     ...theme.text.header,
@@ -41,22 +44,22 @@ const styles = StyleSheet.create({
   }
 });
 
-const Empty = ({ title, icon, content, hideMobile }) => (
-  <div
-    className={hideMobile ? css(styles.hideMobile) : css(styles.container)}
-    {...dataTest("empty")}
-  >
-    {React.cloneElement(icon, { style: inlineStyles.icon })}
+const Empty = ({ title, icon, content }) => (
+  <div className={css(styles.container)} {...dataTest("empty")}>
+    <div className={css(styles.paddingBlock)} />
+    <div className={css(styles.iconWrapper)}>
+      {React.cloneElement(icon, { style: inlineStyles.icon })}
+    </div>
     <div className={css(styles.title)}>{title}</div>
-    {content ? <div className={css(styles.content)}>{content}</div> : ""}
+    {content && <div className={css(styles.content)}>{content}</div>}
+    <div className={css(styles.paddingBlock)} />
   </div>
 );
 
 Empty.propTypes = {
-  title: PropTypes.string,
-  icon: PropTypes.object,
-  content: PropTypes.object,
-  hideMobile: PropTypes.bool
+  title: PropTypes.string.isRequired,
+  icon: PropTypes.object.isRequired,
+  content: PropTypes.object
 };
 
 export default Empty;

--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -74,9 +74,15 @@ const styles = StyleSheet.create({
     flex: "0 0 auto"
   },
   dynamicFlexSection: {
-    flex: "1 1 auto"
+    flex: "1 1 0",
+    position: "relative"
   },
   verticalScrollingSection: {
+    position: "absolute",
+    top: "0",
+    left: "0",
+    bottom: "0",
+    right: "0",
     overflowY: "scroll",
     overflow: "-moz-scrollbars-vertical"
   },

--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -46,26 +46,15 @@ const TexterDialogType = Object.freeze({
 });
 
 const styles = StyleSheet.create({
-  mobile: {
-    "@media(min-width: 425px)": {
-      display: "none !important"
-    }
+  fullSize: {
+    width: "100%",
+    height: "100%"
   },
-  desktop: {
-    "@media(max-width: 450px)": {
-      display: "none !important"
-    }
-  },
-  container: {
-    margin: 0,
-    position: "absolute",
-    top: 0,
-    bottom: 0,
-    left: 0,
-    right: 0,
+  flexContainer: {
     display: "flex",
     flexDirection: "column",
-    height: "100%"
+    height: "100%",
+    margin: 0
   },
   overlay: {
     margin: 0,
@@ -81,17 +70,18 @@ const styles = StyleSheet.create({
     color: "black",
     zIndex: 1000000
   },
-  topFixedSection: {
+  fixedFlexSection: {
     flex: "0 0 auto"
   },
-  middleScrollingSection: {
-    flex: "1 1 auto",
+  dynamicFlexSection: {
+    flex: "1 1 auto"
+  },
+  verticalScrollingSection: {
     overflowY: "scroll",
     overflow: "-moz-scrollbars-vertical"
   },
-  bottomFixedSection: {
+  messageComposition: {
     borderTop: `1px solid ${grey100}`,
-    flex: "0 0 auto",
     marginBottom: "none"
   },
   messageField: {
@@ -180,10 +170,10 @@ export class AssignmentTexterContact extends React.Component {
       }, 1500);
     }
 
-    this.refs.messageScrollContainer.scrollTo(
-      0,
-      this.refs.messageScrollContainer.scrollHeight
-    );
+    const scroller = this.refs.messageScrollContainer;
+    if (scroller) {
+      scroller.scrollTo(0, scroller.scrollHeight);
+    }
 
     document.body.addEventListener("keyup", this.onEnterUp);
   }
@@ -556,30 +546,20 @@ export class AssignmentTexterContact extends React.Component {
 
   renderSurveySection() {
     const { contact } = this.props;
-    const { messages } = contact;
-
     const { questionResponses } = this.state;
 
     const availableInteractionSteps = this.getAvailableInteractionSteps(
       questionResponses
     );
 
-    return messages.length === 0 ? (
-      <Empty
-        title={"This is your first message to " + contact.firstName}
-        icon={<CreateIcon color="rgb(83, 180, 119)" />}
-        hideMobile
+    return (
+      <AssignmentTexterSurveys
+        contact={contact}
+        interactionSteps={availableInteractionSteps}
+        onQuestionResponseChange={this.handleQuestionResponseChange}
+        currentInteractionStep={this.state.currentInteractionStep}
+        questionResponses={questionResponses}
       />
-    ) : (
-      <div>
-        <AssignmentTexterSurveys
-          contact={contact}
-          interactionSteps={availableInteractionSteps}
-          onQuestionResponseChange={this.handleQuestionResponseChange}
-          currentInteractionStep={this.state.currentInteractionStep}
-          questionResponses={questionResponses}
-        />
-      </div>
     );
   }
 
@@ -786,7 +766,7 @@ export class AssignmentTexterContact extends React.Component {
 
     return (
       <div>
-        {this.renderSurveySection()}
+        {contact.messages.length > 0 && this.renderSurveySection()}
         {dialogType === TexterDialogType.None && (
           <div>
             <div className={css(styles.messageField)}>
@@ -844,29 +824,38 @@ export class AssignmentTexterContact extends React.Component {
         : "";
 
     return (
-      <div>
+      <div className={css(styles.fullSize)}>
         {disabled && (
           <div className={css(styles.overlay)}>
             <CircularProgress size={24} style={{ marginRight: "10px" }} />
             {this.state.disabledText}
           </div>
         )}
-        <div className={css(styles.container)} style={{ backgroundColor }}>
-          <div className={css(styles.topFixedSection)}>
+        <div className={css(styles.flexContainer)}>
+          <div className={css(styles.fixedFlexSection)}>
             <TopFixedSection
               campaign={campaign}
               contact={contact}
               onExitTexter={onExitTexter}
             />
           </div>
-          <div
-            {...dataTest("messageList")}
-            ref="messageScrollContainer"
-            className={css(styles.middleScrollingSection)}
-          >
-            <MessageList contact={contact} messages={contact.messages} />
+          <div className={css(styles.dynamicFlexSection)}>
+            {contact.messages.length > 0 ? (
+              <div
+                ref="messageScrollContainer"
+                className={css(styles.verticalScrollingSection)}
+                {...dataTest("messageList")}
+              >
+                <MessageList contact={contact} messages={contact.messages} />
+              </div>
+            ) : (
+              <Empty
+                title={`This is your first message to ${contact.firstName}`}
+                icon={<CreateIcon color="rgb(83, 180, 119)" />}
+              />
+            )}
           </div>
-          <div className={css(styles.bottomFixedSection)}>
+          <div className={css(styles.fixedFlexSection, css.messageComposition)}>
             {this.renderBottomFixedSection()}
           </div>
         </div>


### PR DESCRIPTION
When sending initial messages, the pencil icon would often push the Send button off the screen.
This adjusts component hierarchy and styling to ensure that nothing is pushed off and that it is
solely the middle section that grows/shrinks.

Reimplements #559