### PR TITLE
chore: limit shutdown grace period in development

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -571,7 +571,8 @@ if (isClient()) {
     SHUTDOWN_GRACE_PERIOD: num({
       desc:
         "How long to wait after receiving kill signal before tearing down. Useful for waiting for readiness probe period.",
-      default: 5000
+      default: 5000,
+      devDefault: 10
     }),
     SLACK_TEAM_NAME: str({
       desc: "The name of the Slack team to use for sign-in.",


### PR DESCRIPTION
## Description

Go (nearly) straight to teardown in development environment by default.

## Motivation and Context

There's no need to wait for current express requests to complete before tearing down in a development environment.

## How Has This Been Tested?

Running locally with different values for `NODE_ENV` gives the desired shutdown behavior for each value.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
