### PR TITLE
build: restore Docker layer caching of node deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,13 @@
+### Dependency Cacher
+### -------------------------
+FROM endeveit/docker-jq:latest as deps
+
+# To prevent cache invalidation from changes in fields other than dependencies
+# https://stackoverflow.com/a/59606373
+COPY package.json /tmp
+RUN jq '{ dependencies, devDependencies }' < /tmp/package.json > /tmp/deps.json
+
+
 ### Fat Build
 ### -------------------------
 FROM node:12.16.1-alpine AS builder
@@ -5,7 +15,8 @@ FROM node:12.16.1-alpine AS builder
 WORKDIR /usr/Spoke
 
 # Cache dependencies
-COPY package.json yarn.lock ./
+COPY --from=deps /tmp/deps.json ./package.json
+COPY yarn.lock ./
 RUN yarn install
 
 # Configure build environment
@@ -31,7 +42,8 @@ FROM node:12.16.1-alpine
 WORKDIR /usr/Spoke
 
 # Install and cache production dependencies
-COPY package.json yarn.lock ./
+COPY --from=deps /tmp/deps.json ./package.json
+COPY yarn.lock ./
 RUN yarn install --production
 
 # Copy only the built source

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM endeveit/docker-jq:latest as deps
 # To prevent cache invalidation from changes in fields other than dependencies
 # https://stackoverflow.com/a/59606373
 COPY package.json /tmp
-RUN jq '{ dependencies, devDependencies }' < /tmp/package.json > /tmp/deps.json
+RUN jq '{ dependencies, devDependencies, resolutions }' < /tmp/package.json > /tmp/deps.json
 
 
 ### Fat Build

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,8 @@ ENV NODE_ENV="production" \
   PHONE_NUMBER_COUNTRY=$PHONE_NUMBER_COUNTRY \
   SPOKE_VERSION=$SPOKE_VERSION
 
+COPY package.json ./
+
 # Run the production compiled code
 EXPOSE 3000
 CMD [ "node", "--no-deprecation", "./build/src/server" ]


### PR DESCRIPTION
## Description

Ensures that non-dependency changes to `package.json` don't invalidate the cached `yarn install` image layers.

## Motivation and Context

Node deps caching should only depend on the `dependencies` and `devDependencies` properties of `package.json`. Prior to this change, bumping the package version would invalidate the `yarn install` layers and require full installs on the next build.

This reduces build time by 40%.

## How Has This Been Tested?

1. Built image -- full installation happened
2. Built image again -- every step, including `yarn install`, cached
3. Changed version in `package.json`
4. Built image -- `yarn install` steps were cached, only the build step ran again

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
