### PR TITLE
fix(edit-campaign): expose validation stats to user

### DIFF
--- a/src/components/CampaignContactsForm.jsx
+++ b/src/components/CampaignContactsForm.jsx
@@ -202,19 +202,11 @@ export default class CampaignContactsForm extends React.Component {
   }
 
   renderForm() {
-    const { canFilterLandlines } = this.props;
+    const { canFilterLandlines, jobResult } = this.props;
     const { contactUploadError, contactSqlError } = this.state;
     return (
       <div>
         {this.renderCampaignExclusion()}
-        {!this.props.jobResultMessage ? (
-          ""
-        ) : (
-          <div>
-            <CampaignFormSectionHeading title="Job Outcome" />
-            <div>{this.props.jobResultMessage}</div>
-          </div>
-        )}
         <GSForm
           schema={yup.object({
             contactSql: yup.string()
@@ -290,6 +282,20 @@ export default class CampaignContactsForm extends React.Component {
               )}
             </div>
           )}
+          {jobResult && (
+            <List>
+              <Subheader>Upload Messages</Subheader>
+              {jobResult.resultMessage.split("\n").length > 0 ? (
+                jobResult.resultMessage
+                  .split("\n")
+                  .map(message => (
+                    <ListItem key={message} primaryText={message} />
+                  ))
+              ) : (
+                <ListItem primaryText={"No results"} />
+              )}
+            </List>
+          )}
           {this.renderContactStats()}
           {contactUploadError ? (
             <List>
@@ -347,7 +353,7 @@ CampaignContactsForm.propTypes = {
   onSubmit: type.func,
   saveDisabled: type.bool,
   saveLabel: type.string,
-  jobResultMessage: type.string,
+  jobResult: type.object,
   otherCampaigns: type.array,
   canFilterLandlines: type.bool
 };

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -395,12 +395,9 @@ class AdminCampaignEdit extends React.Component {
           optOuts: [], // this.props.organizationData.organization.optOuts, // <= doesn't scale
           datawarehouseAvailable: this.props.campaignData.campaign
             .datawarehouseAvailable,
-          jobResultMessage:
-            (
-              this.props.pendingJobsData.campaign.pendingJobs.filter(job =>
-                /contacts/.test(job.jobType)
-              )[0] || {}
-            ).resultMessage || "",
+          jobResult: this.props.pendingJobsData.campaign.pendingJobs.find(job =>
+            /contacts/.test(job.jobType)
+          ),
           canFilterLandlines:
             this.props.organizationData.organization &&
             !!this.props.organizationData.organization.numbersApiKey,

--- a/src/server/api/lib/edit-campaign.js
+++ b/src/server/api/lib/edit-campaign.js
@@ -67,11 +67,11 @@ export const processContactsFile = async file => {
       },
       complete: ({ meta: { aborted } }) => {
         if (aborted) return reject(`CSV missing fields: ${missingFields}`);
-        const { contacts } = validateCsv({
+        const { contacts, validationStats } = validateCsv({
           data: resultData,
           meta: resultMeta
         });
-        return resolve(contacts);
+        return resolve({ contacts, validationStats });
       },
       error: err => reject(err)
     });

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -202,8 +202,11 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
     }
   });
 
+  let validationStats = {};
   if (campaign.hasOwnProperty("contactsFile")) {
-    campaign.contacts = await processContactsFile(campaign.contactsFile);
+    const processedContacts = await processContactsFile(campaign.contactsFile);
+    campaign.contacts = processedContacts.contacts;
+    validationStats = processedContacts.validationStats;
   }
 
   if (campaign.hasOwnProperty("contacts") && campaign.contacts) {
@@ -226,7 +229,8 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
     const jobPayload = {
       excludeCampaignIds: campaign.excludeCampaignIds || [],
       contacts: contactsToSave,
-      filterOutLandlines: campaign.filterOutLandlines
+      filterOutLandlines: campaign.filterOutLandlines,
+      validationStats
     };
     const compressedString = await gzip(JSON.stringify(jobPayload));
     const [job] = await r

--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -193,7 +193,8 @@ export async function uploadContacts(job) {
   let {
     contacts,
     excludeCampaignIds = [],
-    filterOutLandlines = false
+    filterOutLandlines = false,
+    validationStats
   } = jobPayload;
 
   const shouldRemoveLandlines = filterOutLandlines && numbersApiKey;
@@ -301,6 +302,34 @@ export async function uploadContacts(job) {
       if (deleteOptOutCells) {
         resultMessages.push(
           `Number of contacts excluded due to their opt-out status: ${deleteOptOutCells}`
+        );
+      }
+
+      const {
+        dupeCount = 0,
+        missingCellCount = 0,
+        invalidCellCount = 0,
+        zipCount = 0
+      } = validationStats;
+
+      if (dupeCount) {
+        resultMessages.push(
+          `Number of duplicate contacts removed: ${dupeCount}`
+        );
+      }
+      if (missingCellCount) {
+        resultMessages.push(
+          `Number of contacts excluded due to missing cells: ${missingCellCount}`
+        );
+      }
+      if (invalidCellCount) {
+        resultMessages.push(
+          `Number of contacts with excluded due to invalid cells: ${invalidCellCount}`
+        );
+      }
+      if (zipCount) {
+        resultMessages.push(
+          `Number of contacts with valid zip codes: ${zipCount}`
         );
       }
     } catch (exc) {


### PR DESCRIPTION
## Description

Result messages that had previously been exposed to the user became hidden when the CSV processing moved to the backend. This exposes those messages to the user.

## Motivation and Context

Admins should be informed of how many contacts were removed due to invalid or missing numbers, etc.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

![Screen_Shot_2020-03-12_at_1_07_42_PM](https://user-images.githubusercontent.com/2145526/76546837-8ccc6700-6462-11ea-8ade-d0fe64159baf.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
