### PR TITLE
fix: handle case where campaign has no interaction steps

### DIFF
--- a/src/components/IncomingMessageList/SurveyColumn/ManageSurveyResponses.jsx
+++ b/src/components/IncomingMessageList/SurveyColumn/ManageSurveyResponses.jsx
@@ -104,7 +104,11 @@ class ManageSurveyResponses extends Component {
     let startingStep = interactionSteps.find(
       iStep => iStep.parentInteractionId === null
     );
-    const renderSteps = this.getResponsesFrom(startingStep.id);
+
+    // There may not be an interaction step, or it may not define a question
+    const renderSteps = startingStep
+      ? this.getResponsesFrom(startingStep.id)
+      : [];
 
     if (renderSteps.length === 0) {
       return <p>No answerable questions for this campaign.</p>;


### PR DESCRIPTION
## Description

Prevent React from crashing when a campaign does not have any interaction steps.

## Motivation and Context

This is unlikely to be case outside of development campaigns, but it should be handled nonetheless.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
