### PR TITLE
build: tightly scope imports to reduce client bundle size

### DIFF
--- a/src/components/AdminDashboard.jsx
+++ b/src/components/AdminDashboard.jsx
@@ -6,7 +6,7 @@ import gql from "graphql-tag";
 import { StyleSheet, css } from "aphrodite";
 
 import { loadData } from "../containers/hoc/with-operations";
-import { hasRole } from "../lib";
+import { hasRole } from "../lib/permissions";
 import theme from "../styles/theme";
 import TopNav from "./TopNav";
 import AdminNavigation from "../containers/AdminNavigation";

--- a/src/components/AuthzProvider.jsx
+++ b/src/components/AuthzProvider.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import createReactContext from "create-react-context";
 import gql from "graphql-tag";
 
-import { hasRole } from "../lib";
+import { hasRole } from "../lib/permissions";
 import ApolloClientSingleton from "../network/apollo-client-singleton";
 
 const AuthzContext = createReactContext(false);

--- a/src/components/CampaignInteractionStepsForm.jsx
+++ b/src/components/CampaignInteractionStepsForm.jsx
@@ -9,7 +9,7 @@ import IconButton from "material-ui/IconButton";
 import HelpIconOutline from "material-ui/svg-icons/action/help-outline";
 import DeleteIcon from "material-ui/svg-icons/action/delete";
 
-import { makeTree } from "../lib";
+import { makeTree } from "../lib/interaction-step-helpers";
 import { dataTest } from "../lib/attributes";
 import theme from "../styles/theme";
 import GSForm from "./forms/GSForm";

--- a/src/components/Chip.jsx
+++ b/src/components/Chip.jsx
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
-import _ from "lodash";
+import extend from "lodash/extend";
 
 // Credit to materialize CSS
 // Material UI coming out with Chip
@@ -37,7 +37,7 @@ function Chip({
   style = {}
 }) {
   return (
-    <div style={_.extend({}, styles.chip, style)} onTouchTap={onTouchTap}>
+    <div style={extend({}, styles.chip, style)} onTouchTap={onTouchTap}>
       {text}
       {iconRightClass
         ? React.createElement(iconRightClass, {

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -5,8 +5,8 @@ import { List, ListItem } from "material-ui/List";
 import Divider from "material-ui/Divider";
 import Avatar from "material-ui/Avatar";
 import { withRouter } from "react-router";
-import _ from "lodash";
-import { dataTest, camelCase } from "../lib/attributes";
+import camelCase from "lodash/camelCase";
+import { dataTest } from "../lib/attributes";
 import { FlatButton } from "material-ui";
 import { StyleSheet, css } from "aphrodite";
 
@@ -42,7 +42,7 @@ const Navigation = function Navigation(props) {
           <List>
             {sections.map(section => (
               <ListItem
-                {...dataTest(_.camelCase(`nav ${section.path}`))}
+                {...dataTest(camelCase(`nav ${section.path}`))}
                 key={section.name}
                 primaryText={section.name}
                 onTouchTap={() => props.history.push(section.url)}

--- a/src/containers/AdminIncomingMessageList/index.jsx
+++ b/src/containers/AdminIncomingMessageList/index.jsx
@@ -3,7 +3,9 @@ import PropTypes from "prop-types";
 import { withRouter } from "react-router";
 import { compose } from "react-apollo";
 import gql from "graphql-tag";
-import _ from "lodash";
+import omit from "lodash/omit";
+import pick from "lodash/pick";
+import isEqual from "lodash/isEqual";
 
 import Dialog from "material-ui/Dialog";
 import FlatButton from "material-ui/FlatButton";
@@ -107,10 +109,10 @@ export class AdminIncomingMessageList extends Component {
   shouldComponentUpdate(dummy, nextState) {
     if (
       !nextState.needsRender &&
-      _.isEqual(this.state.contactsFilter, nextState.contactsFilter) &&
-      _.isEqual(this.state.campaignsFilter, nextState.campaignsFilter) &&
-      _.isEqual(this.state.assignmentsFilter, nextState.assignmentsFilter) &&
-      _.isEqual(this.state.tagsFilter, nextState.tagsFilter)
+      isEqual(this.state.contactsFilter, nextState.contactsFilter) &&
+      isEqual(this.state.campaignsFilter, nextState.campaignsFilter) &&
+      isEqual(this.state.assignmentsFilter, nextState.assignmentsFilter) &&
+      isEqual(this.state.tagsFilter, nextState.tagsFilter)
     ) {
       return false;
     }
@@ -172,7 +174,7 @@ export class AdminIncomingMessageList extends Component {
 
   handleMessageFilterChange = async messagesFilter => {
     const contactsFilter = Object.assign(
-      _.omit(this.state.contactsFilter, ["messageStatus"]),
+      omit(this.state.contactsFilter, ["messageStatus"]),
       { messageStatus: messagesFilter }
     );
     await this.setState({
@@ -322,7 +324,7 @@ export class AdminIncomingMessageList extends Component {
     );
 
     const contactsFilter = Object.assign(
-      _.omit(this.state.contactsFilter, ["isOptedOut"]),
+      omit(this.state.contactsFilter, ["isOptedOut"]),
       contactsFilterUpdate
     );
 
@@ -344,7 +346,7 @@ export class AdminIncomingMessageList extends Component {
     );
 
     const contactsFilter = Object.assign(
-      _.omit(this.state.contactsFilter, ["isOptedOut"]),
+      omit(this.state.contactsFilter, ["isOptedOut"]),
       contactsFilterUpdate
     );
 
@@ -457,7 +459,7 @@ export class AdminIncomingMessageList extends Component {
         />
         <PaginatedCampaignsRetriever
           organizationId={organizationId}
-          campaignsFilter={_.pick(this.state.campaignsFilter, "isArchived")}
+          campaignsFilter={pick(this.state.campaignsFilter, "isArchived")}
           onCampaignsReceived={this.handleCampaignsReceived}
           onTagsReceived={this.handleTagsReceived}
           pageSize={1000}

--- a/src/containers/AdminPersonList.jsx
+++ b/src/containers/AdminPersonList.jsx
@@ -14,7 +14,7 @@ import Dialog from "material-ui/Dialog";
 import PeopleIcon from "material-ui/svg-icons/social/people";
 import ContentAdd from "material-ui/svg-icons/content/add";
 
-import { getHighestRole, ROLE_HIERARCHY } from "../lib";
+import { getHighestRole, ROLE_HIERARCHY } from "../lib/permissions";
 import { dataTest } from "../lib/attributes";
 import { loadData } from "./hoc/with-operations";
 import theme from "../styles/theme";

--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -20,7 +20,11 @@ import MoreVertIcon from "material-ui/svg-icons/navigation/more-vert";
 import LocalOfferIcon from "material-ui/svg-icons/maps/local-offer";
 
 import { isContactNowWithinCampaignHours } from "../../lib/timezones";
-import { getChildren, getTopMostParent, interactionStepForId } from "../../lib";
+import {
+  getChildren,
+  getTopMostParent,
+  interactionStepForId
+} from "../../lib/interaction-step-helpers";
 import { applyScript } from "../../lib/scripts";
 import { dataTest } from "../../lib/attributes";
 import MessageList from "../../components/MessageList";


### PR DESCRIPTION
Reduce client bundle size from ~4MB to ~2.9MB by limiting the scope of imports.

## Description

This removes `lodash` and `google-libphonenumber` as modules included in the bundle. `google-libphonenumber` is no longer needed on the client as CSVs are processed on the backend. The entire `lodash` library is not needed, only a few of functions which are imported directly.

## Motivation and Context

The bundle size is very big! And it doesn't need to be.

## How Has This Been Tested?

I have run Spoke locally and confirmed that each of the affected components still works.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
