### PR TITLE
improvement(texter): leave placeholder first name values lowercase

### DIFF
--- a/src/lib/scripts.js
+++ b/src/lib/scripts.js
@@ -28,6 +28,9 @@ const CAPITALIZE_FIELDS = [
   "texterLastName"
 ];
 
+// Special first names that should not be capitalized
+const LOWERCASE_FIRST_NAMES = ["friend", "there"];
+
 // TODO: This will include zipCode even if you ddin't upload it
 export const allScriptFields = customFields =>
   TOP_LEVEL_UPLOAD_FIELDS.concat(TEXTER_SCRIPT_FIELDS).concat(customFields);
@@ -50,7 +53,11 @@ const getScriptFieldValue = (contact, texter, fieldName) => {
     result = customFieldNames[fieldName];
   }
 
-  if (CAPITALIZE_FIELDS.indexOf(fieldName) >= 0) {
+  const isCapitalizedField = CAPITALIZE_FIELDS.includes(fieldName);
+  const isSpecialFirstName =
+    fieldName === "firstName" &&
+    LOWERCASE_FIRST_NAMES.includes(result.toLowerCase());
+  if (isCapitalizedField && !isSpecialFirstName) {
     result = capitalize(result);
   }
 


### PR DESCRIPTION
## Description

Leave placeholder first name values lowercase.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Placeholder names are often used when the a contact's name is not known. These common placeholder
names should not be capitalized.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This has been tested locally.

## Screenshots (if appropriate):

<table border="1"><tr><td>

![Spoke](https://user-images.githubusercontent.com/2145526/78612918-7bdffd00-7838-11ea-945f-21b473f2d080.png)

</td></tr></table>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

The [Contact lists](https://docs.spokerewired.com/article/64-contact-lists) article has been updated to include a note about the capitalization behavior.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] My change requires a change to the documentation.
- [x] I have included updates for the documentation accordingly.
