### PR TITLE
Feat: release stale replies

### DIFF
--- a/migrations/20200413115931_add-replies-stale-at.js
+++ b/migrations/20200413115931_add-replies-stale-at.js
@@ -1,0 +1,11 @@
+exports.up = function(knex) {
+  return knex.schema.alterTable("campaign", table => {
+    table.integer("replies_stale_after_minutes");
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable("campaign", table => {
+    table.dropColumn("replies_stale_after_minutes");
+  });
+};

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "express-winston": "^3.1.0",
     "fs": "^0.0.2",
     "google-libphonenumber": "^3.2.6",
+    "graphile-scheduler": "^0.0.1",
     "graphile-worker": "^0.5.0",
     "graphql": "^0.13.2",
     "graphql-date": "^1.0.3",

--- a/src/api/campaign.js
+++ b/src/api/campaign.js
@@ -59,6 +59,7 @@ export const schema = `
     textingHoursStart: Int
     textingHoursEnd: Int
     isAutoassignEnabled: Boolean!
+    repliesStaleAfter: Int
     isAssignmentLimitedToTeams: Boolean!
     timezone: String
     createdAt: Date

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -103,7 +103,7 @@ const rootSchema = `
     textingHoursEnd: Int
     isAutoassignEnabled: Boolean
     timezone: String
-    repliesStaleAt: Int
+    repliesStaleAfter: Int
   }
 
   input MessageInput {

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -103,6 +103,7 @@ const rootSchema = `
     textingHoursEnd: Int
     isAutoassignEnabled: Boolean
     timezone: String
+    repliesStaleAt: Int
   }
 
   input MessageInput {

--- a/src/containers/AdminCampaignEdit/sections/CampaignAutoassignModeForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignAutoassignModeForm.tsx
@@ -46,8 +46,11 @@ class CampaignAutoassignModeForm extends React.Component<
   AutoassignInnerProps,
   AutoassignState
 > {
-  state = {
+  state: AutoassignState = {
     isAutoassignEnabled: undefined,
+
+    // Undefined means there are no client side changes (use props.campaign.repliesStaleAfter)
+    // Null means a database value of null
     repliesStaleAfter: undefined,
     isWorking: false
   };
@@ -145,10 +148,9 @@ class CampaignAutoassignModeForm extends React.Component<
 
         {isAutoReleaseEnabled && (
           <div>
-            <label htmlFor="idle_minutes"> Idle Minutes: </label>
             <TextField
               name="idle_minutes"
-              // label="Idle Minutes"
+              floatingLabelText="Idle Minutes"
               type="number"
               value={repliesStaleAfter!}
               onChange={this.handleReleaseStaleRepliesAfterChange}

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -224,6 +224,7 @@ export const resolvers = {
       "createdAt"
     ]),
     readiness: campaign => campaign,
+    repliesStaleAfter: campaign => campaign.replies_stale_after_minutes,
     useDynamicAssignment: _ => false,
     isAssignmentLimitedToTeams: campaign => campaign.limit_assignment_to_teams,
     dueBy: campaign =>

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -173,7 +173,7 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
     textingHoursStart,
     textingHoursEnd,
     isAutoassignEnabled,
-    repliesStaleAt,
+    repliesStaleAfter,
     timezone
   } = campaign;
 
@@ -192,7 +192,7 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
     texting_hours_start: textingHoursStart,
     texting_hours_end: textingHoursEnd,
     is_autoassign_enabled: isAutoassignEnabled,
-    replies_stale_at: repliesStaleAt, // this is null to unset it - it must be null, not undefined
+    replies_stale_after_minutes: repliesStaleAfter, // this is null to unset it - it must be null, not undefined
     timezone
   };
 

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -173,8 +173,10 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
     textingHoursStart,
     textingHoursEnd,
     isAutoassignEnabled,
+    repliesStaleAt,
     timezone
   } = campaign;
+
   const organizationId = origCampaignRecord.organization_id;
   const campaignUpdates = {
     id,
@@ -190,6 +192,7 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
     texting_hours_start: textingHoursStart,
     texting_hours_end: textingHoursEnd,
     is_autoassign_enabled: isAutoassignEnabled,
+    replies_stale_at: repliesStaleAt, // this is null to unset it - it must be null, not undefined
     timezone
   };
 

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -174,7 +174,9 @@ const teardownKnex = async () => {
 
 const teardownGraphile = async () =>
   getRunner()
-    .then(runner => runner.stop())
+    .then(async rs => {
+      await Promise.all([rs.runner.stop(), rs.scheduler.stop()]);
+    })
     .then(() => logger.info("  - tore down Graphile runner"));
 
 const onSignal = () => {

--- a/src/server/tasks/release-stale-replies.js
+++ b/src/server/tasks/release-stale-replies.js
@@ -1,0 +1,36 @@
+import { r } from "../models";
+import { chunk } from "lodash";
+
+const CONCURRENCY = 2;
+
+export const releaseStaleReplies = async (_payload, _helpers) => {
+  const campaignsToReleaseStaleRepliesFrom = await r
+    .knex("campaign")
+    .whereNotNull("replies_stale_after_minutes")
+    .where({ is_archived: false });
+
+  const batches = chunk(campaignsToReleaseStaleRepliesFrom, CONCURRENCY);
+
+  for (const batch of batches) {
+    await Promise.all(
+      batch.map(c =>
+        releaseStaleRepliesOnCampaign(c.id, c.replies_stale_after_minutes)
+      )
+    );
+  }
+};
+
+const releaseStaleRepliesOnCampaign = async (campaignId, afterStaleMinutes) => {
+  await r
+    .knex("campaign_contact")
+    .update({ assignment_id: null })
+    .where({
+      campaign_id: campaignId,
+      message_status: "needsResponse"
+    })
+    .whereNotNull("assignment_id")
+    .whereRaw(
+      `campaign_contact.updated_at < now() - ('1 minute'::interval * ?)`,
+      [afterStaleMinutes]
+    );
+};

--- a/src/server/tasks/release-stale-replies.js
+++ b/src/server/tasks/release-stale-replies.js
@@ -6,6 +6,7 @@ const CONCURRENCY = 2;
 export const releaseStaleReplies = async (_payload, _helpers) => {
   const campaignsToReleaseStaleRepliesFrom = await r
     .knex("campaign")
+    .select(["id", "replies_stale_after_minutes"])
     .whereNotNull("replies_stale_after_minutes")
     .where({ is_archived: false });
 

--- a/src/server/worker.js
+++ b/src/server/worker.js
@@ -51,7 +51,7 @@ export const getRunner = async (attempt = 0) => {
     return getRunner(attempt + 1);
   }
 
-  return runner;
+  return { runner, scheduler };
 };
 
 let worker = undefined;

--- a/src/server/worker.js
+++ b/src/server/worker.js
@@ -1,21 +1,28 @@
 import { makeWorkerUtils, run, Logger } from "graphile-worker";
+import { run as runSchedule } from "graphile-scheduler";
 
 import { config } from "../config";
 import logger from "../logger";
 import handleAutoassignmentRequest from "./tasks/handle-autoassignment-request";
+import { Pool } from "pg";
+import { releaseStaleReplies } from "./tasks/release-stale-replies";
 
 const logFactory = scope => (level, message, meta) =>
   logger.log({ level, message, ...meta, ...scope });
 const graphileLogger = new Logger(logFactory);
 
 let runner = undefined;
+let scheduler = undefined;
 let runnerSemaphore = false;
+
+const workerPool = new Pool({ connectionString: config.DATABASE_URL });
+
 export const getRunner = async (attempt = 0) => {
   // We are the first one to request the runner
   if (!runner && !runnerSemaphore) {
     runnerSemaphore = true;
     runner = await run({
-      connectionString: config.DATABASE_URL,
+      pgPool: workerPool,
       concurrency: 5,
       logger: graphileLogger,
       // Signals are handled by Terminus
@@ -24,6 +31,17 @@ export const getRunner = async (attempt = 0) => {
       taskList: {
         "handle-autoassignment-request": handleAutoassignmentRequest
       }
+    });
+
+    scheduler = await runSchedule({
+      pgPool: workerPool,
+      schedules: [
+        {
+          name: "release-stale-replies",
+          pattern: "*/5 * * * *",
+          task: releaseStaleReplies
+        }
+      ]
     });
   }
   // Someone beat us to the punch of initializing the runner

--- a/yarn.lock
+++ b/yarn.lock
@@ -1437,6 +1437,13 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/chokidar@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@types/chokidar/-/chokidar-2.1.3.tgz#123ab795dba6d89be04bf076e6aecaf8620db674"
+  integrity sha512-6qK3xoLLAhQVTucQGHTySwOVA1crHRXnJeLwqK6KIFkkKa2aoMFXh+WEi8PotxDtvN6MQJLyYN9ag9P6NLV81w==
+  dependencies:
+    chokidar "*"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -1544,6 +1551,13 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@^24.0.11":
+  version "24.9.1"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.9.1.tgz#02baf9573c78f1b9974a5f36778b366aa77bd534"
+  integrity sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==
+  dependencies:
+    jest-diff "^24.3.0"
+
 "@types/keygrip@*":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@types/keygrip/-/keygrip-1.0.2.tgz#513abfd256d7ad0bf1ee1873606317b33b1b2a72"
@@ -1635,7 +1649,7 @@
   resolved "https://registry.yarnpkg.com/@types/pg-types/-/pg-types-1.11.5.tgz#1eebbe62b6772fcc75c18957a90f933d155e005b"
   integrity sha512-L8ogeT6vDzT1vxlW3KITTCt+BVXXVkLXfZ/XNm6UqbcJgxf+KPO7yjWx7dQQE8RW07KopL10x2gNMs41+IkMGQ==
 
-"@types/pg@^7.14.1":
+"@types/pg@^7.14.1", "@types/pg@^7.4.11":
   version "7.14.3"
   resolved "https://registry.yarnpkg.com/@types/pg/-/pg-7.14.3.tgz#eb166e4f4287923890b10ed20371f937938cb995"
   integrity sha512-go5zddQ1FrUQHeBvqPzQ1svKo4KKucSwvqLsvwc/EIuQ9sxDA21b68xc/RwhzAK5pPCnez8NrkYatFIGdJBVvA==
@@ -4416,6 +4430,21 @@ cheerio@^1.0.0-rc.3:
     lodash "^4.15.0"
     parse5 "^3.0.1"
 
+chokidar@*, chokidar@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.1.tgz#c84e5b3d18d9a4d77558fef466b1bf16bbeb3450"
+  integrity sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.3.0"
+  optionalDependencies:
+    fsevents "~2.1.2"
+
 chokidar@^2.0.0, chokidar@^2.0.2, chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -4434,21 +4463,6 @@ chokidar@^2.0.0, chokidar@^2.0.2, chokidar@^2.1.8:
     upath "^1.1.1"
   optionalDependencies:
     fsevents "^1.2.7"
-
-chokidar@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.1.tgz#c84e5b3d18d9a4d77558fef466b1bf16bbeb3450"
-  integrity sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==
-  dependencies:
-    anymatch "~3.1.1"
-    braces "~3.0.2"
-    glob-parent "~5.1.0"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.3.0"
-  optionalDependencies:
-    fsevents "~2.1.2"
 
 chownr@^1.1.1, chownr@^1.1.2:
   version "1.1.3"
@@ -5902,6 +5916,11 @@ dicer@0.3.0:
   integrity sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==
   dependencies:
     streamsearch "0.1.2"
+
+diff-sequences@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
+  integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
 
 diff@^3.2.0:
   version "3.5.0"
@@ -8101,6 +8120,35 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
 
+graphile-scheduler@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/graphile-scheduler/-/graphile-scheduler-0.0.1.tgz#dbb43270ba4b22314358d5328fb7af2c2dc2b22a"
+  integrity sha512-sCQ5dE6Jp4q2F5NKWR2GL0VYm/iWuFCZv0r7TJEuWF4geOWiBq+Clxnv4fCjeB+qqpEJ1X8k9dH240LumyeoIw==
+  dependencies:
+    "@types/debug" "^4.1.2"
+    "@types/jest" "^24.0.11"
+    "@types/pg" "^7.4.11"
+    graphile-worker "0.4.0"
+    moment "^2.24.0"
+    pg ">=6.5 <8"
+    pg-connection-string "^2.0.0"
+    tslib "^1.9.3"
+    yargs "^15.1.0"
+
+graphile-worker@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/graphile-worker/-/graphile-worker-0.4.0.tgz#728b052e3c9569b78dd88cf8114d5f00997dc21e"
+  integrity sha512-cQW69ERlosKf0kaVpAuLT9YIqi5h+kChuTn0hd43wsDB/NPExgljGyMsSiqD5bUFLlut6EqdNmJ2r54SHGbOuw==
+  dependencies:
+    "@types/chokidar" "^2.1.3"
+    "@types/debug" "^4.1.2"
+    "@types/pg" "^7.14.1"
+    chokidar "^3.3.1"
+    pg ">=6.5 <8"
+    pg-connection-string "^2.0.0"
+    tslib "^1.9.3"
+    yargs "^15.1.0"
+
 graphile-worker@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/graphile-worker/-/graphile-worker-0.5.0.tgz#6a338e31bfe69580c9d43941779c838aca39fd6c"
@@ -9829,6 +9877,16 @@ jest-diff@^22.4.0, jest-diff@^22.4.3:
     diff "^3.2.0"
     jest-get-type "^22.4.3"
     pretty-format "^22.4.3"
+
+jest-diff@^24.3.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
+  integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
+  dependencies:
+    chalk "^2.0.1"
+    diff-sequences "^24.9.0"
+    jest-get-type "^24.9.0"
+    pretty-format "^24.9.0"
 
 jest-docblock@^20.0.3:
   version "20.0.3"
@@ -11687,7 +11745,7 @@ moment-timezone@^0.5.14:
   dependencies:
     moment ">= 2.9.0"
 
-moment@*, moment@2.x.x, "moment@>= 2.9.0", moment@^2.14.1:
+moment@*, moment@2.x.x, "moment@>= 2.9.0", moment@^2.14.1, moment@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
@@ -12861,6 +12919,11 @@ pg-connection-string@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.1.0.tgz#e07258f280476540b24818ebb5dca29e101ca502"
   integrity sha512-bhlV7Eq09JrRIvo1eKngpwuqKtJnNhZdpdOlvrPrA4dxqXPjxSrbNrfnIDmTpwMyRszrcV4kU5ZA4mMsQUrjdg==
+
+pg-connection-string@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.2.0.tgz#caab4d38a9de4fdc29c9317acceed752897de41c"
+  integrity sha512-xB/+wxcpFipUZOQcSzcgkjcNOosGhEoPSjz06jC89lv1dj7mc9bZv6wLVy8M2fVjP0a/xN0N988YDq1L0FhK3A==
 
 pg-int8@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add campaign.release_stale_replies, UI controls for it, and a cron job to release the stale replies

## Description
<!--- Describe your changes in detail -->
This adds an attribute `replies_stale_after_minutes` to campaigns, which, if not null, means that their replies will auto-release (the assignment_id becomes null) after `replies_stale_after_minutes` minutes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This automates the constant unassignment of old replies that many admins have to do.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
The cron job has been tested on some locally generated data and the scheduler setup locally running the server. 

The UI changes were tested locally.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
