### PR TITLE
fix: remove afterCreate hook

### DIFF
--- a/src/server/knex.js
+++ b/src/server/knex.js
@@ -9,13 +9,6 @@ const pg = require("pg");
 // see https://github.com/tgriesser/knex/issues/852
 pg.defaults.ssl = config.DB_USE_SSL;
 
-// https://dba.stackexchange.com/questions/164419/is-it-possible-to-limit-timeout-on-postgres-server
-const afterCreate = (conn, done) =>
-  conn.query(
-    `SET idle_in_transaction_session_timeout = ${config.DB_IDLE_TIMEOUT_MS};`,
-    (error, _results, _fields) => done(error, conn)
-  );
-
 let connection = {};
 
 if (config.isTest) {
@@ -47,8 +40,7 @@ const knexConfig = {
     min: config.DB_MAX_POOL,
     max: config.DB_MAX_POOL,
     idleTimeoutMillis: config.DB_IDLE_TIMEOUT_MS,
-    reapIntervalMillis: config.DB_REAP_INTERVAL_MS,
-    afterCreate
+    reapIntervalMillis: config.DB_REAP_INTERVAL_MS
   }
 };
 


### PR DESCRIPTION
## Description

Removes the now-unnecessary `afterCreate` hook.

## Motivation and Context

This hook is redundant as `idle_in_transaction_session_timeout` is already set in the pool config:

```js
pool: {
  idleTimeoutMillis: config.DB_IDLE_TIMEOUT_MS
}
```

But also because a more robust solution is to set this at the Postgres role level and not during session creation.

~~For a still-unknown reason, this is causing issues in production. Possibly due to a Typescript compilation error, but have not been able to reproduce locally.~~
The bug this was supposed to address was fixed in #640. Removing the `afterCreate` hook is still a good idea, however.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
