### PR TITLE
fix: fix permission check

### DIFF
--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1270,15 +1270,7 @@ const rootMutations = {
       // to fail – this fixes it by ensuring its a proper object
       const campaign = Object.assign({}, campaignEdits);
 
-      if (campaign.organizationId) {
-        await accessRequired(user, campaign.organizationId, "ADMIN");
-      } else {
-        await accessRequired(
-          user,
-          origCampaign.organization_id,
-          "SUPERVOLUNTEER"
-        );
-      }
+      await accessRequired(user, origCampaign.organization_id, "ADMIN");
 
       memoizer.invalidate(cacheOpts.CampaignsList.key, {
         organizationId: campaign.organizationId

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -175,15 +175,7 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
     isAutoassignEnabled,
     timezone
   } = campaign;
-  // some changes require ADMIN and we recheck below
-  const organizationId =
-    campaign.organizationId || origCampaignRecord.organization_id;
-  await accessRequired(
-    user,
-    organizationId,
-    "SUPERVOLUNTEER",
-    /* superadmin*/ true
-  );
+  const organizationId = origCampaignRecord.organization_id;
   const campaignUpdates = {
     id,
     title,


### PR DESCRIPTION
## Description

Consolidate permission checks, require `ADMIN` permission across the board, and only ever perform permission check using organization ID from the database record.

## Motivation and Context

Using user-provided values for security verification is a no-no.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

This is part of ongoing updates to User Roles page. See draft.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] My change requires a change to the documentation.
- [x] I have included updates for the documentation accordingly.
