### PR TITLE
feat: expose texter auto-approval status

### DIFF
--- a/src/api/organization-membership.js
+++ b/src/api/organization-membership.js
@@ -1,0 +1,45 @@
+export const UserRoleType = Object.freeze({
+  TEXTER: "TEXTER",
+  SUPERVOLUNTEER: "SUPERVOLUNTEER",
+  ADMIN: "ADMIN",
+  OWNER: "OWNER"
+});
+
+export const RequestAutoApproveType = Object.freeze({
+  DO_NOT_APPROVE: "DO_NOT_APPROVE",
+  APPROVAL_REQUIRED: "APPROVAL_REQUIRED",
+  AUTO_APPROVE: "AUTO_APPROVE"
+});
+
+export const schema = `
+  enum UserRole {
+    TEXTER
+    SUPERVOLUNTEER
+    ADMIN
+    OWNER
+  }
+
+  enum RequestAutoApprove {
+    DO_NOT_APPROVE
+    APPROVAL_REQUIRED
+    AUTO_APPROVE
+  }
+
+  type OrganizationMembership {
+    id: ID!
+    user: User!
+    organization: Organization!
+    role: UserRole!
+    requestAutoApprove: RequestAutoApprove!
+  }
+
+  type OrganizationMembershipEdge {
+    cursor: Cursor!
+    node: OrganizationMembership!
+  }
+
+  type OrganizationMembershipPage {
+    edges: [OrganizationMembershipEdge!]!
+    pageInfo: RelayPageInfo!
+  }
+`;

--- a/src/api/organization.js
+++ b/src/api/organization.js
@@ -24,6 +24,7 @@ export const schema = `
     uuid: String
     name: String
     campaigns(cursor:OffsetLimitCursor, campaignsFilter: CampaignsFilter): PaginatedCampaigns
+    memberships(after: Cursor, first: Int): OrganizationMembershipPage
     people(role: String, campaignId: String, offset: Int): [User]
     peopleCount: Int
     optOuts: [OptOut]

--- a/src/api/pagination.js
+++ b/src/api/pagination.js
@@ -1,0 +1,11 @@
+export const schema = `
+  scalar Cursor
+
+  type RelayPageInfo {
+    totalCount: Int!
+    hasNextPage: Boolean!
+    hasPreviousPage: Boolean!
+    startCursor: Cursor
+    endCursor: Cursor
+  }
+`;

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -16,6 +16,7 @@ import { schema as assignmentRequestSchema } from "./assignment-request";
 import { schema as tagSchema } from "./tag";
 import { schema as teamSchema } from "./team";
 import { schema as trollbotSchema } from "./trollbot";
+import { schema as paginationSchema } from "./pagination";
 
 const rootSchema = `
   input CampaignContactInput {
@@ -305,6 +306,7 @@ export const schema = [
   rootSchema,
   userSchema,
   organizationSchema,
+  paginationSchema,
   "scalar Upload",
   "scalar Date",
   "scalar JSON",

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -243,6 +243,7 @@ const rootSchema = `
     createOrganization(name: String!, userId: String!, inviteId: String!): Organization
     joinOrganization(organizationUuid: String!): Organization
     editOrganizationRoles(organizationId: String!, userId: String!, campaignId: String, roles: [String]): Organization
+    editUserAutoApprove(organizationId: String!, userId: String!, level: RequestAutoApprove!): OrganizationMembership
     editUser(organizationId: String!, userId: Int!, userData:UserInput): User
     resetUserPassword(organizationId: String!, userId: Int!): String!
     changeUserPassword(userId: Int!, formData: UserPasswordChange): User

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -243,7 +243,7 @@ const rootSchema = `
     createOrganization(name: String!, userId: String!, inviteId: String!): Organization
     joinOrganization(organizationUuid: String!): Organization
     editOrganizationRoles(organizationId: String!, userId: String!, campaignId: String, roles: [String]): Organization
-    editUserAutoApprove(organizationId: String!, userId: String!, level: RequestAutoApprove!): OrganizationMembership
+    editOrganizationMembership(id: String!, level: RequestAutoApprove, role: String): OrganizationMembership!
     editUser(organizationId: String!, userId: Int!, userData:UserInput): User
     resetUserPassword(organizationId: String!, userId: Int!): String!
     changeUserPassword(userId: Int!, formData: UserPasswordChange): User

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -1,54 +1,16 @@
-import {
-  schema as userSchema,
-  resolvers as userResolvers,
-  buildUserOrganizationQuery
-} from "./user";
-import {
-  schema as conversationSchema,
-  getConversations,
-  resolvers as conversationsResolver
-} from "./conversations";
-import {
-  schema as organizationSchema,
-  resolvers as organizationResolvers
-} from "./organization";
-import {
-  schema as campaignSchema,
-  resolvers as campaignResolvers
-} from "./campaign";
-import {
-  schema as assignmentSchema,
-  resolvers as assignmentResolvers
-} from "./assignment";
-import {
-  schema as interactionStepSchema,
-  resolvers as interactionStepResolvers
-} from "./interaction-step";
-import {
-  schema as questionSchema,
-  resolvers as questionResolvers
-} from "./question";
-import {
-  schema as questionResponseSchema,
-  resolvers as questionResponseResolvers
-} from "./question-response";
-import {
-  schema as optOutSchema,
-  resolvers as optOutResolvers
-} from "./opt-out";
-import {
-  schema as messageSchema,
-  resolvers as messageResolvers
-} from "./message";
-import {
-  schema as campaignContactSchema,
-  resolvers as campaignContactResolvers
-} from "./campaign-contact";
-import {
-  schema as cannedResponseSchema,
-  resolvers as cannedResponseResolvers
-} from "./canned-response";
-import { schema as inviteSchema, resolvers as inviteResolvers } from "./invite";
+import { schema as userSchema } from "./user";
+import { schema as conversationSchema } from "./conversations";
+import { schema as organizationSchema } from "./organization";
+import { schema as campaignSchema } from "./campaign";
+import { schema as assignmentSchema } from "./assignment";
+import { schema as interactionStepSchema } from "./interaction-step";
+import { schema as questionSchema } from "./question";
+import { schema as questionResponseSchema } from "./question-response";
+import { schema as optOutSchema } from "./opt-out";
+import { schema as messageSchema } from "./message";
+import { schema as campaignContactSchema } from "./campaign-contact";
+import { schema as cannedResponseSchema } from "./canned-response";
+import { schema as inviteSchema } from "./invite";
 import { schema as linkDomainSchema } from "./link-domain";
 import { schema as assignmentRequestSchema } from "./assignment-request";
 import { schema as tagSchema } from "./tag";

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -17,6 +17,7 @@ import { schema as tagSchema } from "./tag";
 import { schema as teamSchema } from "./team";
 import { schema as trollbotSchema } from "./trollbot";
 import { schema as paginationSchema } from "./pagination";
+import { schema as membershipSchema } from "./organization-membership";
 
 const rootSchema = `
   input CampaignContactInput {
@@ -311,6 +312,7 @@ export const schema = [
   "scalar Date",
   "scalar JSON",
   "scalar Phone",
+  membershipSchema,
   campaignSchema,
   assignmentSchema,
   interactionStepSchema,

--- a/src/api/user.js
+++ b/src/api/user.js
@@ -6,7 +6,7 @@ export const schema = `
     displayName: String
     email: String
     cell: String
-    memberships(after: Cursor, first: Int): OrganizationMembershipPage
+    memberships(organizationId: String, after: Cursor, first: Int): OrganizationMembershipPage
     organizations(role: String): [Organization]
     todos(organizationId: String): [Assignment]
     roles(organizationId: String!): [String]

--- a/src/api/user.js
+++ b/src/api/user.js
@@ -6,6 +6,7 @@ export const schema = `
     displayName: String
     email: String
     cell: String
+    memberships(after: Cursor, first: Int): OrganizationMembershipPage
     organizations(role: String): [Organization]
     todos(organizationId: String): [Assignment]
     roles(organizationId: String!): [String]

--- a/src/containers/AdminPersonList.jsx
+++ b/src/containers/AdminPersonList.jsx
@@ -25,14 +25,6 @@ import PasswordResetLink from "../components/PasswordResetLink";
 import LoadingIndicator from "../components/LoadingIndicator";
 
 class AdminPersonList extends React.Component {
-  constructor(props) {
-    super(props);
-    this.handleOpen = this.handleOpen.bind(this);
-    this.handleClose = this.handleClose.bind(this);
-    this.handleChange = this.handleChange.bind(this);
-    this.updateUser = this.updateUser.bind(this);
-  }
-
   state = {
     open: false,
     userEdit: false,
@@ -56,13 +48,9 @@ class AdminPersonList extends React.Component {
     this.handleFilterChange(campaignId, value);
   };
 
-  handleOpen() {
-    this.setState({ open: true });
-  }
+  handleOpen = () => this.setState({ open: true });
 
-  handleClose() {
-    this.setState({ open: false, passwordResetHash: "" });
-  }
+  handleClose = () => this.setState({ open: false, passwordResetHash: "" });
 
   handleChange = async (userId, value) => {
     await this.props.mutations.editOrganizationRoles(
@@ -72,14 +60,12 @@ class AdminPersonList extends React.Component {
     );
   };
 
-  editUser(userId) {
-    this.setState({ userEdit: userId });
-  }
+  editUser = userId => this.setState({ userEdit: userId });
 
-  updateUser() {
+  updateUser = () => {
     this.setState({ userEdit: false });
     this.props.personData.refetch();
-  }
+  };
 
   renderOffsetList() {
     const LIMIT = 200;

--- a/src/containers/AdminPersonList.jsx
+++ b/src/containers/AdminPersonList.jsx
@@ -15,7 +15,7 @@ import Snackbar from "material-ui/Snackbar";
 import PeopleIcon from "material-ui/svg-icons/social/people";
 import ContentAdd from "material-ui/svg-icons/content/add";
 
-import { getHighestRole, ROLE_HIERARCHY } from "../lib/permissions";
+import { getHighestRole, ROLE_HIERARCHY, hasRole } from "../lib/permissions";
 import { RequestAutoApproveType } from "../api/organization-membership";
 import { dataTest } from "../lib/attributes";
 import { loadData } from "./hoc/with-operations";
@@ -211,7 +211,7 @@ class AdminPersonList extends React.Component {
               <TableRowColumn>
                 <DropDownMenu
                   value={person.memberships.edges[0].node.requestAutoApprove}
-                  disabled={false}
+                  disabled={!hasRole("ADMIN", currentUser.roles)}
                   onChange={this.handleOnChangeAutoApprovalLevel(
                     person.memberships.edges[0].node.id
                   )}

--- a/src/containers/AdminPersonList.jsx
+++ b/src/containers/AdminPersonList.jsx
@@ -11,10 +11,12 @@ import FloatingActionButton from "material-ui/FloatingActionButton";
 import DropDownMenu from "material-ui/DropDownMenu";
 import MenuItem from "material-ui/MenuItem";
 import Dialog from "material-ui/Dialog";
+import Snackbar from "material-ui/Snackbar";
 import PeopleIcon from "material-ui/svg-icons/social/people";
 import ContentAdd from "material-ui/svg-icons/content/add";
 
 import { getHighestRole, ROLE_HIERARCHY } from "../lib/permissions";
+import { RequestAutoApproveType } from "../api/organization-membership";
 import { dataTest } from "../lib/attributes";
 import { loadData } from "./hoc/with-operations";
 import theme from "../styles/theme";
@@ -24,11 +26,21 @@ import OrganizationJoinLink from "../components/OrganizationJoinLink";
 import PasswordResetLink from "../components/PasswordResetLink";
 import LoadingIndicator from "../components/LoadingIndicator";
 
+const titleCase = value =>
+  `${value.charAt(0).toUpperCase()}${value.substring(1).toLowerCase()}`;
+const snakeToTitleCase = value =>
+  value
+    .split("_")
+    .map(s => titleCase(s))
+    .join(" ");
+
 class AdminPersonList extends React.Component {
   state = {
     open: false,
     userEdit: false,
-    passwordResetHash: ""
+    passwordResetHash: "",
+    isWorking: false,
+    saveError: undefined
   };
 
   handleFilterChange = (campaignId, offset) => {
@@ -52,12 +64,35 @@ class AdminPersonList extends React.Component {
 
   handleClose = () => this.setState({ open: false, passwordResetHash: "" });
 
+  handleDismissSaveError = () => this.setState({ saveError: undefined });
+
   handleChange = async (userId, value) => {
     await this.props.mutations.editOrganizationRoles(
       this.props.match.params.organizationId,
       userId,
       [value]
     );
+  };
+
+  handleOnChangeAutoApprovalLevel = membershipId => async (
+    _event,
+    _index,
+    level
+  ) => {
+    const { editOrganizationMembership } = this.props.mutations;
+    this.setState({ isWorking: true, saveError: undefined });
+    try {
+      const response = await editOrganizationMembership(membershipId, {
+        level
+      });
+      if (response.errors) throw response.errors;
+    } catch (err) {
+      this.setState({
+        saveError: `Couldn't update approval level: ${err.message}`
+      });
+    } finally {
+      this.setState({ isWorking: false });
+    }
   };
 
   editUser = userId => this.setState({ userEdit: userId });
@@ -168,12 +203,30 @@ class AdminPersonList extends React.Component {
                         option === "OWNER" &&
                         getHighestRole(currentUser.roles) !== "OWNER"
                       }
-                      primaryText={`${option
-                        .charAt(0)
-                        .toUpperCase()}${option.substring(1).toLowerCase()}`}
+                      primaryText={titleCase(option)}
                     />
                   ))}
                 </DropDownMenu>
+              </TableRowColumn>
+              <TableRowColumn>
+                <DropDownMenu
+                  value={person.memberships.edges[0].node.requestAutoApprove}
+                  disabled={false}
+                  onChange={this.handleOnChangeAutoApprovalLevel(
+                    person.memberships.edges[0].node.id
+                  )}
+                >
+                  {Object.keys(RequestAutoApproveType).map(option => (
+                    <MenuItem
+                      key={`${person.id}_${option}`}
+                      value={option}
+                      disabled={false}
+                      primaryText={snakeToTitleCase(option)}
+                    />
+                  ))}
+                </DropDownMenu>
+              </TableRowColumn>
+              <TableRowColumn>
                 <FlatButton
                   {...dataTest("editPerson")}
                   label="Edit"
@@ -181,7 +234,9 @@ class AdminPersonList extends React.Component {
                     this.editUser(person.id);
                   }}
                 />
-                {canResetPassword && (
+              </TableRowColumn>
+              {canResetPassword && (
+                <TableRowColumn>
                   <FlatButton
                     label="Reset Password"
                     disabled={currentUser.id === person.id}
@@ -189,8 +244,8 @@ class AdminPersonList extends React.Component {
                       this.resetPassword(person.id);
                     }}
                   />
-                )}
-              </TableRowColumn>
+                </TableRowColumn>
+              )}
             </TableRow>
           ))}
         </TableBody>
@@ -271,6 +326,12 @@ class AdminPersonList extends React.Component {
             </Dialog>
           </div>
         )}
+        <Snackbar
+          open={this.state.saveError !== undefined}
+          message={this.state.saveError || ""}
+          autoHideDuration={4000}
+          onRequestClose={this.handleDismissSaveError}
+        />
       </div>
     );
   }
@@ -298,6 +359,14 @@ const organizationFragment = `
     displayName
     email
     roles(organizationId: $organizationId)
+    memberships(organizationId: $organizationId) {
+      edges {
+        node {
+          id
+          requestAutoApprove
+        }
+      }
+    }
   }
 `;
 
@@ -319,6 +388,33 @@ const mutations = {
         queryString.parse(ownProps.location.search).offset !== undefined
           ? queryString.parse(ownProps.location.search).offset * 200
           : 0
+    }
+  }),
+  editOrganizationMembership: ownProps => (
+    membershipId,
+    { level = null, role = null }
+  ) => ({
+    mutation: gql`
+      mutation editOrganizationMembership(
+        $membershipId: String!
+        $level: RequestAutoApprove
+        $role: String
+      ) {
+        editOrganizationMembership(
+          id: $membershipId
+          level: $level
+          role: $role
+        ) {
+          id
+          role
+          requestAutoApprove
+        }
+      }
+    `,
+    variables: {
+      membershipId: membershipId.toString(),
+      level,
+      role
     }
   }),
   resetUserPassword: ownProps => (organizationId, userId) => ({

--- a/src/server/api/lib/pagination.js
+++ b/src/server/api/lib/pagination.js
@@ -1,0 +1,55 @@
+const encode = value => Buffer.from(`${value}`).toString("base64");
+const decode = value => Buffer.from(value, "base64").toString();
+
+const defaultOptions = {
+  nodeTransformer: node => node
+};
+
+/**
+ * Take a basic query and return it as a Relay-style page
+ *
+ * @param {Knex} query The base query to paginate (only joins, wheres, etc.)
+ * @param {Object} options Options for creating the page
+ * @param {Cursor} [options.after] The cursor to begin the query at
+ * @param {number} [options.first] How many results to return in the page
+ * @param {Function} [options.nodeTransformer] Transformation to turn a record into a node.
+ * This could be used for destructuring results of a join query.
+ */
+export const formatPage = async (query, options) => {
+  const { after, first, nodeTransformer } = Object.assign(
+    {},
+    defaultOptions,
+    options
+  );
+  const countQuery = query.clone().clearSelect();
+
+  if (after) {
+    const afterId = decode(after);
+    query.where("id", ">", afterId);
+  }
+
+  if (first) {
+    query.limit(first + 1);
+  }
+
+  query.orderBy("id");
+
+  const [{ count: totalCount }] = await countQuery.count();
+  const results = await query;
+  const edges = results.slice(0, first || undefined).map(record => ({
+    cursor: encode(record.id),
+    node: nodeTransformer(record)
+  }));
+  const pageInfo = {
+    totalCount,
+    hasNextPage: first && results.length > first,
+    // Backward pagination not yet supported
+    hasPreviousPage: false,
+    startCursor: edges.length > 0 ? edges[0].cursor : null,
+    endCursor: edges.length > 0 ? edges.slice(-1)[0].cursor : null
+  };
+  return {
+    edges,
+    pageInfo
+  };
+};

--- a/src/server/api/organization-membership.js
+++ b/src/server/api/organization-membership.js
@@ -1,12 +1,5 @@
 import { sqlResolvers } from "./lib/utils";
 import { r } from "../models";
-import { RequestAutoApproveType } from "../../api/organization-membership";
-
-const pgToGql = {
-  do_not_approve: RequestAutoApproveType.DO_NOT_APPROVE,
-  approval_required: RequestAutoApproveType.APPROVAL_REQUIRED,
-  auto_approve: RequestAutoApproveType.AUTO_APPROVE
-};
 
 export const resolvers = {
   OrganizationMembership: {
@@ -25,6 +18,6 @@ export const resolvers = {
             .reader("organization")
             .where({ id: membership.organization_id })
             .first(),
-    requestAutoApprove: membership => pgToGql[membership.request_status]
+    requestAutoApprove: membership => membership.request_status.toUpperCase()
   }
 };

--- a/src/server/api/organization-membership.js
+++ b/src/server/api/organization-membership.js
@@ -1,0 +1,30 @@
+import { sqlResolvers } from "./lib/utils";
+import { r } from "../models";
+import { RequestAutoApproveType } from "../../api/organization-membership";
+
+const pgToGql = {
+  do_not_approve: RequestAutoApproveType.DO_NOT_APPROVE,
+  approval_required: RequestAutoApproveType.APPROVAL_REQUIRED,
+  auto_approve: RequestAutoApproveType.AUTO_APPROVE
+};
+
+export const resolvers = {
+  OrganizationMembership: {
+    ...sqlResolvers(["id", "role"]),
+    user: async membership =>
+      membership.user
+        ? membership.user
+        : r
+            .reader("user")
+            .where({ id: membership.user_id })
+            .first(),
+    organization: async membership =>
+      membership.organization
+        ? membership.organization
+        : r
+            .reader("organization")
+            .where({ id: membership.organization_id })
+            .first(),
+    requestAutoApprove: membership => pgToGql[membership.request_status]
+  }
+};

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -58,7 +58,7 @@ export const resolvers = {
         .where({ organization_id: organization.id });
 
       // Perform a a join if User fields are requested
-      let nodeTransformer = undefined;
+      let nodeTransformer = node => node;
       const edgesQuery = info.fieldNodes[0].selectionSet.selections.find(
         s => s.name.value === "edges"
       );

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -816,6 +816,21 @@ const rootMutations = {
       return loaders.organization.load(organizationId);
     },
 
+    editUserAutoApprove: async (
+      _,
+      { organizationId, userId, level },
+      { user: authUser }
+    ) => {
+      await accessRequired(authUser, organizationId, "ADMIN", true);
+
+      const [orgMembership] = await r
+        .knex("user_organization")
+        .where({ user_id: userId, organization_id: organizationId })
+        .update({ request_status: level.toLowerCase() })
+        .returning("*");
+      return orgMembership;
+    },
+
     editUser: async (_, { organizationId, userId, userData }, { user }) => {
       if (user.id !== userId) {
         // User can edit themselves

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -63,6 +63,7 @@ import {
   resolvers as organizationResolvers,
   getEscalationUserId
 } from "./organization";
+import { resolvers as membershipSchema } from "./organization-membership";
 import { GraphQLPhone } from "./phone";
 import { resolvers as questionResolvers } from "./question";
 import { resolvers as questionResponseResolvers } from "./question-response";
@@ -3500,6 +3501,7 @@ export const resolvers = {
   ...assignmentRequestResolvers,
   ...rootResolvers,
   ...userResolvers,
+  ...membershipSchema,
   ...organizationResolvers,
   ...campaignResolvers,
   ...assignmentResolvers,

--- a/src/server/api/user.js
+++ b/src/server/api/user.js
@@ -1,7 +1,9 @@
+import { GraphQLError } from "graphql/error";
 import { sqlResolvers } from "./lib/utils";
 import { r } from "../models";
 import groupBy from "lodash/groupBy";
 import { memoizer, cacheOpts } from "../memoredis";
+import { formatPage } from "./lib/pagination";
 
 export function buildUserOrganizationQuery(
   queryParam,
@@ -175,6 +177,16 @@ export const resolvers = {
         .where({ user_id: user.id, campaign_id: campaignId })
         .first()
         .then(record => record || null),
+    memberships: async (user, { after, first }, { user: authUser }) => {
+      if (authUser.id !== user.id || !authUser.is_superadmin) {
+        throw new GraphQLError(
+          "You are not authorized to access that resource."
+        );
+      }
+
+      const query = r.reader("user_organization").where({ user_id: user.id });
+      return await formatPage(query, { after, first });
+    },
     organizations: async (user, { role }) => {
       if (!user || !user.id) {
         return [];


### PR DESCRIPTION
Add user-facing management of texter auto-approval status.

## Description

This adds the ability to view and change a user's auto-approval status from the people page.

A later PR will add new actions to the Assignment Requests page to update the status from an approval/denial.

## Motivation and Context

The functionality has been there on the backend for a while but never exposed. A few larger organizations are reporting that manually approving requests is getting tedious with the volume they are doing.

## How Has This Been Tested?

This has been tested manually.

## Screenshots (if appropriate):

<table border="1"><tr><td>
<img width="1439" alt="Spoke" src="https://user-images.githubusercontent.com/2145526/77655322-a08ac980-6f48-11ea-910c-06689c9b8ab4.png">
</td></tr></table>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

A "Auto-approve texter requests" section has been added to the draft topic "Assignment control".

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] My change requires a change to the documentation.
- [x] I have included updates for the documentation accordingly.
