### PR TITLE
fix: remove auth query param from segments helpdesk url

### DIFF
--- a/src/components/ScriptEditor.jsx
+++ b/src/components/ScriptEditor.jsx
@@ -228,7 +228,7 @@ class ScriptEditor extends React.Component {
           <br />
           Not sure what a segment is? Check out the{" "}
           <a
-            href="https://docs.spokerewired.com/article/89-segments-and-encodings?auth=true"
+            href="https://docs.spokerewired.com/article/89-segments-and-encodings"
             target="_blank"
           >
             docs here


### PR DESCRIPTION
## Description

Removes the `auth` query param from the link to the "Segments and encoding" helpdesk article.

## Motivation and Context

This query param was breaking the URL for some clients.

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
