### PR TITLE
feat: display icon next to organizations with available assignments

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -68,6 +68,12 @@ const validators = {
       "Comma separated list of team IDs to restrict 'assignment complete' notifications to.",
     default: ""
   }),
+  ASSIGNMENT_SHOW_REQUESTS_AVAILABLE: bool({
+    desc:
+      "If enabled, display icons on the home page organization selection list indicating availability of assignments.",
+    default: false,
+    isClient: true
+  }),
   ASSIGNMENT_MANAGER_DATABASE_URL: str({
     desc:
       "Database url of external assignent manager - used by 'update-sms-spanish-speakers' cron job",

--- a/src/containers/Home.tsx
+++ b/src/containers/Home.tsx
@@ -164,27 +164,34 @@ const Home: React.SFC<HomeProps> = props => {
       return <Redirect to={`/${path}/${orgId}`} />;
     }
 
+    const showIcons = window.ASSIGNMENT_SHOW_REQUESTS_AVAILABLE;
+
     return (
       <div>
         <div className={css(styles.header)}>Select your organization</div>
-        <p>
-          Organizations with available assignments are marked with an amber
-          mailbox icon.
-        </p>
+        {showIcons && (
+          <p>
+            Organizations with available assignments are marked with an amber
+            mailbox icon.
+          </p>
+        )}
         <Paper style={{ margin: "15px auto", maxWidth: "450px" }}>
           <List>
             {memberships.map(({ node: membership }) => {
               const hasAssignments =
                 membership.organization.myCurrentAssignmentTargets.length > 0;
+              const leftIcon = showIcons ? (
+                hasAssignments ? (
+                  <MailboxIcon color={amber500} />
+                ) : (
+                  <NotificationsPausedIcon color={grey500} />
+                )
+              ) : (
+                undefined
+              );
               return (
                 <ListItem
-                  leftIcon={
-                    hasAssignments ? (
-                      <MailboxIcon color={amber500} />
-                    ) : (
-                      <NotificationsPausedIcon color={grey500} />
-                    )
-                  }
+                  leftIcon={leftIcon}
                   key={membership.organization.id}
                   primaryText={membership.organization.name}
                   onClick={handleSelectOrg(membership)}

--- a/src/containers/Home.tsx
+++ b/src/containers/Home.tsx
@@ -8,6 +8,9 @@ import { StyleSheet, css } from "aphrodite";
 
 import Paper from "material-ui/Paper";
 import { List, ListItem } from "material-ui/List";
+import { amber500, grey500 } from "material-ui/styles/colors";
+import MailboxIcon from "material-ui/svg-icons/action/markunread-mailbox";
+import NotificationsPausedIcon from "material-ui/svg-icons/social/notifications-paused";
 
 import { loadData } from "./hoc/with-operations";
 import { RelayPaginatedResponse } from "../api/types";
@@ -59,6 +62,9 @@ interface MembershipType {
   organization: {
     id: string;
     name: string;
+    myCurrentAssignmentTargets: {
+      maxRequestCount: number;
+    }[];
   };
 }
 
@@ -161,15 +167,30 @@ const Home: React.SFC<HomeProps> = props => {
     return (
       <div>
         <div className={css(styles.header)}>Select your organization</div>
+        <p>
+          Organizations with available assignments are marked with an amber
+          mailbox icon.
+        </p>
         <Paper style={{ margin: "15px auto", maxWidth: "450px" }}>
           <List>
-            {memberships.map(({ node: membership }) => (
-              <ListItem
-                key={membership.organization.id}
-                primaryText={membership.organization.name}
-                onClick={handleSelectOrg(membership)}
-              />
-            ))}
+            {memberships.map(({ node: membership }) => {
+              const hasAssignments =
+                membership.organization.myCurrentAssignmentTargets.length > 0;
+              return (
+                <ListItem
+                  leftIcon={
+                    hasAssignments ? (
+                      <MailboxIcon color={amber500} />
+                    ) : (
+                      <NotificationsPausedIcon color={grey500} />
+                    )
+                  }
+                  key={membership.organization.id}
+                  primaryText={membership.organization.name}
+                  onClick={handleSelectOrg(membership)}
+                />
+              );
+            })}
           </List>
         </Paper>
       </div>
@@ -204,6 +225,9 @@ const queries = {
                 organization {
                   id
                   name
+                  myCurrentAssignmentTargets {
+                    maxRequestCount
+                  }
                 }
               }
             }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -3,6 +3,7 @@
 interface Window {
   ALTERNATE_LOGIN_URL?: string;
   SUPPRESS_SELF_INVITE?: boolean;
+  ASSIGNMENT_SHOW_REQUESTS_AVAILABLE: boolean;
 }
 
 // This is a workaround while we are transitioning from JS to TS


### PR DESCRIPTION
## Description

Display an icon next to organizations that have available assignments.

## Motivation and Context

This makes it easier for texters to know where to head to when an instance has many organizations.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<table border="1"><tr><td>

![Spoke](https://user-images.githubusercontent.com/2145526/82342070-2febb080-99bf-11ea-87c9-2e8b2b725fc0.png)

</td></tr></table>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
