### PR TITLE
fix(trollbot): escape trigger tokens

### DIFF
--- a/src/workers/cron/catch-troll-alarms.js
+++ b/src/workers/cron/catch-troll-alarms.js
@@ -14,7 +14,7 @@ const main = async () => {
   const { rows: newAlarms } = await db.raw(`
     with
       trigger_query as (
-        select to_tsquery(array_to_string(array_agg(token), ' | ')) as query
+        select to_tsquery(string_agg($$token$$, ' | ')) as query
         from troll_trigger
       ),
       trigger_matches as (


### PR DESCRIPTION
## Description

Escape trigger tokens when building the tsquery.

## Motivation and Context

Triggers containing single quotes (ex. `c'mon`) would cause a syntax error to be thrown.

## How Has This Been Tested?

I have verified that the new query generates the same tsquery result without breaking on single quotes.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
