### PR TITLE
fix: texter stuck loading

### DIFF
--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -58,14 +58,15 @@ class TexterTodo extends React.Component {
 
   assignContactsIfNeeded = async (checkServer = false) => {
     const { assignment } = this.props.data;
-    if (assignment.contacts.length === 0 || checkServer) {
+    const { contacts } = this.props.contacts.assignment;
+    if (contacts.length === 0 || checkServer) {
       if (assignment.campaign.useDynamicAssignment) {
         const didAddContacts = (await this.props.mutations.findNewCampaignContact(
           assignment.id,
           1
         )).data.findNewCampaignContact.found;
         if (didAddContacts) {
-          this.props.data.refetch();
+          this.props.contacts.refetch();
           return;
         }
       }
@@ -84,8 +85,9 @@ class TexterTodo extends React.Component {
   render() {
     const { assignment } = this.props.data;
     const { organizationId } = this.props.match.params;
-    const contactIds = assignment.contacts.map(contact => contact.id);
-    const allContactsCount = assignment.allContactsCount;
+    const { contacts, allContactsCount } = this.props.contacts.assignment;
+    const contactIds = contacts.map(contact => contact.id);
+
     return (
       <AssignmentTexter
         assignment={assignment}
@@ -113,10 +115,7 @@ TexterTodo.propTypes = {
 const queries = {
   data: {
     query: gql`
-      query getContacts(
-        $assignmentId: String!
-        $contactsFilter: ContactsFilter!
-      ) {
+      query getTexterAssignmentData($assignmentId: String!) {
         assignment(id: $assignmentId) {
           id
           userCannedResponses {
@@ -167,6 +166,24 @@ const queries = {
               }
             }
           }
+        }
+      }
+    `,
+    options: ownProps => ({
+      variables: {
+        assignmentId: ownProps.match.params.assignmentId
+      },
+      pollInterval: 20000
+    })
+  },
+  contacts: {
+    query: gql`
+      query getTexterAssignmentContactIds(
+        $assignmentId: String!
+        $contactsFilter: ContactsFilter!
+      ) {
+        assignment(id: $assignmentId) {
+          id
           contacts(contactsFilter: $contactsFilter) {
             id
           }

--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -183,8 +183,7 @@ const queries = {
         },
         assignmentId: ownProps.match.params.assignmentId
       },
-      fetchPolicy: "network-only",
-      pollInterval: 20000
+      fetchPolicy: "network-only"
     })
   }
 };


### PR DESCRIPTION
This fixes the bugs where a texter will a) get stuck on a loading screen indefinitely and b) gets kicked out of a conversation.

## Description

This breaks up the GraphQL query that fetches campaign data (script, canned responses, etc.) and the list of campaign contact IDs. We want to poll for changes to the campaign data but do not want the list of campaign contact IDs to shift underneath us.

## Motivation and Context

A change to a campaign contact's status will cause it to be excluded from the next polling of
contacts. This causes at the least the two following problems:

1. When a reply comes in the current contact index changes and the texter is booted out of the
   reply they are crafting.
2. When a message is sent and then navigated back to the texter can view the past conversation
   for a moment but is booted to a permanent loading screen when the next poll completes. The
   currentContactIndex gets set to -1 leading to no currentContact and thus the loading screen.
   Usually this could only happen while Spoke is fetching the next batch of 10 contacts.

Spoke tries to handle these cases in AssignmentTexter.componentWillUpdate but it does not really
work. A list of contacts that shifts underneath the user is also not the correct approach in my
opinion.

## How Has This Been Tested?

This has been tested locally.

Changes to `assignContactsIfNeeded` have _not_ been tested.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
