### PR TITLE
feat: contact detail display settings

### DIFF
--- a/src/api/organization-settings.js
+++ b/src/api/organization-settings.js
@@ -3,6 +3,8 @@ export const schema = `
     defaulTexterApprovalStatus: RequestAutoApprove
     optOutMessage: String
     numbersApiKey: String
+    showContactLastName: Boolean
+    showContactCell: Boolean
   }
 
   type OranizationSettings {
@@ -10,5 +12,7 @@ export const schema = `
     defaulTexterApprovalStatus: RequestAutoApprove!
     optOutMessage: String
     numbersApiKey: String
+    showContactLastName: Boolean
+    showContactCell: Boolean
   }
 `;

--- a/src/components/AssignmentTexter.jsx
+++ b/src/components/AssignmentTexter.jsx
@@ -378,7 +378,7 @@ class AssignmentTexter extends React.Component {
 
   renderTexter = () => {
     const { errors } = this.state;
-    const { assignment, organizationTags } = this.props;
+    const { assignment, organizationTags, contactSettings } = this.props;
     const { campaign, texter } = assignment;
     const contact = this.currentContact();
 
@@ -393,6 +393,7 @@ class AssignmentTexter extends React.Component {
         key={contact.id}
         assignment={assignment}
         contact={contact}
+        contactSettings={contactSettings.organization.settings}
         tags={organizationTags.organization.tagList}
         texter={texter}
         campaign={campaign}
@@ -450,6 +451,25 @@ AssignmentTexter.propTypes = {
 };
 
 const queries = {
+  contactSettings: {
+    query: gql`
+      query getOrganizationContactSettings($organizationId: String!) {
+        organization(id: $organizationId) {
+          id
+          settings {
+            id
+            showContactLastName
+            showContactCell
+          }
+        }
+      }
+    `,
+    options: ownProps => ({
+      variables: {
+        organizationId: ownProps.organizationId
+      }
+    })
+  },
   organizationTags: {
     query: gql`
       query getTags($organizationId: String!) {

--- a/src/components/ContactToolbar.jsx
+++ b/src/components/ContactToolbar.jsx
@@ -18,12 +18,22 @@ const inlineStyles = {
 };
 
 const ContactToolbar = function ContactToolbar(props) {
-  const { campaign, campaignContact, rightToolbarIcon } = props;
+  const {
+    campaign,
+    campaignContact,
+    contactSettings,
+    rightToolbarIcon
+  } = props;
   const {
     location: { city, state },
     timezone: contactTimezone,
-    firstName
+    firstName,
+    lastName
   } = campaignContact;
+
+  const contactName = contactSettings.showContactLastName
+    ? `${firstName} ${lastName}`
+    : `${firstName}`;
 
   const timezone = contactTimezone || campaign.timezone;
   const localTime = moment()
@@ -35,9 +45,14 @@ const ContactToolbar = function ContactToolbar(props) {
     .join(", ")
     .trim();
 
+  const cell = contactSettings.showContactCell
+    ? campaignContact.cell
+    : undefined;
+  const detailComponents = [location, localTime, cell].filter(item => !!item);
+
   const contactDetailText = (
     <span>
-      {firstName} &nbsp;&nbsp; {location} {localTime}
+      {contactName} &nbsp;&nbsp; {detailComponents.join(" ")}
     </span>
   );
 

--- a/src/containers/AssignmentTexterContact/TopFixedSection.jsx
+++ b/src/containers/AssignmentTexterContact/TopFixedSection.jsx
@@ -4,12 +4,13 @@ import NavigateHomeIcon from "material-ui/svg-icons/action/home";
 import IconButton from "material-ui/IconButton/IconButton";
 
 const TopFixedSection = props => {
-  const { contact, campaign, onExitTexter } = props;
+  const { contactSettings, contact, campaign, onExitTexter } = props;
 
   return (
     <ContactToolbar
       campaign={campaign}
       campaignContact={contact}
+      contactSettings={contactSettings}
       rightToolbarIcon={
         <IconButton
           onTouchTap={onExitTexter}

--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -819,7 +819,7 @@ export class AssignmentTexterContact extends React.Component {
 
   render() {
     const { disabled } = this.state;
-    const { campaign, contact, onExitTexter } = this.props;
+    const { campaign, contact, contactSettings, onExitTexter } = this.props;
 
     const backgroundColor =
       contact.messageStatus === "needsResponse"
@@ -837,6 +837,7 @@ export class AssignmentTexterContact extends React.Component {
         <div className={css(styles.flexContainer)}>
           <div className={css(styles.fixedFlexSection)}>
             <TopFixedSection
+              contactSettings={contactSettings}
               campaign={campaign}
               contact={contact}
               onExitTexter={onExitTexter}
@@ -892,6 +893,7 @@ export class AssignmentTexterContact extends React.Component {
 AssignmentTexterContact.propTypes = {
   errors: PropTypes.array,
   contact: PropTypes.object,
+  contactSettings: PropTypes.object,
   tags: PropTypes.arrayOf(PropTypes.object).isRequired,
   campaign: PropTypes.object,
   assignment: PropTypes.object,

--- a/src/containers/Settings/components/General.jsx
+++ b/src/containers/Settings/components/General.jsx
@@ -129,6 +129,16 @@ class Settings extends React.Component {
   handleEditOptOutMessage = ({ optOutMessage }) =>
     this.editSettings("Opt Out Messasge", { optOutMessage });
 
+  handleEditShowContactLastName = async (event, isToggled) =>
+    this.editSettings("Show Contact Last Name", {
+      showContactLastName: isToggled
+    });
+
+  handleEditShowContactCell = async (event, isToggled) =>
+    this.editSettings("Show Contact Cell Phone", {
+      showContactCell: isToggled
+    });
+
   handleDismissError = () => this.setState({ error: undefined });
 
   renderTextingHoursForm() {
@@ -192,7 +202,9 @@ class Settings extends React.Component {
     const {
       optOutMessage,
       numbersApiKey,
-      defaulTexterApprovalStatus
+      defaulTexterApprovalStatus,
+      showContactLastName,
+      showContactCell
     } = organization.settings;
 
     const formSchema = yup.object({
@@ -342,6 +354,27 @@ class Settings extends React.Component {
             </CardActions>
           </GSForm>
         </Card>
+
+        <Card className={css(styles.sectionCard)}>
+          <CardHeader title="Contact Information Display" />
+          <CardText>
+            <p>
+              Choose how much information about a contact is displayed to the
+              texter.
+            </p>
+            <Toggle
+              toggled={showContactLastName}
+              label="Show contact's last name?"
+              onToggle={this.handleEditShowContactLastName}
+            />
+            <Toggle
+              toggled={showContactCell}
+              label="Show contact's cell phone number?"
+              onToggle={this.handleEditShowContactCell}
+            />
+          </CardText>
+        </Card>
+
         <Dialog
           title="Error Saving Settings"
           open={error !== undefined}
@@ -420,6 +453,8 @@ const mutations = {
           optOutMessage
           numbersApiKey
           defaulTexterApprovalStatus
+          showContactLastName
+          showContactCell
         }
       }
     `,
@@ -445,6 +480,8 @@ const queries = {
             optOutMessage
             numbersApiKey
             defaulTexterApprovalStatus
+            showContactLastName
+            showContactCell
           }
         }
       }
@@ -452,8 +489,7 @@ const queries = {
     options: ownProps => ({
       variables: {
         organizationId: ownProps.match.params.organizationId
-      },
-      fetchPolicy: "cache-and-network"
+      }
     })
   }
 };

--- a/src/server/api/organization-settings.ts
+++ b/src/server/api/organization-settings.ts
@@ -8,12 +8,16 @@ interface IOrganizationSettings {
   defaulTexterApprovalStatus: string;
   optOutMessage: string;
   numbersApiKey?: string;
+  showContactLastName: boolean;
+  showContactCell: boolean;
 }
 
 const SETTINGS_PERMISSIONS: { [key in keyof IOrganizationSettings]: string } = {
   defaulTexterApprovalStatus: "OWNER",
   optOutMessage: "OWNER",
-  numbersApiKey: "OWNER"
+  numbersApiKey: "OWNER",
+  showContactLastName: "TEXTER",
+  showContactCell: "TEXTER"
 };
 
 const SETTINGS_NAMES: { [key: string]: string } = {
@@ -25,6 +29,8 @@ const SETTINGS_DEFAULTS: IOrganizationSettings = {
   optOutMessage:
     config.OPT_OUT_MESSAGE ??
     "I'm opting you out of texts immediately. Have a great day.",
+  showContactLastName: false,
+  showContactCell: false
 };
 
 const SETTINGS_TRANSFORMERS: { [key: string]: { (value: string): string } } = {
@@ -45,7 +51,7 @@ const SETTINGS_VALIDATORS: {
 const getOrgFeature = (
   featureName: keyof IOrganizationSettings,
   rawFeatures = "{}"
-): string | null => {
+): string | boolean | null => {
   const defaultValue = SETTINGS_DEFAULTS[featureName];
   const finalName = SETTINGS_NAMES[featureName] ?? featureName;
   try {
@@ -66,7 +72,7 @@ interface SettingsResolverType {
     organization: { id: string; features: string },
     _: any,
     context: { user: { id: string } }
-  ): Promise<string | null>;
+  ): Promise<string | boolean | null>;
 }
 
 const settingResolvers = (settingNames: (keyof IOrganizationSettings)[]) =>
@@ -89,7 +95,9 @@ export const resolvers = {
     ...settingResolvers([
       "defaulTexterApprovalStatus",
       "optOutMessage",
-      "numbersApiKey"
+      "numbersApiKey",
+      "showContactLastName",
+      "showContactCell"
     ])
   }
 };

--- a/src/server/api/organization-settings.ts
+++ b/src/server/api/organization-settings.ts
@@ -16,8 +16,8 @@ const SETTINGS_NAMES: { [key: string]: string } = {
 const SETTINGS_DEFAULTS: IOrganizationSettings = {
   defaulTexterApprovalStatus: RequestAutoApproveType.APPROVAL_REQUIRED,
   optOutMessage:
-    config.OPT_OUT_MESSAGE ||
-    "I'm opting you out of texts immediately. Have a great day."
+    config.OPT_OUT_MESSAGE ??
+    "I'm opting you out of texts immediately. Have a great day.",
 };
 
 const SETTINGS_TRANSFORMERS: { [key: string]: { (value: string): string } } = {
@@ -40,17 +40,17 @@ const getOrgFeature = (
   rawFeatures = "{}"
 ): string | null => {
   const defaultValue = SETTINGS_DEFAULTS[featureName];
-  const finalName = SETTINGS_NAMES[featureName] || featureName;
+  const finalName = SETTINGS_NAMES[featureName] ?? featureName;
   try {
     const features = JSON.parse(rawFeatures);
-    const value = features[finalName] || defaultValue || null;
+    const value = features[finalName] ?? defaultValue ?? null;
     const transformer = SETTINGS_TRANSFORMERS[featureName];
     if (transformer && value) {
       return SETTINGS_TRANSFORMERS[featureName](value);
     }
     return value;
   } catch (_err) {
-    return SETTINGS_DEFAULTS[featureName] || null;
+    return SETTINGS_DEFAULTS[featureName] ?? null;
   }
 };
 
@@ -92,7 +92,7 @@ export const updateOrganizationSettings = async (
     if (validator && value) {
       validator(value);
     }
-    const dbKey = SETTINGS_NAMES[key] || key;
+    const dbKey = SETTINGS_NAMES[key] ?? key;
     return Object.assign(acc, { [dbKey]: value });
   }, currentFeatures);
 

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -36,10 +36,7 @@ export const getEscalationUserId = async organizationId => {
 export const resolvers = {
   Organization: {
     ...sqlResolvers(["id", "name"]),
-    settings: async (organization, _, { user }) => {
-      await accessRequired(user, organization.id, "OWNER");
-      return organization;
-    },
+    settings: organization => organization,
     campaigns: async (organization, { cursor, campaignsFilter }, { user }) => {
       await accessRequired(user, organization.id, "SUPERVOLUNTEER");
       return getCampaigns(organization.id, cursor, campaignsFilter);


### PR DESCRIPTION
## Description

Allow organization owners to show the contact's last name and/or cell phone.

## Motivation and Context

This is a much requested feature for the membership contact use case (e.g. unions).

Closes #483

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<table border="1"><tr><td>Settings</td><td>

<img width="1178" alt="Spoke" src="https://user-images.githubusercontent.com/2145526/81693443-e84cae00-942d-11ea-936f-f1cc603865a6.png">

</td></tr><tr><td>Texter</td><td>

<img width="1440" alt="Spoke" src="https://user-images.githubusercontent.com/2145526/81693395-d0752a00-942d-11ea-9b00-121b13bfeb7a.png">

</td></tr></table>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

Added "Contact Information Display" section to the [Settings](https://docs.spokerewired.com/article/78-settings) article.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] My change requires a change to the documentation.
- [x] I have included updates for the documentation accordingly.
