### PR TITLE
fix: validate phone number in the correct place

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -70,7 +70,10 @@ const getValidatedData = (data, optOuts) => {
       cell: getFormattedPhoneNumber(row.cell, PHONE_NUMBER_COUNTRY)
     })
   );
-  result = _.partition(validatedData, row => !!row.cell);
+  // Restrict to 10-digit US numbers
+  result = _.partition(validatedData, row =>
+    /^\+1[0-9]{10}$/.test(row.cell || "")
+  );
   validatedData = result[0];
   const invalidCellRows = result[1];
 

--- a/src/server/api/lib/edit-campaign.js
+++ b/src/server/api/lib/edit-campaign.js
@@ -59,11 +59,7 @@ export const processContactsFile = async file => {
           }
         }
         const contact = sanitizeRawContact(data);
-
-        // Restrict to 10-digit US numbers
-        if (/^\+1[0-9]{10}$/.test(contact.cell)) {
-          resultData.push(contact);
-        }
+        resultData.push(contact);
       },
       complete: ({ meta: { aborted } }) => {
         if (aborted) return reject(`CSV missing fields: ${missingFields}`);


### PR DESCRIPTION
## Description

The check for a valid 10-digit US phone number was happening before `libphonenumber` had sanitized the input phone number.

## Motivation and Context

This prevents premature filtering of valid phone numbers.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

N/A

## Checklist:

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
