### PR TITLE
fix: reset texter loading UI state on refetch

### DIFF
--- a/src/containers/PaginatedUsersRetriever.jsx
+++ b/src/containers/PaginatedUsersRetriever.jsx
@@ -56,6 +56,9 @@ export class PaginatedUsersRetriever extends Component {
 
     const { organizationId, campaignsFilter, pageSize } = this.props;
 
+    this.props.onUsersReceived([]);
+    this.props.setCampaignTextersLoadedFraction(0);
+
     let offset = 0;
     let total = undefined;
     let users = [];


### PR DESCRIPTION
### Description

The UI should be updated to reflect when the texter list is being reloaded in response to changed in campaign filter settings.

## Motivation and Context

It is unclear to the user that the list is being updated in the background and that they are working from a stale user list.

## How Has This Been Tested?

This change has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
