### PR TITLE
improvement: pass Spoke's logger to scheduler

### DIFF
--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -1,5 +1,15 @@
-import { makeWorkerUtils, run, Logger } from "graphile-worker";
-import { run as runSchedule } from "graphile-scheduler";
+import {
+  makeWorkerUtils,
+  run,
+  LogFunctionFactory,
+  Logger,
+  Runner,
+  WorkerUtils
+} from "graphile-worker";
+import {
+  run as runSchedule,
+  Runner as ScheduleRunner
+} from "graphile-scheduler";
 
 import { config } from "../config";
 import logger from "../logger";
@@ -7,17 +17,19 @@ import handleAutoassignmentRequest from "./tasks/handle-autoassignment-request";
 import { Pool } from "pg";
 import { releaseStaleReplies } from "./tasks/release-stale-replies";
 
-const logFactory = scope => (level, message, meta) =>
+const logFactory: LogFunctionFactory = scope => (level, message, meta) =>
   logger.log({ level, message, ...meta, ...scope });
 const graphileLogger = new Logger(logFactory);
 
-let runner = undefined;
-let scheduler = undefined;
+let runner: Runner | undefined = undefined;
+let scheduler: ScheduleRunner | undefined = undefined;
 let runnerSemaphore = false;
 
 const workerPool = new Pool({ connectionString: config.DATABASE_URL });
 
-export const getRunner = async (attempt = 0) => {
+export const getRunner = async (
+  attempt = 0
+): Promise<{ runner: Runner; scheduler: ScheduleRunner }> => {
   // We are the first one to request the runner
   if (!runner && !runnerSemaphore) {
     runnerSemaphore = true;
@@ -35,10 +47,13 @@ export const getRunner = async (attempt = 0) => {
 
     scheduler = await runSchedule({
       pgPool: workerPool,
+      // Use <any> cast as short-term workaround for https://github.com/davbeck/graphile-scheduler/pull/2
+      logger: <any>graphileLogger,
       schedules: [
         {
           name: "release-stale-replies",
           pattern: "*/5 * * * *",
+          timeZone: config.TZ,
           task: releaseStaleReplies
         }
       ]
@@ -51,12 +66,12 @@ export const getRunner = async (attempt = 0) => {
     return getRunner(attempt + 1);
   }
 
-  return { runner, scheduler };
+  return { runner: runner!, scheduler: scheduler! };
 };
 
-let worker = undefined;
+let worker: WorkerUtils | undefined = undefined;
 let workerSemaphore = false;
-export const getWorker = async (attempt = 0) => {
+export const getWorker = async (attempt = 0): Promise<WorkerUtils> => {
   // We are the first one to request the worker
   if (!worker && !workerSemaphore) {
     workerSemaphore = true;
@@ -71,5 +86,5 @@ export const getWorker = async (attempt = 0) => {
     return getWorker(attempt + 1);
   }
 
-  return worker;
+  return worker!;
 };


### PR DESCRIPTION
## Description

Pass our custom Graphile Logger to the scheduler.

## Motivation and Context

We want standardized structured logging.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
