### PR TITLE
fix: message review actions

### DIFF
--- a/src/components/IncomingMessageActions.jsx
+++ b/src/components/IncomingMessageActions.jsx
@@ -118,6 +118,7 @@ class IncomingMessageActions extends Component {
       />
     ];
 
+    const { contactsAreSelected, conversationCount } = this.props;
     const { selectedTexters } = this.state;
     const hasSeletedTexters = selectedTexters.length > 0;
     return (
@@ -148,18 +149,14 @@ class IncomingMessageActions extends Component {
                   <FlatButton
                     label={"Reassign selected"}
                     onClick={this.onReassignmentClicked}
-                    disabled={!hasSeletedTexters}
+                    disabled={!contactsAreSelected || !hasSeletedTexters}
                   />
                 </div>
                 <div className={css(styles.flexColumn)}>
                   <FlatButton
-                    label={`Reassign all ${
-                      this.props.conversationCount
-                    } matching`}
+                    label={`Reassign all ${conversationCount} matching`}
                     onClick={this.onReassignAllMatchingClicked}
-                    disabled={
-                      !hasSeletedTexters || this.props.conversationCount === 0
-                    }
+                    disabled={conversationCount === 0}
                   />
                 </div>
                 <Dialog
@@ -171,9 +168,7 @@ class IncomingMessageActions extends Component {
                   modal={true}
                   onRequestClose={this.handleConfirmDialogCancel}
                 >
-                  {`Reassign all ${
-                    this.props.conversationCount
-                  } matching conversations?`}
+                  {`Reassign all ${conversationCount} matching conversations?`}
                 </Dialog>
               </div>
             </Tab>
@@ -183,16 +178,14 @@ class IncomingMessageActions extends Component {
                   <FlatButton
                     label={"Unassign selected"}
                     onClick={this.onUnassignClicked}
-                    disabled={this.props.conversationCount === 0}
+                    disabled={!contactsAreSelected}
                   />
                 </div>
                 <div className={css(styles.flexColumn)}>
                   <FlatButton
-                    label={`Unassign all ${
-                      this.props.conversationCount
-                    } matching`}
+                    label={`Unassign all ${conversationCount} matching`}
                     onClick={this.onUnassignAllMatchingClicked}
-                    disabled={this.props.conversationCount === 0}
+                    disabled={conversationCount === 0}
                   />
                 </div>
                 <Dialog
@@ -204,9 +197,7 @@ class IncomingMessageActions extends Component {
                   modal={true}
                   onRequestClose={this.handleConfirmDialogCancel}
                 >
-                  {`Unassign all ${
-                    this.props.conversationCount
-                  } matching conversations?`}
+                  {`Unassign all ${conversationCount} matching conversations?`}
                 </Dialog>
               </div>
             </Tab>

--- a/src/components/IncomingMessageList/index.jsx
+++ b/src/components/IncomingMessageList/index.jsx
@@ -56,16 +56,14 @@ export class IncomingMessageList extends Component {
   };
 
   componentDidMount() {
-    const convos = (this.props.conversations || {}).conversations || {};
-    const { total = 0 } = convos.pageInfo;
+    const { total = 0 } = this.props.conversations.conversations.pageInfo;
     this.props.onConversationCountChanged(total);
   }
 
   componentDidUpdate(prevProps) {
-    const prevConvos = (prevProps.conversations || {}).conversations || {};
+    const prevConvos = prevProps.conversations.conversations;
     const { total: prevTotal = 0 } = prevConvos.pageInfo;
-    const convos = (this.props.conversations || {}).conversations || {};
-    const { total = 0 } = convos.pageInfo;
+    const { total = 0 } = this.props.conversations.conversations.pageInfo;
 
     if (prevTotal !== total) {
       this.props.onConversationCountChanged(pageInfo.total);

--- a/src/components/IncomingMessageList/index.jsx
+++ b/src/components/IncomingMessageList/index.jsx
@@ -55,21 +55,19 @@ export class IncomingMessageList extends Component {
     activeConversationIndex: -1
   };
 
+  componentDidMount() {
+    const convos = (this.props.conversations || {}).conversations || {};
+    const { total = 0 } = convos.pageInfo;
+    this.props.onConversationCountChanged(total);
+  }
+
   componentDidUpdate(prevProps) {
-    let previousPageInfo = { total: 0 };
-    if (prevProps.conversations.conversations) {
-      previousPageInfo = prevProps.conversations.conversations.pageInfo;
-    }
+    const prevConvos = (prevProps.conversations || {}).conversations || {};
+    const { total: prevTotal = 0 } = prevConvos.pageInfo;
+    const convos = (this.props.conversations || {}).conversations || {};
+    const { total = 0 } = convos.pageInfo;
 
-    let pageInfo = { total: 0 };
-    if (this.props.conversations.conversations) {
-      pageInfo = this.props.conversations.conversations.pageInfo;
-    }
-
-    if (
-      previousPageInfo.total !== pageInfo.total ||
-      (!previousPageInfo && pageInfo)
-    ) {
+    if (prevTotal !== total) {
       this.props.onConversationCountChanged(pageInfo.total);
     }
   }
@@ -208,13 +206,11 @@ export class IncomingMessageList extends Component {
   };
 
   handleRowsSelected = rowsSelected => {
-    console.log({ rowsSelected });
     const conversations = this.props.conversations.conversations.conversations;
     const [selection, selectedData] = prepareSelectedRowsData(
       conversations,
       rowsSelected
     );
-    console.log({ selection });
     this.props.onConversationSelected(selection, selectedData);
   };
 


### PR DESCRIPTION
`DataTable` pagination was a red herring (though this means there's a different bug there I haven't been able to reproduce tonight).

This was likely a regression introduced by #517 wherein the new `loadData` fixes how loading state after the initial load is handled and branches to `<LoadingIndicator />`. This means that `IncomingMessageList` is recreated rather than updated more often than not and so the conversation count also needs to be passed up from `componentDidMount()`.