### PR TITLE
fix: show all canned response text

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "@babel/runtime-corejs3": "^7.9.2",
     "@commitlint/cli": "^8.3.5",
     "@commitlint/config-conventional": "^8.3.4",
+    "@types/material-ui": "^0.21.7",
     "@types/react": "^16.9.27",
     "@types/react-dom": "^16.9.5",
     "babel-core": "^7.0.0-bridge.0",

--- a/src/components/LargeList.tsx
+++ b/src/components/LargeList.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+
+import { grey900, grey600 } from "material-ui/styles/colors";
+
+const largeListStyle: React.CSSProperties = {
+  listStyleType: "none",
+  margin: 0,
+  padding: 0
+};
+
+export const LargeList: React.SFC = props => {
+  return <ul style={largeListStyle}>{props.children}</ul>;
+};
+
+const largeListItemStyles: { [key: string]: React.CSSProperties } = {
+  flexContainer: {
+    display: "flex",
+    alignItems: "center"
+  },
+  textWrapper: {
+    flexGrow: 1
+  },
+  actionWrapper: {
+    flexGrow: 0
+  },
+  primaryText: {
+    margin: "10px 0 0 0",
+    padding: 0,
+    fontFamily: "Poppins",
+    fontSize: "16px",
+    color: grey900
+  },
+  secondaryText: {
+    margin: "5px 0 0 0",
+    padding: 0,
+    fontFamily: "Poppins",
+    fontSize: "14px",
+    color: grey600
+  }
+};
+
+export interface LargeListItemProps {
+  primaryText?: string;
+  secondaryText?: string;
+  rightIconButton?: React.ReactNode;
+}
+
+export const LargeListItem: React.SFC<LargeListItemProps> = props => {
+  const { primaryText, secondaryText, rightIconButton } = props;
+
+  return (
+    <li style={largeListItemStyles.flexContainer}>
+      <div style={largeListItemStyles.textWrapper}>
+        {primaryText && (
+          <p style={largeListItemStyles.primaryText}>{primaryText}</p>
+        )}
+        {secondaryText && (
+          <p style={largeListItemStyles.secondaryText}>{secondaryText}</p>
+        )}
+      </div>
+      {rightIconButton && (
+        <div style={largeListItemStyles.actionWrapper}>{rightIconButton}</div>
+      )}
+    </li>
+  );
+};

--- a/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm.jsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm.jsx
@@ -4,9 +4,7 @@ import * as yup from "yup";
 import Form from "react-formal";
 import { StyleSheet, css } from "aphrodite";
 
-import { List, ListItem } from "material-ui/List";
 import FlatButton from "material-ui/FlatButton";
-import Divider from "material-ui/Divider";
 import IconButton from "material-ui/IconButton";
 import CreateIcon from "material-ui/svg-icons/content/create";
 import DeleteIcon from "material-ui/svg-icons/action/delete";
@@ -14,6 +12,7 @@ import DeleteIcon from "material-ui/svg-icons/action/delete";
 import { dataTest } from "../../../lib/attributes";
 import theme from "../../../styles/theme";
 import GSForm from "../../../components/forms/GSForm";
+import { LargeList, LargeListItem } from "../../../components/LargeList";
 import CampaignCannedResponseForm from "./CampaignCannedResponseForm";
 import CampaignFormSectionHeading from "../components/CampaignFormSectionHeading";
 
@@ -87,9 +86,8 @@ export default class CampaignCannedResponsesForm extends React.Component {
 
   listItems(cannedResponses) {
     const listItems = cannedResponses.map(response => (
-      <ListItem
+      <LargeListItem
         {...dataTest("cannedResponse")}
-        value={response.text}
         key={response.id}
         primaryText={response.title}
         secondaryText={response.text}
@@ -113,7 +111,6 @@ export default class CampaignCannedResponsesForm extends React.Component {
             <DeleteIcon />
           </IconButton>
         }
-        secondaryTextLines={2}
       />
     ));
     return listItems;
@@ -124,10 +121,7 @@ export default class CampaignCannedResponsesForm extends React.Component {
     const cannedResponses = formValues.cannedResponses;
     const list =
       cannedResponses.length === 0 ? null : (
-        <List>
-          {this.listItems(cannedResponses)}
-          <Divider />
-        </List>
+        <LargeList>{this.listItems(cannedResponses)}</LargeList>
       );
 
     return (
@@ -142,6 +136,7 @@ export default class CampaignCannedResponsesForm extends React.Component {
           subtitle="Save some scripts for your texters to use to answer additional FAQs that may come up outside of the survey questions and scripts you already set up."
         />
         {list}
+        <hr />
         {this.showAddForm()}
         <Form.Button
           type="submit"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1573,6 +1573,14 @@
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
   integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
 
+"@types/material-ui@^0.21.7":
+  version "0.21.7"
+  resolved "https://registry.yarnpkg.com/@types/material-ui/-/material-ui-0.21.7.tgz#2a4ab77a56a16adef044ba607edde5214151a5d8"
+  integrity sha512-OxGu+Jfm3d8IVYu5w2cqosSFU+8KJYCeVjw1jLZ7DzgoE7KpSFFpbDJKWhV1FAf/HEQXzL1IpX6PmLwINlE4Xg==
+  dependencies:
+    "@types/react" "*"
+    "@types/react-addons-linked-state-mixin" "*"
+
 "@types/mime@*":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
@@ -1632,6 +1640,13 @@
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
+
+"@types/react-addons-linked-state-mixin@*":
+  version "0.14.20"
+  resolved "https://registry.yarnpkg.com/@types/react-addons-linked-state-mixin/-/react-addons-linked-state-mixin-0.14.20.tgz#5f0cd884ace049d538982a3b254f4807b9395eb6"
+  integrity sha512-17M8ymjR/vvyaQnLNuLSQipxtUrxaIq19phbWKKz1drIXeVQx+AnqMVVVIClno/gPheJWcLVCbf+yXXbbRalIg==
+  dependencies:
+    "@types/react" "*"
 
 "@types/react-dom@^16.9.5":
   version "16.9.5"


### PR DESCRIPTION
## Description

Show the complete text of a canned response script.

## Motivation and Context

The current implementation uses ListItem which truncates the test at 2 lines. Copying-and-pasting canned responses between campaigns would be easier if the entire text were visible/selectable without a massively wide screen.

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<table border="1"><tr><td>

![Spoke](https://user-images.githubusercontent.com/2145526/78612057-6b2e8780-7836-11ea-954c-04f2385417e8.png)

</td></tr></table>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
