### PR TITLE
refactor: pass section pending job

### DIFF
--- a/src/containers/AdminCampaignEdit/components/SectionWrapper.tsx
+++ b/src/containers/AdminCampaignEdit/components/SectionWrapper.tsx
@@ -212,7 +212,8 @@ const makeQueries = (hasJobQueues: boolean) => ({
     options: (ownProps: RequiredComponentProps) => ({
       variables: {
         campaignId: ownProps.campaignId
-      }
+      },
+      pollInterval: hasJobQueues ? 10 * 1000 : undefined
     })
   },
   jobs: {

--- a/src/containers/AdminCampaignEdit/components/SectionWrapper.tsx
+++ b/src/containers/AdminCampaignEdit/components/SectionWrapper.tsx
@@ -251,7 +251,8 @@ const mutations = {
     variables: {
       campaignId: ownProps.campaignId,
       id: jobId
-    }
+    },
+    refetchQueries: ["getCampaignJobs"]
   })
 };
 

--- a/src/containers/AdminCampaignEdit/components/SectionWrapper.tsx
+++ b/src/containers/AdminCampaignEdit/components/SectionWrapper.tsx
@@ -265,6 +265,10 @@ export interface RequiredComponentProps {
   onError(message: string): void;
 }
 
+export interface FullComponentProps extends RequiredComponentProps {
+  pendingJob?: PendingJobType;
+}
+
 export interface SectionOptions {
   title: string;
   readinessName: keyof CampaignReadinessType;
@@ -306,11 +310,7 @@ interface WrappedComponentProps
 }
 
 export const asSection = (options: SectionOptions) => (
-  Component: React.ComponentType<
-    RequiredComponentProps & {
-      pendingJob?: PendingJobType;
-    }
-  >
+  Component: React.ComponentType<FullComponentProps>
 ) =>
   compose<WrappedComponentProps, RequiredComponentProps>(
     withAuthzContext,

--- a/src/containers/AdminCampaignEdit/index.jsx
+++ b/src/containers/AdminCampaignEdit/index.jsx
@@ -174,7 +174,7 @@ class AdminCampaignEdit extends React.Component {
   }
 
   isNew() {
-    return queryString.parse(this.props.location.search).new;
+    return Boolean(queryString.parse(this.props.location.search).new);
   }
 
   async handleDeleteJob(jobId) {
@@ -744,6 +744,7 @@ class AdminCampaignEdit extends React.Component {
             return (
               <Component
                 key={section.title}
+                organizationId={match.params.organizationId}
                 campaignId={campaignId}
                 active={expandedSection === sectionIndex}
                 isNew={isNew}

--- a/src/containers/AdminCampaignEdit/sections/CampaignAutoassignModeForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignAutoassignModeForm.tsx
@@ -9,6 +9,7 @@ import RaisedButton from "material-ui/RaisedButton";
 import { loadData } from "../../hoc/with-operations";
 import {
   asSection,
+  FullComponentProps,
   RequiredComponentProps
 } from "../components/SectionWrapper";
 import CampaignFormSectionHeading from "../components/CampaignFormSectionHeading";
@@ -28,9 +29,7 @@ interface AutoassignHocProps {
   };
 }
 
-interface AutoassignInnerProps
-  extends RequiredComponentProps,
-    AutoassignHocProps {}
+interface AutoassignInnerProps extends FullComponentProps, AutoassignHocProps {}
 
 interface AutoassignState {
   isAutoassignEnabled?: boolean;

--- a/src/containers/AdminCampaignEdit/sections/CampaignAutoassignModeForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignAutoassignModeForm.tsx
@@ -153,15 +153,15 @@ const mutations = {
 };
 
 export default compose<AutoassignInnerProps, RequiredComponentProps>(
-  loadData({
-    queries,
-    mutations
-  }),
   asSection({
     title: "Autoassign Mode",
     readinessName: "autoassign",
     jobQueueNames: [],
     expandAfterCampaignStarts: true,
     expandableBySuperVolunteers: false
+  }),
+  loadData({
+    queries,
+    mutations
   })
 )(CampaignAutoassignModeForm);

--- a/src/containers/AdminCampaignEdit/sections/CampaignBasicsForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignBasicsForm.tsx
@@ -225,15 +225,15 @@ const mutations = {
 };
 
 export default compose<BasicsInnerProps, RequiredComponentProps>(
-  loadData({
-    queries,
-    mutations
-  }),
   asSection({
     title: "Basics",
     readinessName: "basics",
     jobQueueNames: [],
     expandAfterCampaignStarts: true,
     expandableBySuperVolunteers: true
+  }),
+  loadData({
+    queries,
+    mutations
   })
 )(CampaignBasicsForm);

--- a/src/containers/AdminCampaignEdit/sections/CampaignBasicsForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignBasicsForm.tsx
@@ -16,6 +16,7 @@ import GSForm from "../../../components/forms/GSForm";
 import CampaignFormSectionHeading from "../components/CampaignFormSectionHeading";
 import {
   asSection,
+  FullComponentProps,
   RequiredComponentProps
 } from "../components/SectionWrapper";
 
@@ -40,7 +41,7 @@ interface BasicsHocProps {
   };
 }
 
-interface BasicsInnerProps extends RequiredComponentProps, BasicsHocProps {}
+interface BasicsInnerProps extends FullComponentProps, BasicsHocProps {}
 
 interface BasicsState {
   pendingChanges: BasicsValues;

--- a/src/containers/AdminCampaignEdit/sections/CampaignTextingHoursForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignTextingHoursForm.tsx
@@ -12,6 +12,7 @@ import Autocomplete from "material-ui/AutoComplete";
 
 import {
   asSection,
+  FullComponentProps,
   RequiredComponentProps
 } from "../components/SectionWrapper";
 import { DataSourceItemType } from "../types";
@@ -74,9 +75,7 @@ interface AutoassignHocProps {
   };
 }
 
-interface AutoassignInnerProps
-  extends RequiredComponentProps,
-    AutoassignHocProps {}
+interface AutoassignInnerProps extends FullComponentProps, AutoassignHocProps {}
 
 interface AutoassignState {
   pendingChanges: Partial<TextingHoursValues>;

--- a/src/containers/AdminCampaignEdit/sections/CampaignTextingHoursForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignTextingHoursForm.tsx
@@ -293,15 +293,15 @@ const mutations = {
 };
 
 export default compose<AutoassignInnerProps, RequiredComponentProps>(
-  loadData({
-    queries,
-    mutations
-  }),
   asSection({
     title: "Texting Hours",
     readinessName: "textingHours",
     jobQueueNames: [],
     expandAfterCampaignStarts: true,
     expandableBySuperVolunteers: false
+  }),
+  loadData({
+    queries,
+    mutations
   })
 )(CampaignTextingHoursForm);

--- a/src/containers/hoc/with-operations.jsx
+++ b/src/containers/hoc/with-operations.jsx
@@ -14,11 +14,11 @@ import LoadingIndicator from "../../components/LoadingIndicator";
 const isLoading = queryNames =>
   withProps(parentProps => {
     const loadingReducer = (loadingAcc, queryName) =>
-      loadingAcc || parentProps[queryName].loading;
+      loadingAcc || (parentProps[queryName] || {}).loading;
     const loading = queryNames.reduce(loadingReducer, false);
 
     const errorReducer = (errorAcc, queryName) => {
-      const error = parentProps[queryName].error;
+      const error = (parentProps[queryName] || {}).error;
       return error ? errorAcc.concat([error]) : errorAcc;
     };
     const errors = queryNames.reduce(errorReducer, []);


### PR DESCRIPTION
Only poll jobs for sections with job queues. Increase frequency of this polling. Pass the job, if found, to the Component.

## Description

The main types of changes are:
- Moves intermediate logic of props out of SectionWrapper `render()` and into a `withProps` HOC
- Simpler type definitions. While many of the prop types are related, trying to use `extends` for this just muddies the water.
- Only use one HOC `compose()`. This gives the section Component access to the pending job and just simplifies `asSection()`.
- Skips the pending jobs query entirely if the section does not use jobs. This required a change to with-operations to handle the empty-query possibility.

## Motivation and Context

The section Component may need to access the result message of the job (e.g. contact upload). Passing that down required reworking the `asSection` HOC.

It's safe to poll jobs more frequently now that queries are tightly scoped.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
