### PR TITLE
fix: fix flexbox height calculation in Safari

### DIFF
--- a/src/components/Empty.jsx
+++ b/src/components/Empty.jsx
@@ -44,8 +44,8 @@ const styles = StyleSheet.create({
   }
 });
 
-const Empty = ({ title, icon, content }) => (
-  <div className={css(styles.container)} {...dataTest("empty")}>
+const Empty = ({ title, icon, content, style = {} }) => (
+  <div className={css(styles.container)} style={style} {...dataTest("empty")}>
     <div className={css(styles.paddingBlock)} />
     <div className={css(styles.iconWrapper)}>
       {React.cloneElement(icon, { style: inlineStyles.icon })}

--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -75,14 +75,10 @@ const styles = StyleSheet.create({
   },
   dynamicFlexSection: {
     flex: "1 1 0",
-    position: "relative"
+    display: "flex"
   },
   verticalScrollingSection: {
-    position: "absolute",
-    top: "0",
-    left: "0",
-    bottom: "0",
-    right: "0",
+    flex: "1 1 auto",
     overflowY: "scroll",
     overflow: "-moz-scrollbars-vertical"
   },
@@ -858,6 +854,7 @@ export class AssignmentTexterContact extends React.Component {
               <Empty
                 title={`This is your first message to ${contact.firstName}`}
                 icon={<CreateIcon color="rgb(83, 180, 119)" />}
+                style={{ flex: "1 1 auto" }}
               />
             )}
           </div>


### PR DESCRIPTION
##  Description

This fixes a height calculation issue in Safari.

I think this is because setting the `<TextArea />`'s value was not triggering a layout/repaint. Opening the Elements inspector and toggling a flexbox CSS property off and then back on displays it correctly.

## Motivation and Context

The height calculation issue pushed the send button off the screen.

## How Has This Been Tested?

Extensively in Safari.

## Screenshots (if appropriate):

<table border="1"><tr><th>Safari Mobile</th><th>Safari Desktop</th></tr><tr><td>

<img width="337" alt="Screen Shot 2020-04-09 at 9 13 47 PM" src="https://user-images.githubusercontent.com/2145526/78953858-2c076d00-7aa8-11ea-83cc-73c940c3df38.png">

</td><td>

<img width="697" alt="Screen Shot 2020-04-09 at 9 14 15 PM" src="https://user-images.githubusercontent.com/2145526/78953908-59541b00-7aa8-11ea-82b1-89e88e11135a.png">

</td><tr></table>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
