### PR TITLE
feat: default texter approval status

### DIFF
--- a/migrations/20200327130102_enforce_one_role_per_org.js
+++ b/migrations/20200327130102_enforce_one_role_per_org.js
@@ -1,0 +1,11 @@
+exports.up = function(knex) {
+  return knex.schema.alterTable("user_organization", table => {
+    table.unique(["user_id", "organization_id"]);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable("user_organization", table => {
+    table.dropUnique(["user_id", "organization_id"]);
+  });
+};

--- a/src/api/organization-settings.js
+++ b/src/api/organization-settings.js
@@ -1,0 +1,14 @@
+export const schema = `
+  input OrganizationSettingsInput {
+    defaulTexterApprovalStatus: RequestAutoApprove
+    optOutMessage: String
+    numbersApiKey: String
+  }
+
+  type OranizationSettings {
+    id: ID!
+    defaulTexterApprovalStatus: RequestAutoApprove!
+    optOutMessage: String
+    numbersApiKey: String
+  }
+`;

--- a/src/api/organization.js
+++ b/src/api/organization.js
@@ -45,6 +45,7 @@ export const schema = `
     linkDomains: [LinkDomain]!
     unhealthyLinkDomains: [UnhealthyLinkDomain]!
     numbersApiKey: String
+    settings: OranizationSettings!
     tagList: [Tag]
     escalationTagList: [Tag]
     teams: [Team]!

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -241,7 +241,7 @@ const rootSchema = `
     exportCampaign(id:String!): JobRequest
     createCannedResponse(cannedResponse:CannedResponseInput!): CannedResponse
     createOrganization(name: String!, userId: String!, inviteId: String!): Organization
-    joinOrganization(organizationUuid: String!): Organization
+    joinOrganization(organizationUuid: String!): Organization!
     editOrganizationMembership(id: String!, level: RequestAutoApprove, role: String): OrganizationMembership!
     editUser(organizationId: String!, userId: Int!, userData:UserInput): User
     resetUserPassword(organizationId: String!, userId: Int!): String!

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -1,6 +1,7 @@
 import { schema as userSchema } from "./user";
 import { schema as conversationSchema } from "./conversations";
 import { schema as organizationSchema } from "./organization";
+import { schema as organizationSettingsSchema } from "./organization-settings";
 import { schema as campaignSchema } from "./campaign";
 import { schema as assignmentSchema } from "./assignment";
 import { schema as interactionStepSchema } from "./interaction-step";
@@ -243,6 +244,7 @@ const rootSchema = `
     createOrganization(name: String!, userId: String!, inviteId: String!): Organization
     joinOrganization(organizationUuid: String!): Organization!
     editOrganizationMembership(id: String!, level: RequestAutoApprove, role: String): OrganizationMembership!
+    editOrganizationSettings(id: String!, input: OrganizationSettingsInput!): OranizationSettings!
     editUser(organizationId: String!, userId: Int!, userData:UserInput): User
     resetUserPassword(organizationId: String!, userId: Int!): String!
     changeUserPassword(userId: Int!, formData: UserPasswordChange): User
@@ -311,6 +313,7 @@ export const schema = [
   "scalar Date",
   "scalar JSON",
   "scalar Phone",
+  organizationSettingsSchema,
   membershipSchema,
   campaignSchema,
   assignmentSchema,

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -242,7 +242,6 @@ const rootSchema = `
     createCannedResponse(cannedResponse:CannedResponseInput!): CannedResponse
     createOrganization(name: String!, userId: String!, inviteId: String!): Organization
     joinOrganization(organizationUuid: String!): Organization
-    editOrganizationRoles(organizationId: String!, userId: String!, campaignId: String, roles: [String]): Organization
     editOrganizationMembership(id: String!, level: RequestAutoApprove, role: String): OrganizationMembership!
     editUser(organizationId: String!, userId: Int!, userData:UserInput): User
     resetUserPassword(organizationId: String!, userId: Int!): String!

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -251,7 +251,6 @@ const rootSchema = `
     updateTextingHours( organizationId: String!, textingHoursStart: Int!, textingHoursEnd: Int!): Organization
     updateTextingHoursEnforcement( organizationId: String!, textingHoursEnforced: Boolean!): Organization
     updateTextRequestFormSettings(organizationId: String!, textRequestFormEnabled: Boolean!, textRequestType: String!, textRequestMaxCount: Int!): Organization
-    updateOptOutMessage( organizationId: String!, optOutMessage: String!): Organization
     bulkSendMessages(assignmentId: Int!): [CampaignContact]
     sendMessage(message:MessageInput!, campaignContactId:String!): CampaignContact,
     tagConversation(campaignContactId: String!, tag: ContactTagActionInput!): CampaignContact
@@ -284,7 +283,6 @@ const rootSchema = `
     deleteCampaignOverlap(organizationId: String!, campaignId: String!, overlappingCampaignId: String!): DeleteCampaignOverlapResult!
     deleteManyCampaignOverlap(organizationId: String!, campaignId: String!, overlappingCampaignIds: [String]!): Int!
     resolveAssignmentRequest(assignmentRequestId: String!, approved: Boolean!, autoApproveLevel: RequestAutoApprove): Int!
-    setNumbersApiKey(organizationId: String!, numbersApiKey: String): Organization!
     saveTag(organizationId: String!, tag: TagInput!): Tag!
     deleteTag(organizationId: String!, tagId: String!): Boolean!
     saveTeams(organizationId: String!, teams: [TeamInput]!): [Team]!

--- a/src/containers/AdminPersonList.jsx
+++ b/src/containers/AdminPersonList.jsx
@@ -21,6 +21,7 @@ import {
   RequestAutoApproveType
 } from "../api/organization-membership";
 import { dataTest } from "../lib/attributes";
+import { snakeToTitleCase } from "../lib/attributes";
 import { loadData } from "./hoc/with-operations";
 import theme from "../styles/theme";
 import UserEdit from "./UserEdit";
@@ -28,14 +29,6 @@ import Empty from "../components/Empty";
 import OrganizationJoinLink from "../components/OrganizationJoinLink";
 import PasswordResetLink from "../components/PasswordResetLink";
 import LoadingIndicator from "../components/LoadingIndicator";
-
-const titleCase = value =>
-  `${value.charAt(0).toUpperCase()}${value.substring(1).toLowerCase()}`;
-const snakeToTitleCase = value =>
-  value
-    .split("_")
-    .map(s => titleCase(s))
-    .join(" ");
 
 class AdminPersonList extends React.Component {
   state = {

--- a/src/containers/AdminPersonList.jsx
+++ b/src/containers/AdminPersonList.jsx
@@ -15,8 +15,11 @@ import Snackbar from "material-ui/Snackbar";
 import PeopleIcon from "material-ui/svg-icons/social/people";
 import ContentAdd from "material-ui/svg-icons/content/add";
 
-import { getHighestRole, ROLE_HIERARCHY, hasRole } from "../lib/permissions";
-import { RequestAutoApproveType } from "../api/organization-membership";
+import { hasRoleAtLeast } from "../lib/permissions";
+import {
+  UserRoleType,
+  RequestAutoApproveType
+} from "../api/organization-membership";
 import { dataTest } from "../lib/attributes";
 import { loadData } from "./hoc/with-operations";
 import theme from "../styles/theme";
@@ -66,12 +69,19 @@ class AdminPersonList extends React.Component {
 
   handleDismissSaveError = () => this.setState({ saveError: undefined });
 
-  handleChange = async (userId, value) => {
-    await this.props.mutations.editOrganizationRoles(
-      this.props.match.params.organizationId,
-      userId,
-      [value]
-    );
+  handleRoleChange = membershipId => async (_event, _index, role) => {
+    const { editOrganizationMembership } = this.props.mutations;
+    this.setState({ isWorking: true, saveError: undefined });
+    try {
+      const response = await editOrganizationMembership(membershipId, { role });
+      if (response.errors) throw response.errors;
+    } catch (err) {
+      this.setState({
+        saveError: `Couldn't update user role: ${err.message}`
+      });
+    } finally {
+      this.setState({ isWorking: false });
+    }
   };
 
   handleOnChangeAutoApprovalLevel = membershipId => async (
@@ -185,25 +195,25 @@ class AdminPersonList extends React.Component {
               <TableRowColumn>{person.email}</TableRowColumn>
               <TableRowColumn>
                 <DropDownMenu
-                  value={getHighestRole(person.roles)}
+                  value={person.memberships.edges[0].node.role}
                   disabled={
                     person.id === currentUser.id ||
-                    (getHighestRole(person.roles) === "OWNER" &&
-                      getHighestRole(currentUser.roles) !== "OWNER")
+                    (person.memberships.edges[0].node.role === "OWNER" &&
+                      currentUser.memberships.edges[0].node.role !== "OWNER")
                   }
-                  onChange={(event, index, value) =>
-                    this.handleChange(person.id, value)
-                  }
+                  onChange={this.handleRoleChange(
+                    person.memberships.edges[0].node.id
+                  )}
                 >
-                  {ROLE_HIERARCHY.map(option => (
+                  {Object.keys(UserRoleType).map(option => (
                     <MenuItem
-                      key={person.id + "_" + option}
+                      key={`${person.id}_${option}`}
                       value={option}
                       disabled={
                         option === "OWNER" &&
-                        getHighestRole(currentUser.roles) !== "OWNER"
+                        currentUser.memberships.edges[0].node.role !== "OWNER"
                       }
-                      primaryText={titleCase(option)}
+                      primaryText={snakeToTitleCase(option)}
                     />
                   ))}
                 </DropDownMenu>
@@ -211,7 +221,12 @@ class AdminPersonList extends React.Component {
               <TableRowColumn>
                 <DropDownMenu
                   value={person.memberships.edges[0].node.requestAutoApprove}
-                  disabled={!hasRole("ADMIN", currentUser.roles)}
+                  disabled={
+                    !hasRoleAtLeast(
+                      currentUser.memberships.edges[0].node.role,
+                      "ADMIN"
+                    )
+                  }
                   onChange={this.handleOnChangeAutoApprovalLevel(
                     person.memberships.edges[0].node.id
                   )}
@@ -339,7 +354,7 @@ class AdminPersonList extends React.Component {
 
 AdminPersonList.propTypes = {
   mutations: PropTypes.shape({
-    editOrganizationRoles: PropTypes.func.isRequired,
+    editOrganizationMembership: PropTypes.func.isRequired,
     resetUserPassword: PropTypes.func.isRequired
   }).isRequired,
   personData: PropTypes.object.isRequired,
@@ -358,11 +373,11 @@ const organizationFragment = `
     id
     displayName
     email
-    roles(organizationId: $organizationId)
     memberships(organizationId: $organizationId) {
       edges {
         node {
           id
+          role
           requestAutoApprove
         }
       }
@@ -371,25 +386,6 @@ const organizationFragment = `
 `;
 
 const mutations = {
-  editOrganizationRoles: ownProps => (organizationId, userId, roles) => ({
-    mutation: gql`
-      mutation editOrganizationRoles($organizationId: String!, $userId: String!, $roles: [String], $campaignId: String, $offset: Int) {
-        editOrganizationRoles(organizationId: $organizationId, userId: $userId, roles: $roles, campaignId: $campaignId) {
-          ${organizationFragment}
-        }
-      }
-    `,
-    variables: {
-      organizationId,
-      userId,
-      roles,
-      campaignId: queryString.parse(ownProps.location.search).campaignId,
-      offset:
-        queryString.parse(ownProps.location.search).offset !== undefined
-          ? queryString.parse(ownProps.location.search).offset * 200
-          : 0
-    }
-  }),
   editOrganizationMembership: ownProps => (
     membershipId,
     { level = null, role = null }
@@ -454,7 +450,14 @@ const queries = {
       query getCurrentUserAndRoles($organizationId: String!) {
         currentUser {
           id
-          roles(organizationId: $organizationId)
+          memberships(organizationId: $organizationId) {
+            edges {
+              node {
+                id
+                role
+              }
+            }
+          }
         }
       }
     `,

--- a/src/containers/Settings/components/General.jsx
+++ b/src/containers/Settings/components/General.jsx
@@ -15,6 +15,7 @@ import MenuItem from "material-ui/MenuItem";
 import { StyleSheet, css } from "aphrodite";
 
 import { loadData } from "../../hoc/with-operations";
+import { snakeToTitleCase } from "../../../lib/attributes";
 import { RequestAutoApproveType } from "../../../api/organization-membership";
 import GSForm from "../../../components/forms/GSForm";
 import GSSubmitButton from "../../../components/forms/GSSubmitButton";
@@ -224,7 +225,11 @@ class Settings extends React.Component {
               onChange={this.handleChangeApprovalLevel}
             >
               {Object.keys(RequestAutoApproveType).map(level => (
-                <MenuItem key={level} value={level} primaryText={level} />
+                <MenuItem
+                  key={level}
+                  value={level}
+                  primaryText={snakeToTitleCase(level)}
+                />
               ))}
             </DropDownMenu>
           </CardText>

--- a/src/containers/Settings/components/General.jsx
+++ b/src/containers/Settings/components/General.jsx
@@ -95,34 +95,7 @@ class Settings extends React.Component {
       textingHoursEnd: yup.number().required()
     });
 
-    const hours = [
-      0,
-      1,
-      2,
-      3,
-      4,
-      5,
-      6,
-      7,
-      8,
-      9,
-      10,
-      11,
-      12,
-      13,
-      14,
-      15,
-      16,
-      17,
-      18,
-      19,
-      20,
-      21,
-      22,
-      23,
-      24
-    ];
-    const hourChoices = hours.map(hour => ({
+    const hourChoices = [...Array(25).keys()].map(hour => ({
       value: hour,
       label: formatTextingHours(hour)
     }));

--- a/src/containers/Settings/components/General.jsx
+++ b/src/containers/Settings/components/General.jsx
@@ -68,8 +68,8 @@ class Settings extends React.Component {
     try {
       const response = await this.props.mutations.editSettings(input);
       if (response.errors) throw response.errors;
+      success = true;
     } catch (err) {
-      success = false;
       const message = `Error saving ${name}: ${err.message}`;
       this.setState({ error: message });
     } finally {

--- a/src/lib/attributes.js
+++ b/src/lib/attributes.js
@@ -15,6 +15,15 @@ export const camelCase = str => {
     .replace(/\s+/g, "");
 };
 
+export const titleCase = value =>
+  `${value.charAt(0).toUpperCase()}${value.substring(1).toLowerCase()}`;
+
+export const snakeToTitleCase = value =>
+  value
+    .split("_")
+    .map(s => titleCase(s))
+    .join(" ");
+
 export const nameComponents = name => {
   let firstName = undefined;
   let lastName = undefined;

--- a/src/server/api/organization-settings.js
+++ b/src/server/api/organization-settings.js
@@ -1,0 +1,72 @@
+import { r } from "../models";
+import { config } from "../../config";
+import { RequestAutoApproveType } from "../../api/organization-membership";
+
+const SETTINGS_NAMES = {
+  optOutMessage: "opt_out_message"
+};
+
+const SETTINGS_DEFAULTS = {
+  defaulTexterApprovalStatus: RequestAutoApproveType.APPROVAL_REQUIRED,
+  optOutMessage:
+    config.OPT_OUT_MESSAGE ||
+    "I'm opting you out of texts immediately. Have a great day."
+};
+
+const SETTINGS_TRANSFORMERS = {
+  numbersApiKey: value => value.slice(0, 4) + "****************"
+};
+
+const getOrgFeature = (featureName, rawFeatures = "{}") => {
+  const defaultValue = SETTINGS_DEFAULTS[featureName];
+  featureName = SETTINGS_NAMES[featureName] || featureName;
+  try {
+    const features = JSON.parse(rawFeatures);
+    const value = features[featureName] || defaultValue || null;
+    if (SETTINGS_TRANSFORMERS[featureName] && value) {
+      return SETTINGS_TRANSFORMERS[featureName](value);
+    }
+    return value;
+  } catch (_err) {
+    return SETTINGS_DEFAULTS[featureName] || null;
+  }
+};
+
+const settingResolvers = settingNames =>
+  settingNames.reduce((accumulator, settingName) => {
+    const resolver = ({ features }) => getOrgFeature(settingName, features);
+    return Object.assign(accumulator, { [settingName]: resolver });
+  }, {});
+
+export const resolvers = {
+  OranizationSettings: {
+    id: organization => organization.id,
+    ...settingResolvers([
+      "defaulTexterApprovalStatus",
+      "optOutMessage",
+      "numbersApiKey"
+    ])
+  }
+};
+
+export const updateOrganizationSettings = async (id, input) => {
+  const currentFeatures = await r
+    .knex("organization")
+    .where({ id })
+    .first("features")
+    .then(({ features }) => JSON.parse(features))
+    .catch(() => ({}));
+
+  const features = Object.entries(input).reduce((acc, [key, value]) => {
+    key = SETTINGS_NAMES[key] || key;
+    return Object.assign(acc, { [key]: value });
+  }, currentFeatures);
+
+  const [organization] = await r
+    .knex("organization")
+    .where({ id })
+    .update({ features: JSON.stringify(features) })
+    .returning("*");
+
+  return organization;
+};

--- a/src/server/api/organization-settings.js
+++ b/src/server/api/organization-settings.js
@@ -1,4 +1,5 @@
 import { r } from "../models";
+import { organizationCache } from "../models/cacheable_queries/organization";
 import { config } from "../../config";
 import { RequestAutoApproveType } from "../../api/organization-membership";
 

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -35,6 +35,7 @@ export const getEscalationUserId = async organizationId => {
 export const resolvers = {
   Organization: {
     ...sqlResolvers(["id", "name"]),
+    settings: organization => organization,
     campaigns: async (organization, { cursor, campaignsFilter }, { user }) => {
       await accessRequired(user, organization.id, "SUPERVOLUNTEER");
       return getCampaigns(organization.id, cursor, campaignsFilter);

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -10,7 +10,6 @@ import isUrl from "is-url";
 import request from "superagent";
 import _ from "lodash";
 import moment from "moment-timezone";
-import { organizationCache } from "../models/cacheable_queries/organization";
 
 import { getWorker } from "../worker";
 import { processContactsFile } from "./lib/edit-campaign";

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -64,6 +64,7 @@ import {
   getEscalationUserId
 } from "./organization";
 import { resolvers as membershipSchema } from "./organization-membership";
+import { RequestAutoApproveType } from "../../api/organization-membership";
 import { GraphQLPhone } from "./phone";
 import { resolvers as questionResolvers } from "./question";
 import { resolvers as questionResponseResolvers } from "./question-response";
@@ -1499,7 +1500,10 @@ const rootMutations = {
       const { payload = {} } = invite;
 
       const newOrganization = await r.knex.transaction(async trx => {
-        const orgFeatures = {};
+        const defaultStatus = RequestAutoApproveType.APPROVAL_REQUIRED;
+        const orgFeatures = {
+          defaulTexterApprovalStatus: defaultStatus.toLowerCase()
+        };
         if (payload.org_features) {
           const { switchboard_lrn_api_key } = payload.org_features;
           if (switchboard_lrn_api_key) {

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -65,6 +65,10 @@ import {
 } from "./organization";
 import { resolvers as membershipSchema } from "./organization-membership";
 import { RequestAutoApproveType } from "../../api/organization-membership";
+import {
+  resolvers as settingsSchema,
+  updateOrganizationSettings
+} from "./organization-settings";
 import { GraphQLPhone } from "./phone";
 import { resolvers as questionResolvers } from "./question";
 import { resolvers as questionResponseResolvers } from "./question-response";
@@ -808,6 +812,16 @@ const rootMutations = {
       });
 
       return orgMembership;
+    },
+
+    editOrganizationSettings: async (_, { id, input }, { user: authUser }) => {
+      const organizationId = parseInt(id);
+      await accessRequired(authUser, organizationId, "OWNER");
+      const updatedOrganization = await updateOrganizationSettings(
+        organizationId,
+        input
+      );
+      return updatedOrganization;
     },
 
     editUser: async (_, { organizationId, userId, userData }, { user }) => {
@@ -3497,6 +3511,7 @@ export const resolvers = {
   ...rootResolvers,
   ...userResolvers,
   ...membershipSchema,
+  ...settingsSchema,
   ...organizationResolvers,
   ...campaignResolvers,
   ...assignmentResolvers,

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1075,32 +1075,6 @@ const rootMutations = {
       return await loaders.organization.load(organizationId);
     },
 
-    updateOptOutMessage: async (
-      _,
-      { organizationId, optOutMessage },
-      { user }
-    ) => {
-      await accessRequired(user, organizationId, "OWNER");
-
-      const { features } = await r
-        .knex("organization")
-        .where({ id: organizationId })
-        .first("features");
-      const featuresJSON = JSON.parse(features || "{}");
-      featuresJSON.opt_out_message = optOutMessage;
-
-      await r
-        .knex("organization")
-        .update({ features: JSON.stringify(featuresJSON) })
-        .where({ id: organizationId });
-      await organizationCache.clear(organizationId);
-
-      return await r
-        .knex("organization")
-        .where({ id: organizationId })
-        .first();
-    },
-
     createInvite: async (_, { user }) => {
       if ((user && user.is_superadmin) || !config.SUPPRESS_SELF_INVITE) {
         const [newInvite] = await r
@@ -2900,36 +2874,6 @@ const rootMutations = {
       });
 
       return numberAssigned;
-    },
-    setNumbersApiKey: async (
-      _,
-      { organizationId, numbersApiKey },
-      { user }
-    ) => {
-      await accessRequired(user, organizationId, "OWNER");
-
-      // User probably made a mistake - no API key will have a *
-      if (numbersApiKey && numbersApiKey.includes("*")) {
-        throw new Error("Numbers API Key cannot have character: *");
-      }
-
-      const { features } = await r
-        .knex("organization")
-        .where({ id: organizationId })
-        .first("features");
-      const featuresJSON = JSON.parse(features || "{}");
-      featuresJSON.numbersApiKey = numbersApiKey;
-
-      await r
-        .knex("organization")
-        .update({ features: JSON.stringify(featuresJSON) })
-        .where({ id: organizationId });
-      await organizationCache.clear(organizationId);
-
-      return await r
-        .knex("organization")
-        .where({ id: organizationId })
-        .first();
     },
     saveTag: async (_, { organizationId, tag }, { user }) => {
       await accessRequired(user, organizationId, "ADMIN");


### PR DESCRIPTION
## Description

Adds editable `defaulTexterApprovalStatus` to organization features. Use this value as the default for new organization memberships.

## Motivation and Context

If an organization wants to default all texters to a status other than `approval_required` they must edit every new user manually via #610. That could be a lot of overhead.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<table border="1"><tr><td>

<img width="1424" alt="Spoke" src="https://user-images.githubusercontent.com/2145526/77824526-c5627680-70d9-11ea-9b7c-9fdf8b3d014b.png">

</td></tr></table>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

The "Assignment control" draft topic has been edited to document this new setting.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] My change requires a change to the documentation.
- [x] I have included updates for the documentation accordingly.
