### PR TITLE
fix: update client-side messages cache after sending

### DIFF
--- a/src/components/AssignmentTexter.jsx
+++ b/src/components/AssignmentTexter.jsx
@@ -290,6 +290,10 @@ class AssignmentTexter extends React.Component {
         this.props.mutations
           .sendMessage(payload.message, contact_id)
           .then(catchError)
+          .then(response => {
+            const { id, messages } = response.data.sendMessage;
+            this.state.contactCache[id].messages = messages;
+          })
           .catch(this.handleSendMessageError(contact_id))
       );
 


### PR DESCRIPTION
## Description

Update the custom client-side cache of contact data that Spoke maintains after sending a message.

## Motivation and Context

Spoke maintains a cache separate from the Apollo cache of contact data for the texter workflow. Requesting the updated `messages` list in the `sendMessage` mutation will update the Apollo cache, but not the custom Spoke cache. This means the texter will see a stale message list when they navigate backwards to a conversation they just sent a message on.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
