### PR TITLE
feat: improve assignment request webhook

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -54,6 +54,11 @@ const validators = {
     desc: "Webhook URL to notify when a texter assignment is requested.",
     default: undefined
   }),
+  ASSIGNMENT_REQUESTED_URL_REQUIRED: bool({
+    desc:
+      "Require successful assignment requested webhook to persist assignment request in Spoke.",
+    default: false
+  }),
   ASSIGNMENT_REQUESTED_TOKEN: str({
     desc: "Bearer token to use as authorization with ASSIGNMENT_REQUESTED_URL.",
     default: undefined

--- a/src/server/api/assignment.js
+++ b/src/server/api/assignment.js
@@ -886,7 +886,7 @@ export async function autoHandleRequest(pendingAssignmentRequest) {
     if (user_organization.request_status === "do_not_approve") {
       await r
         .knex("assignment_request")
-        .update({ status: "rejected " })
+        .update({ status: "rejected" })
         .where({ id: pendingAssignmentRequest.id });
     }
   }


### PR DESCRIPTION
## Description

- limit sending webhook to requests requiring manual approval
- add config option for whether webhook error fails the entire request
- include Slack user ID in webhook payload, if applicable
- fix request status typo causing postgres constraint to fail

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

For most users the value of assignment request notification webhooks is to notify admins they need to approve/deny a request. Notifications for auto assigned requests are noisy and can dramatically increase cost of services such as Zapier at high volume.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This has been tested locally with a combination of envvars and user assignment request modes.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

We do not currently document envvar webhooks anywhere. We probably should? Or continue to use those on a request-only basis?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
