### PR TITLE
fix: filter landlines

### DIFF
--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -335,6 +335,8 @@ export async function uploadContacts(job) {
 }
 
 export async function filterLandlines(job) {
+  const LRN_BATCH_SIZE = 1000;
+
   const { campaign_id } = job;
 
   const organization = await r
@@ -363,7 +365,8 @@ export async function filterLandlines(job) {
       .where({ campaign_id })
       .where("id", ">", highestId)
       .orderBy("id", "asc")
-      .select("id", "cell");
+      .select("id", "cell")
+      .limit(LRN_BATCH_SIZE);
 
     highestId = nextBatch.length > 0 ? nextBatch[nextBatch.length - 1].id : 0;
 

--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -365,7 +365,7 @@ export async function filterLandlines(job) {
       .orderBy("id", "asc")
       .select("id", "cell");
 
-    highestId = nextBatch[nextBatch.length - 1].id;
+    highestId = nextBatch.length > 0 ? nextBatch[nextBatch.length - 1].id : 0;
 
     numbersRequest.addPhoneNumbers(nextBatch.map(cc => cc.cell));
   } while (nextBatch.length > 0);


### PR DESCRIPTION
## Description

Handle the termination condition of the addPhoneNumbers loop. Also add a limit to the query.

## Motivation and Context

`nextBatch[nextBatch.length - 1].id` throws an error when nextBatch is an empty list.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
