### PR TITLE
fix: pass expected error logging function to terminus

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -193,7 +193,7 @@ createTerminus(server, {
   onSignal,
   beforeShutdown,
   onShutdown,
-  logger
+  logger: (msg, err) => logger.error(`${msg}: `, err)
 });
 
 getRunner().then(() => {


### PR DESCRIPTION
## Description

Pass `logger` argument of expected type.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Terminus only logs errors and as such takes a specific logger argument expecting only an error message and error object.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I have tested this locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
