### PR TITLE
fix: use the same knex client throughout query builder

### DIFF
--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -119,14 +119,14 @@ export const resolvers = {
       const campaignIdInt = parseInt(campaignId);
       if (!isNaN(campaignIdInt)) {
         query.whereExists(function() {
-          this.select(r.knex.raw("1"))
+          this.select(this.client.raw("1"))
             .from("assignment")
             .whereRaw('"assignment"."user_id" = "user"."id"')
             .where({ campaign_id: campaignIdInt });
         });
       } else if (campaignArchived === true || campaignArchived === false) {
         query.whereExists(function() {
-          this.select(r.knex.raw("1"))
+          this.select(this.client.raw("1"))
             .from("assignment")
             .join("campaign", "campaign.id", "assignment.campaign_id")
             .whereRaw('"assignment"."user_id" = "user"."id"')


### PR DESCRIPTION
## Description

This ensures that the same knex client is used throughout the `formatPage` query building.

## Motivation and Context

Using `r.knex.raw()` within a `r.reader()` query with `DATABASE_READER_URL` set causes problems. It did not seem like there was another way to access `.raw()` within a subquery. However, this.client.raw() works as expected.

## How Has This Been Tested?

I was able to reproduce the bug locally with `DATABASE_READER_URL` set and this change solves the problem. This has also been tested in production using one-off builds.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
