### PR TITLE
fix(message-review): optimize people() query

### DIFF
--- a/src/server/api/user.js
+++ b/src/server/api/user.js
@@ -30,7 +30,12 @@ export function buildUserOrganizationQuery(
   return queryParam;
 }
 
-async function doGetUsers({ organizationId, cursor, campaignsFilter, role }) {
+async function doGetUsers({
+  organizationId,
+  cursor,
+  campaignsFilter = {},
+  role
+}) {
   const query = r
     .knex("user")
     .innerJoin("user_organization", "user_organization.user_id", "user.id")

--- a/src/server/api/user.js
+++ b/src/server/api/user.js
@@ -45,7 +45,14 @@ async function doGetUsers({
     query.where({ role });
   }
 
-  if (campaignsFilter.isArchived !== undefined) {
+  if (campaignsFilter.campaignId !== undefined) {
+    query.whereExists(function() {
+      this.select(r.knex.raw("1"))
+        .from("assignment")
+        .whereRaw("assignment.user_id = user.id")
+        .where({ campaign_id: parseInt(campaignsFilter.campaignId) });
+    });
+  } else if (campaignsFilter.isArchived !== undefined) {
     query.whereExists(function() {
       this.select(r.knex.raw("1"))
         .from("assignment")
@@ -54,15 +61,6 @@ async function doGetUsers({
         .where({
           is_archived: campaignsFilter.isArchived
         });
-    });
-  }
-
-  if (campaignsFilter.campaignId !== undefined) {
-    query.whereExists(function() {
-      this.select(r.knex.raw("1"))
-        .from("assignment")
-        .whereRaw("assignment.user_id = user.id")
-        .where({ campaign_id: parseInt(campaignsFilter.campaignId) });
     });
   }
 

--- a/src/server/api/user.js
+++ b/src/server/api/user.js
@@ -45,8 +45,7 @@ async function doGetUsers({
     query.where({ role });
   }
 
-  // Only archived = false is performant enough to use at scale due to partial index
-  if (campaignsFilter.isArchived === false) {
+  if (campaignsFilter.isArchived !== undefined) {
     query.whereExists(function() {
       this.select(r.knex.raw("1"))
         .from("assignment")
@@ -69,15 +68,10 @@ async function doGetUsers({
 
   const countQuery = query.clone();
 
-  // Only `archived = false` is performant enough to sort by user name
-  if (campaignsFilter.isArchived !== false) {
-    query.orderBy("id");
-  } else {
-    query
-      .orderBy("first_name")
-      .orderBy("last_name")
-      .orderBy("id");
-  }
+  query
+    .orderBy("first_name")
+    .orderBy("last_name")
+    .orderBy("id");
 
   const { limit, offset } = cursor || {};
   if (offset !== undefined) {


### PR DESCRIPTION
Optimize the query to fetch users for the `people()` query.

## Description

~Ignore sorting options and checking for campaign membership if `archived = true`.~

Making the index a full index addresses the issue. This is now just a refactor.

## Motivation and Context

For a very large number of users and archived campaigns, the `people()` query times out if limited to archived campaigns

## How Has This Been Tested?

Run locally against database with large user and archived campaign counts.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
