### PR TITLE
fix: fix index cleanup migration

### DIFF
--- a/migrations/20200310222822_clean-up-indexes.js
+++ b/migrations/20200310222822_clean-up-indexes.js
@@ -1,29 +1,37 @@
 exports.up = function(knex) {
   return knex.schema.raw(`
-    create unique index campaign_contact_cell_campaign_id_unique on campaign_contact (cell, campaign_id);
+    -- Swap order of cell, campaign_id in unique constraint
+    alter table campaign_contact add constraint campaign_contact_cell_campaign_id_unique unique (cell, campaign_id);
+    alter table campaign_contact drop constraint campaign_contact_campaign_id_cell_unique;
+
+    -- Add partial index on archived = false for performance
     create index campaign_contact_partial_assignment_id_index on campaign_contact (assignment_id) where archived = false;
 
-    drop index campaign_contact_campaign_id_cell_unique;
+    -- Drop unused indexes that just slow down vacuuming
     drop index campaign_contact_timezone_index;
     drop index campaign_contact_assignment_id_index;
     drop index campaign_contact_cell_index;
 
-    drop index message_assignment_id_foreign;
+    -- Drop this unused relationship in favor of campaign contact <> assignment
     alter table message drop constraint message_assignment_id_foreign;
   `);
 };
 
 exports.down = function(knex) {
   return knex.schema.raw(`
-    drop index campaign_contact_cell_campaign_id_unique;
-    drop index campaign_contact_partial_assignment_id_index;
+    -- Restore message <> assignment relationship
+    alter table message add constraint message_assignment_id_foreign foreign key (assignment_id) references assignment (id);
 
-    create index campaign_contact_campaign_id_cell_unique on campaign_contact (campaign_id, cell);
-    create index campaign_contact_timezone_index on campaign_contact (timezone);
+    -- Restore indexes
     create index campaign_contact_cell_index on campaign_contact (cell);
     create index campaign_contact_assignment_id_index on campaign_contact (assignment_id);
+    create index campaign_contact_timezone_index on campaign_contact (timezone);
 
-    create index message_assignment_id_foreign on message (assigment_id);
-    alter table message add constraint message_assignment_id_foreign foreign key (assignment_id) references assignment (id);
+    -- Drop partial index on archived = false
+    drop index campaign_contact_partial_assignment_id_index;
+
+    -- Restore original ordering of unique constraint
+    alter table campaign_contact add constraint campaign_contact_campaign_id_cell_unique unique (campaign_id, cell);
+    alter table campaign_contact drop constraint campaign_contact_cell_campaign_id_unique;
   `);
 };


### PR DESCRIPTION
## Description

This fixes up/down behavior on a clean database.

## Motivation and Context

See above.

## How Has This Been Tested?

I have run this up and down a few times on clean local database.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
