### PR TITLE
feat: add promote-on-assign

### DIFF
--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -282,8 +282,7 @@ const rootSchema = `
     deleteLinkDomain(organizationId: String!, domainId: String!): Boolean!
     deleteCampaignOverlap(organizationId: String!, campaignId: String!, overlappingCampaignId: String!): DeleteCampaignOverlapResult!
     deleteManyCampaignOverlap(organizationId: String!, campaignId: String!, overlappingCampaignIds: [String]!): Int!
-    approveAssignmentRequest(assignmentRequestId: String!): Int!
-    rejectAssignmentRequest(assignmentRequestId: String!): Boolean!
+    resolveAssignmentRequest(assignmentRequestId: String!, approved: Boolean!, autoApproveLevel: RequestAutoApprove): Int!
     setNumbersApiKey(organizationId: String!, numbersApiKey: String): Organization!
     saveTag(organizationId: String!, tag: TagInput!): Tag!
     deleteTag(organizationId: String!, tagId: String!): Boolean!

--- a/src/containers/AdminAssignmentRequest/AssignmentRequestTable.jsx
+++ b/src/containers/AdminAssignmentRequest/AssignmentRequestTable.jsx
@@ -10,9 +10,14 @@ import {
   TableRow,
   TableRowColumn
 } from "material-ui/Table";
+import IconButton from "material-ui/IconButton";
 import RaisedButton from "material-ui/RaisedButton";
 import FlatButton from "material-ui/FlatButton";
 import CircularProgress from "material-ui/CircularProgress";
+import HighlightOffIcon from "material-ui/svg-icons/action/highlight-off";
+import CheckCircleIcon from "material-ui/svg-icons/action/check-circle";
+import AssignmentTurnedInIcon from "material-ui/svg-icons/action/assignment-turned-in";
+import { red500, green300 } from "material-ui/styles/colors";
 
 import theme from "../../styles/theme";
 
@@ -53,8 +58,16 @@ const styles = {
 };
 
 const AssignmentRequestTable = props => {
-  const { assignmentRequests, onApproveRequest, onDenyRequest } = props;
+  const {
+    isAdmin,
+    assignmentRequests,
+    onAutoApproveRequest,
+    onApproveRequest,
+    onDenyRequest
+  } = props;
 
+  const handleAutoApproveRow = requestId => () =>
+    onAutoApproveRequest(requestId);
   const handleApproveRow = requestId => () => onApproveRequest(requestId);
   const handleDenyRow = requestId => () => onDenyRequest(requestId);
 
@@ -81,28 +94,42 @@ const AssignmentRequestTable = props => {
                 <TableRowColumn>{request.amount}</TableRowColumn>
                 <TableRowColumn>{moment(createdAt).fromNow()}</TableRowColumn>
                 <TableRowColumn>
-                  {status === RowWorkStatus.Error && (
-                    <span style={styles.errorText}>Error. Try again.</span>
-                  )}
-                  {showActions && (
-                    <FlatButton
-                      label="Deny"
-                      secondary={true}
-                      style={{ margin: "3px" }}
-                      onClick={handleDenyRow(requestId)}
-                    />
-                  )}
-                  {showActions && (
-                    <RaisedButton
-                      label="Approve"
-                      primary={true}
-                      style={{ margin: "3px" }}
-                      onClick={handleApproveRow(requestId)}
-                    />
-                  )}
-                  {status === RowWorkStatus.Working && (
-                    <CircularProgress size={25} />
-                  )}
+                  <div style={{ display: "flex", alignItems: "center" }}>
+                    {status === RowWorkStatus.Error && (
+                      <span style={styles.errorText}>Error. Try again.</span>
+                    )}
+                    {showActions && (
+                      <IconButton
+                        tooltip="Deny"
+                        tooltipPosition="top-center"
+                        onClick={handleDenyRow(requestId)}
+                      >
+                        <HighlightOffIcon color={red500} />
+                      </IconButton>
+                    )}
+                    {showActions && (
+                      <IconButton
+                        tooltip="Approve"
+                        tooltipPosition="top-center"
+                        onClick={handleApproveRow(requestId)}
+                      >
+                        <CheckCircleIcon color={green300} />
+                      </IconButton>
+                    )}
+                    {showActions &&
+                      isAdmin && (
+                        <FlatButton
+                          label="AutoApprove"
+                          labelPosition="before"
+                          primary={true}
+                          icon={<AssignmentTurnedInIcon color={green300} />}
+                          onClick={handleAutoApproveRow(requestId)}
+                        />
+                      )}
+                    {status === RowWorkStatus.Working && (
+                      <CircularProgress size={25} />
+                    )}
+                  </div>
                 </TableRowColumn>
               </TableRow>
             );
@@ -114,6 +141,7 @@ const AssignmentRequestTable = props => {
 };
 
 AssignmentRequestTable.propTypes = {
+  isAdmin: PropTypes.bool.isRequired,
   assignmentRequests: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,

--- a/src/containers/AdminAssignmentRequest/AssignmentRequestTable.jsx
+++ b/src/containers/AdminAssignmentRequest/AssignmentRequestTable.jsx
@@ -123,7 +123,7 @@ AssignmentRequestTable.propTypes = {
         lastName: PropTypes.string.isRequired
       }).isRequired,
       amount: PropTypes.number.isRequired,
-      createdAt: PropTypes.instanceOf(Date),
+      createdAt: PropTypes.string.isRequired,
       status: PropTypes.string.isRequired
     })
   ),


### PR DESCRIPTION
## Description

Add button for admins to both approve a request and update that user's organization membership record to be auto approve all future assignment requests.

## Motivation and Context

While this can be done from the people page, that requires a few extra steps when you come across a manual approval request from a texter that should be be getting auto approved.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<table border="1">
<tr><td>
<img width="1428" alt="Spoke_and_DevTools_-_localhost_3000_admin_1_assignment-requests" src="https://user-images.githubusercontent.com/2145526/77680020-be1c5b00-6f69-11ea-8ad6-8b4bf17281cc.png">
</td></tr>
<tr><td>
<img width="1426" alt="Spoke" src="https://user-images.githubusercontent.com/2145526/77680107-dee4b080-6f69-11ea-9ed4-e99d1ed4dcc1.png">
</td></tr>
</table>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
