### PR TITLE
fix: use fullscreen modal to fix overflow

### DIFF
--- a/src/components/IncomingMessageList/ConversationPreviewModal.jsx
+++ b/src/components/IncomingMessageList/ConversationPreviewModal.jsx
@@ -1,60 +1,71 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { StyleSheet, css } from "aphrodite";
-import Dialog from "material-ui/Dialog";
+
+import { CardActions } from "material-ui/Card";
+import Paper from "material-ui/Paper";
 import FlatButton from "material-ui/FlatButton";
 import IconButton from "material-ui/IconButton";
+import CloseIcon from "material-ui/svg-icons/navigation/close";
 import ChevronLeft from "material-ui/svg-icons/navigation/chevron-left";
 import ChevronRight from "material-ui/svg-icons/navigation/chevron-right";
 
 import MessageColumn from "./MessageColumn";
 import SurveyColumn from "./SurveyColumn";
 
-const headerStyles = {
-  container: {
-    display: "flex",
-    alignItems: "baseline"
-  },
-  heading: { flex: "1" }
-};
+const ConversationPreviewHeader = ({ campaignTitle, onRequestClose }) => (
+  <div
+    style={{
+      display: "flex",
+      alignItems: "baseline",
+      padding: "0 10px"
+    }}
+  >
+    <h2>
+      {campaignTitle
+        ? `Conversation Review: ${campaignTitle}`
+        : "Conversation Review"}
+    </h2>
+    <span style={{ flex: "1" }} />
+    <FlatButton
+      label="Close"
+      labelPosition="before"
+      icon={<CloseIcon />}
+      onClick={onRequestClose}
+    />
+  </div>
+);
 
 const columnStyles = StyleSheet.create({
   container: {
-    display: "flex"
+    display: "flex",
+    height: "100%"
   },
   column: {
     flex: 1,
+    display: "flex",
+    flexDirection: "column",
     padding: "0 10px 0 10px"
-  },
-  conversationRow: {
-    color: "white",
-    padding: "10px",
-    borderRadius: "5px",
-    fontWeight: "normal"
   }
 });
 
-const ConversationPreviewBody = props => {
-  const { conversation, organizationId } = props,
-    { contact, campaign } = conversation;
-  return (
-    <div className={css(columnStyles.container)}>
-      <div className={css(columnStyles.column)}>
-        <MessageColumn
-          conversation={conversation}
-          organizationId={organizationId}
-        />
-      </div>
-      <div className={css(columnStyles.column)}>
-        <SurveyColumn
-          contact={contact}
-          campaign={campaign}
-          organizationId={organizationId}
-        />
-      </div>
+const ConversationPreviewBody = ({ conversation, organizationId }) => (
+  <div className={css(columnStyles.container)}>
+    <div className={css(columnStyles.column)}>
+      <MessageColumn
+        conversation={conversation}
+        organizationId={organizationId}
+      />
     </div>
-  );
-};
+    <div className={css(columnStyles.column)}>
+      <SurveyColumn
+        contact={conversation.contact}
+        campaign={conversation.campaign}
+        organizationId={organizationId}
+      />
+    </div>
+  </div>
+);
 
 ConversationPreviewBody.propTypes = {
   conversation: PropTypes.object.isRequired,
@@ -71,48 +82,42 @@ const ConversationPreviewModal = props => {
     } = props,
     isOpen = conversation !== undefined;
 
-  const primaryActions = [
-    <FlatButton label="Close" primary={true} onClick={onRequestClose} />
-  ];
-
-  const customContentStyle = {
-    width: "100%",
-    maxWidth: "none"
-  };
-
-  const title = (
-    <div style={headerStyles.container}>
-      <div style={headerStyles.heading}>
-        {conversation
-          ? `Conversation Review: ${conversation.campaign.title}`
-          : "Conversation Review"}
-      </div>
-      <IconButton disabled={!navigation.previous} onClick={onRequestPrevious}>
-        <ChevronLeft />
-      </IconButton>
-      <IconButton disabled={!navigation.next} onClick={onRequestNext}>
-        <ChevronRight />
-      </IconButton>
-    </div>
-  );
-
   return (
-    <Dialog
-      title={title}
-      open={isOpen}
-      actions={primaryActions}
-      modal={false}
-      contentStyle={customContentStyle}
-      onRequestClose={onRequestClose}
+    <Paper
+      style={{
+        display: isOpen ? "flex" : "none",
+        flexDirection: "column",
+        position: "fixed",
+        top: "20px",
+        right: "20px",
+        bottom: "20px",
+        left: "20px",
+        zIndex: "1000"
+      }}
+      onClick={e => e.stopPropagation()}
     >
-      {isOpen && (
-        <ConversationPreviewBody
-          key={conversation.contact.id}
-          conversation={conversation}
-          organizationId={props.organizationId}
-        />
-      )}
-    </Dialog>
+      <ConversationPreviewHeader
+        campaignTitle={conversation && conversation.campaign.title}
+        onRequestClose={onRequestClose}
+      />
+      <div style={{ flex: "1 1 auto" }}>
+        {isOpen && (
+          <ConversationPreviewBody
+            key={conversation.contact.id}
+            conversation={conversation}
+            organizationId={props.organizationId}
+          />
+        )}
+      </div>
+      <CardActions>
+        <IconButton disabled={!navigation.previous} onClick={onRequestPrevious}>
+          <ChevronLeft />
+        </IconButton>
+        <IconButton disabled={!navigation.next} onClick={onRequestNext}>
+          <ChevronRight />
+        </IconButton>
+      </CardActions>
+    </Paper>
   );
 };
 

--- a/src/components/IncomingMessageList/MessageColumn/MessageList.jsx
+++ b/src/components/IncomingMessageList/MessageColumn/MessageList.jsx
@@ -28,7 +28,7 @@ class MessageList extends Component {
     return (
       <div
         ref="messageWindow"
-        style={{ maxHeight: "380px", overflowY: "scroll" }}
+        style={{ flex: "1 1 auto", height: "0px", overflowY: "scroll" }}
       >
         {this.props.messages.map((message, index) => {
           const isFromContact = message.isFromContact;
@@ -77,7 +77,7 @@ class MessageList extends Component {
 }
 
 MessageList.propTypes = {
-  userName: PropTypes.object.isRequired,
+  userNames: PropTypes.object.isRequired,
   messages: PropTypes.arrayOf(PropTypes.object).isRequired
 };
 

--- a/src/components/IncomingMessageList/MessageColumn/index.jsx
+++ b/src/components/IncomingMessageList/MessageColumn/index.jsx
@@ -4,6 +4,14 @@ import MessageList from "./MessageList";
 import MessageResponse from "./MessageResponse";
 import MessageOptOut from "./MessageOptOut";
 
+const styles = {
+  container: {
+    display: "flex",
+    flexDirection: "column",
+    height: "100%"
+  }
+};
+
 class MessageColumn extends Component {
   constructor(props) {
     super(props);
@@ -31,7 +39,7 @@ class MessageColumn extends Component {
       { contact } = conversation;
 
     return (
-      <div>
+      <div style={styles.container}>
         <h4>Messages</h4>
         <MessageList
           messages={messages}


### PR DESCRIPTION
## Description

This fixes content overflow problems in message review detail by using a full screen modal with working flexbox settings.

## Motivation and Context

Dialog's `autoDetectWindowHeight` setting was causing height calculation tension with flexbox.

## How Has This Been Tested?

This has been test locally with a few different window sizes.

## Screenshots (if appropriate):

<table border="1"><tr><td>

![Spoke](https://user-images.githubusercontent.com/2145526/82329254-04f96080-99af-11ea-9a9e-114fcbfb93d2.png)

</td></tr></table>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
