### PR TITLE
feat: reply-to address

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -317,6 +317,11 @@ const validators = {
       "Email from address. Required to send email from either Mailgun or a custom SMTP server.",
     default: undefined
   }),
+  EMAIL_REPLY_TO: email({
+    desc:
+      "Reply-To address. If not supplied, an organization owner's email address will be used.",
+    default: undefined
+  }),
   EMAIL_HOST: host({
     desc: "Email server host. Required for custom SMTP server usage.",
     default: undefined

--- a/src/server/notifications.js
+++ b/src/server/notifications.js
@@ -26,6 +26,7 @@ async function getOrganizationOwner(organizationId) {
       "user_organization.organization_id": organizationId,
       role: "OWNER"
     })
+    .orderBy("user.id")
     .first("user.*");
 }
 const sendAssignmentUserNotification = async (assignment, notification) => {


### PR DESCRIPTION
## Description

Allows setting instance-wide Reply-To address.

## Motivation and Context

Without this, an owner's email is used (now sorted by ID) which is not always the preferred behavior.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

Added a [Notifications](https://docs.spokerewired.com/article/92-notifications) article.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] My change requires a change to the documentation.
- [x] I have included updates for the documentation accordingly.
