### PR TITLE
fix: fix campaign creation error

### DIFF
--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1093,7 +1093,7 @@ const rootMutations = {
         organizationId: campaign.organizationId
       });
 
-      const [newCampaignId] = await r
+      const [origCampaignRecord] = await r
         .knex("campaign")
         .insert({
           organization_id: campaign.organizationId,
@@ -1104,9 +1104,15 @@ const rootMutations = {
           is_started: false,
           is_archived: false
         })
-        .returning("id");
+        .returning("*");
 
-      return editCampaign(newCampaignId, campaign, loaders, user);
+      return editCampaign(
+        origCampaignRecord.id,
+        campaign,
+        loaders,
+        user,
+        origCampaignRecord
+      );
     },
 
     copyCampaign: async (_, { id }, { user, loaders }) => {


### PR DESCRIPTION
Fix campaign creation error.

## Description

This fixes the error creating campaigns where Spoke gets stuck loading by passing the complete argument list to `editCampaign()`.

## Motivation and Context

Previously, creating a campaign would cause Spoke to get stuck loading the campaign list and would require a page refresh to see the new campaign.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
