### PR TITLE
fix(settings): fix capitalization of auto-approve type

### DIFF
--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -931,18 +931,18 @@ const rootMutations = {
         return organization;
       }
 
-      let approvalStatus = RequestAutoApproveType.APPROVAL_REQUIRED.toLowerCase();
+      let approvalStatus = RequestAutoApproveType.APPROVAL_REQUIRED;
       try {
         approvalStatus =
-          JSON.parse(organization.feature || "{}").defaulTexterApprovalStatus ||
-          approvalStatus;
+          JSON.parse(organization.features || "{}")
+            .defaulTexterApprovalStatus || approvalStatus;
       } catch (err) {}
 
       await r.knex("user_organization").insert({
         user_id: user.id,
         organization_id: organization.id,
         role: "TEXTER",
-        request_status: approvalStatus
+        request_status: approvalStatus.toLowerCase()
       });
 
       return organization;
@@ -1424,9 +1424,8 @@ const rootMutations = {
       const { payload = {} } = invite;
 
       const newOrganization = await r.knex.transaction(async trx => {
-        const defaultStatus = RequestAutoApproveType.APPROVAL_REQUIRED;
         const orgFeatures = {
-          defaulTexterApprovalStatus: defaultStatus.toLowerCase()
+          defaulTexterApprovalStatus: RequestAutoApproveType.APPROVAL_REQUIRED
         };
         if (payload.org_features) {
           const { switchboard_lrn_api_key } = payload.org_features;


### PR DESCRIPTION
## Description

This fixes capitalization of default texter autoapprove level.

## Motivation and Context

The type of `user_organization.request_status` must be lowercase, but the way resolvers are set up for
organization settings, `defaulTexterApprovalStatus` must be uppercase.

## How Has This Been Tested?

I have tested the invite flow locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
