### PR TITLE
fix(ux): avoid flashing background between texts

### DIFF
--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -77,9 +77,8 @@ const styles = StyleSheet.create({
     bottom: 0,
     left: 0,
     right: 0,
-    opacity: 0.2,
-    backgroundColor: "black",
-    color: "white",
+    backgroundColor: "rgba(255, 255, 255, 0.25)",
+    color: "black",
     zIndex: 1000000
   },
   topFixedSection: {
@@ -848,7 +847,7 @@ export class AssignmentTexterContact extends React.Component {
       <div>
         {disabled && (
           <div className={css(styles.overlay)}>
-            <CircularProgress size={0.5} />
+            <CircularProgress size={24} style={{ marginRight: "10px" }} />
             {this.state.disabledText}
           </div>
         )}


### PR DESCRIPTION
## Description

This reduces the visual impact of the loading state between texts.

## Motivation and Context

The background flashing to gray between texts is very hard on texters' eyes and dangerous for anyone with epilepsy.

## How Has This Been Tested?

It is only css changes and has been tested locally.

## Screenshots (if appropriate):

![Spoke](https://user-images.githubusercontent.com/2145526/77364343-a99e4f80-6d2a-11ea-8141-b91b82526ae8.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
