### PR TITLE
enhancement: allow matching slack users by email

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -575,6 +575,16 @@ const validators = {
     desc: "The Slack client secret to use for sign-in.",
     default: undefined
   }),
+  SLACK_SCOPES: str({
+    desc: "Comma separated list Slack scopes to request.",
+    example: "groups:read",
+    default: "identity.basic,identity.email,identity.team"
+  }),
+  SLACK_CONVERT_EXISTING: bool({
+    desc:
+      "When true, Slack authentication will attempt to convert existing non-Slack accounts (with matching emails) to Slack accounts",
+    default: true
+  }),
   SLACK_TOKEN: str({
     desc: "The Slack token to use for the slack-teams-update cron job",
     default: undefined

--- a/src/config.js
+++ b/src/config.js
@@ -566,6 +566,10 @@ const validators = {
     desc: "The name of the Slack team to use for sign-in.",
     default: undefined
   }),
+  SLACK_TEAM_ID: str({
+    desc: "The ID of the Slack team to use for sign-in.",
+    default: undefined
+  }),
   SLACK_CLIENT_ID: str({
     desc: "The Slack client ID to use for sign-in.",
     default: undefined,

--- a/src/server/auth-passport.js
+++ b/src/server/auth-passport.js
@@ -15,6 +15,7 @@ const {
   BASE_URL,
   AUTOJOIN_ORG_UUID,
   SLACK_TEAM_NAME,
+  SLACK_TEAM_ID,
   SLACK_CLIENT_ID,
   SLACK_CLIENT_SECRET,
   SLACK_SCOPES,
@@ -144,7 +145,8 @@ function setupSlackPassport() {
   app.get(
     "/login",
     passport.authenticate("slack", {
-      scope: SLACK_SCOPES.split(",")
+      scope: SLACK_SCOPES.split(","),
+      team: SLACK_TEAM_ID
     })
   );
 


### PR DESCRIPTION
## Description

When `SLACK_CONVERT_EXISTING=true` (default) the Slack login handler will try to find an existing local auth user with a matching email address before creating a new Spoke user altogether.

## Motivation and Context

This allows for transitioning from the local or Auth0 Passport strategy to the Slack Passport strategy.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
