### PR TITLE
improvement(trollbot): completely hide trollbot UI if disabled

### DIFF
--- a/src/containers/Settings/components/TrollTokenSettings.jsx
+++ b/src/containers/Settings/components/TrollTokenSettings.jsx
@@ -70,6 +70,7 @@ class TrollTokenSettings extends React.Component {
 
   render() {
     const { addToken, deleteToken, isWorking, error } = this.state;
+    const { isActive } = this.props;
     const { trollTokens } = this.props.trollTokens;
     const sortedTokens = sortBy(trollTokens, "token");
 
@@ -132,13 +133,15 @@ class TrollTokenSettings extends React.Component {
             </TableBody>
           </Table>
         )}
-        <FloatingActionButton
-          style={theme.components.floatingButton}
-          disabled={isWorking}
-          onClick={this.handleAddToken}
-        >
-          <ContentAddIcon />
-        </FloatingActionButton>
+        {isActive && (
+          <FloatingActionButton
+            style={theme.components.floatingButton}
+            disabled={isWorking}
+            onClick={this.handleAddToken}
+          >
+            <ContentAddIcon />
+          </FloatingActionButton>
+        )}
         <Dialog
           title="Add Trigger Token"
           actions={addActions}
@@ -175,6 +178,7 @@ class TrollTokenSettings extends React.Component {
 
 TrollTokenSettings.propTypes = {
   match: PropTypes.object.isRequired,
+  isActive: PropTypes.bool.isRequired,
   trollTokens: PropTypes.shape({
     trollTokens: PropTypes.arrayOf(
       PropTypes.shape({

--- a/src/containers/Settings/index.jsx
+++ b/src/containers/Settings/index.jsx
@@ -21,13 +21,15 @@ export const SettingsRouter = props => {
         <br />
         <General match={match} />
       </Tab>
-      <Tab
-        icon={<AlarmIcon />}
-        label="TrollBot Trigger Tokens"
-        value={"trolltokens"}
-      >
-        <TrollTokenSettings match={match} />
-      </Tab>
+      {window.ENABLE_TROLLBOT && (
+        <Tab
+          icon={<AlarmIcon />}
+          label="TrollBot Trigger Tokens"
+          value={"trolltokens"}
+        >
+          <TrollTokenSettings match={match} isActive={page === "trolltokens"} />
+        </Tab>
+      )}
     </Tabs>
   );
 };


### PR DESCRIPTION
## Description

This completely hides TrollBot UI if the feature is not enabled. It also hides the floating action button when not on the TrollBot tab.

## Motivation and Context

The TrollBot tab in Settings was previously visible regardless of the `ENABLE_TROLLBOT ` envvar.

The "add trigger token" FAB escaped the active tab and would display on the General tab.

## How Has This Been Tested?

These changes have been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
