### PR TITLE
build: execute node directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ ENV SPOKE_VERSION=$SPOKE_VERSION
 
 # Run the production compiled code
 EXPOSE 3000
-CMD [ "yarn", "run", "start" ]
+CMD [ "node", "--no-deprecation", "./build/server/server" ]


### PR DESCRIPTION
Yarn intercepts kill signals and screws up graceful shutdown.

Stock yarn:
```
$ docker run --env-file .env gcr.io/spoke-rewired/spoke:fadb9c3c6003d185ebfd53c6997a812b37937932
yarn run v1.21.1
$ node ./build/server/server
{"message":"Node app is running on port 8090","level":"info","timestamp":"2020-03-03T21:52:46.307Z"}

#> docker stop <pid>

{"message":"Received kill signal, waiting 5000ms before shutting down...","level":"info","timestamp":"2020-03-03T21:52:58.931Z"}
$
```

Node directly
```
$ docker run --env-file .env gcr.io/spoke-rewired/spoke:fadb9c3c6003d185ebfd53c6997a812b37937932 node --no-deprecation ./build/server/server
{"message":"Node app is running on port 8090","level":"info","timestamp":"2020-03-03T21:51:49.535Z"}

#> docker stop <pid>

{"message":"Received kill signal, waiting 5000ms before shutting down...","level":"info","timestamp":"2020-03-03T21:52:07.341Z"}
{"message":"Done waiting","level":"info","timestamp":"2020-03-03T21:52:12.343Z"}
{"message":"Starting cleanup of Postgres pools.","level":"info","timestamp":"2020-03-03T21:52:12.345Z"}
{"message":"Cleanup finished, server is shutting down.","level":"info","timestamp":"2020-03-03T21:52:12.349Z"}
$
```