### PR TITLE
refactor: user cursor pagination for message review

### DIFF
--- a/src/api/organization-membership.js
+++ b/src/api/organization-membership.js
@@ -25,6 +25,12 @@ export const schema = `
     AUTO_APPROVE
   }
 
+  input MembershipFilter {
+    nameSearch: String
+    campaignId: String
+    campaignArchived: Boolean
+  }
+
   type OrganizationMembership {
     id: ID!
     user: User!

--- a/src/api/organization.js
+++ b/src/api/organization.js
@@ -24,7 +24,7 @@ export const schema = `
     uuid: String
     name: String
     campaigns(cursor:OffsetLimitCursor, campaignsFilter: CampaignsFilter): PaginatedCampaigns
-    memberships(after: Cursor, first: Int): OrganizationMembershipPage
+    memberships(after: Cursor, first: Int, filter: MembershipFilter): OrganizationMembershipPage
     people(role: String, campaignId: String, offset: Int): [User]
     peopleCount: Int
     optOuts: [OptOut]

--- a/src/components/IncomingMessageActions.jsx
+++ b/src/components/IncomingMessageActions.jsx
@@ -29,9 +29,8 @@ const styles = StyleSheet.create({
 });
 
 const formatTexter = texter => {
-  const { displayName, email, roles } = texter;
-  const highestRole = getHighestRole(roles);
-  return `${displayName} (${email}) ${highestRole}`;
+  const { displayName, email, role } = texter;
+  return `${displayName} (${email}) ${role}`;
 };
 
 const MenuList = props => {

--- a/src/components/IncomingMessageFilter.jsx
+++ b/src/components/IncomingMessageFilter.jsx
@@ -2,12 +2,10 @@ import React, { Component } from "react";
 import type from "prop-types";
 import Toggle from "material-ui/Toggle";
 
-import { Card, CardHeader, CardText, CardTitle } from "material-ui/Card";
+import { Card, CardHeader, CardText } from "material-ui/Card";
 import AutoComplete from "material-ui/AutoComplete";
 import SelectField from "material-ui/SelectField";
 import TextField from "material-ui/TextField";
-import IconButton from "material-ui/IconButton";
-import UpdateIcon from "material-ui/svg-icons/action/update";
 import MenuItem from "material-ui/MenuItem";
 import theme from "../styles/theme";
 import { dataSourceItem } from "./utils";
@@ -75,24 +73,14 @@ export const TEXTER_FILTERS = [
 const IDLE_KEY_TIME = 500;
 
 class IncomingMessageFilter extends Component {
-  constructor(props) {
-    super(props);
+  state = {
+    firstName: undefined,
+    lastName: undefined
+  };
 
-    this.state = {
-      firstName: undefined,
-      lastName: undefined
-    };
+  submitNameUpdateTimeout = undefined;
 
-    this.onMessageFilterSelectChanged = this.onMessageFilterSelectChanged.bind(
-      this
-    );
-    this.onTexterSelected = this.onTexterSelected.bind(this);
-    this.onCampaignSelected = this.onCampaignSelected.bind(this);
-
-    this.submitNameUpdateTimeout = undefined;
-  }
-
-  onMessageFilterSelectChanged(event, index, values) {
+  onMessageFilterSelectChanged = (event, index, values) => {
     this.setState({ messageFilter: values });
     const messageStatuses = new Set();
     values.forEach(value => {
@@ -106,9 +94,9 @@ class IncomingMessageFilter extends Component {
 
     const messageStatusesString = Array.from(messageStatuses).join(",");
     this.props.onMessageFilterChanged(messageStatusesString);
-  }
+  };
 
-  onCampaignSelected(selection, index) {
+  onCampaignSelected = (selection, index) => {
     let campaignId = undefined;
     if (index === -1) {
       const campaign = this.props.texters.find(campaign => {
@@ -123,9 +111,9 @@ class IncomingMessageFilter extends Component {
     if (campaignId) {
       this.props.onCampaignChanged(parseInt(campaignId, 10));
     }
-  }
+  };
 
-  onTexterSelected(selection, index) {
+  onTexterSelected = (selection, index) => {
     let texterUserId = undefined;
     if (index === -1) {
       const texter = this.props.texters.find(texter => {
@@ -140,7 +128,7 @@ class IncomingMessageFilter extends Component {
     if (texterUserId) {
       this.props.onTexterChanged(parseInt(texterUserId, 10));
     }
-  }
+  };
 
   onContactNameChanged = ev => {
     const name = ev.target.value;

--- a/src/server/api/lib/apollo.js
+++ b/src/server/api/lib/apollo.js
@@ -1,0 +1,20 @@
+export const nodeHasQueryPath = (node, path) => {
+  const pathComponents = path.split(".");
+  const searchName = pathComponents.shift();
+
+  if (node.name.value !== searchName) return false;
+
+  if (pathComponents.length === 0) return true;
+
+  // Can we traverse further?
+  if (!node.selectionSet.selections) return false;
+  const { selections } = node.selectionSet;
+  const nextNode = selections.find(s => s.name.value === pathComponents[0]);
+  if (!nextNode) return false;
+
+  const nextPath = pathComponents.join(".");
+  return nodeHasQueryPath(nextNode, nextPath);
+};
+
+export const infoHasQueryPath = (info, path, fieldIndex = 0) =>
+  nodeHasQueryPath(info.fieldNodes[fieldIndex], path);

--- a/src/server/api/lib/pagination.js
+++ b/src/server/api/lib/pagination.js
@@ -2,6 +2,7 @@ const encode = value => Buffer.from(`${value}`).toString("base64");
 const decode = value => Buffer.from(value, "base64").toString();
 
 const defaultOptions = {
+  primaryColumn: "id",
   nodeTransformer: node => node
 };
 
@@ -12,11 +13,13 @@ const defaultOptions = {
  * @param {Object} options Options for creating the page
  * @param {Cursor} [options.after] The cursor to begin the query at
  * @param {number} [options.first] How many results to return in the page
+ * @param {number} [options.primaryColumn] The name of the primary ID column.
+ * The needs to be passed if query is a join.
  * @param {Function} [options.nodeTransformer] Transformation to turn a record into a node.
  * This could be used for destructuring results of a join query.
  */
 export const formatPage = async (query, options) => {
-  const { after, first, nodeTransformer } = Object.assign(
+  const { after, first, primaryColumn, nodeTransformer } = Object.assign(
     {},
     defaultOptions,
     options
@@ -25,14 +28,14 @@ export const formatPage = async (query, options) => {
 
   if (after) {
     const afterId = decode(after);
-    query.where("id", ">", afterId);
+    query.where(primaryColumn, ">", afterId);
   }
 
   if (first) {
     query.limit(first + 1);
   }
 
-  query.orderBy("id");
+  query.orderBy(primaryColumn);
 
   const [{ count: totalCount }] = await countQuery.count();
   const results = await query;


### PR DESCRIPTION
## Description

Switch to using the new cursor-based pagination to fetch users from the Message Review page.

## Motivation and Context

This query was timing out with offset/limit based pagination for large datasets.

## How Has This Been Tested?

I have tested this change locally

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
