### PR TITLE
chore(worker): add max pool size envvar

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -715,6 +715,14 @@ const validators = {
     desc:
       "If the WAREHOUSE_DB connection/feature is enabled, then on AWS Lambda, queries that take longer than 5min can expire. This will enable incrementing through queries on new lambda invocations to avoid timeouts.",
     default: false
+  }),
+  WORKER_CONCURRENCY: num({
+    desc: "Worker concurrency. ",
+    default: 2
+  }),
+  WORKER_MAX_POOL: num({
+    desc: "Worker database connection pool maximum size. ",
+    default: 2
   })
 };
 


### PR DESCRIPTION
## Description

Add envvar to set max Postgres pool size for the worker.

## Motivation and Context

Finer grained control over connection usage.

## How Has This Been Tested?

This runs locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
