### PR TITLE
fix: prevent passing empty array to addPhoneNumbers

### DIFF
--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -368,9 +368,10 @@ export async function filterLandlines(job) {
       .select("id", "cell")
       .limit(LRN_BATCH_SIZE);
 
-    highestId = nextBatch.length > 0 ? nextBatch[nextBatch.length - 1].id : 0;
-
-    numbersRequest.addPhoneNumbers(nextBatch.map(cc => cc.cell));
+    if (nextBatch.length > 0) {
+      highestId = nextBatch[nextBatch.length - 1].id;
+      await numbersRequest.addPhoneNumbers(nextBatch.map(cc => cc.cell));
+    }
   } while (nextBatch.length > 0);
 
   await numbersRequest.close();


### PR DESCRIPTION
## Description

Prevent trying to add an empty array of phone numbers.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Switchboard will accept an empty array but the will try to execute malformed SQL.

```sql
insert into lookup.accesses (request_id, phone_number)
values  -- empty here!
on conflict on constraint unique_phone_number_request do nothing
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
