### PR TITLE
fix: prevent crash on bad script preview token

### DIFF
--- a/src/server/routes/campaign-preview.js
+++ b/src/server/routes/campaign-preview.js
@@ -8,7 +8,12 @@ import { sortBy } from "lodash";
 router.get("/preview/:campaignId", async (req, res) => {
   const token = req.params.campaignId;
 
-  const campaignId = symmetricDecrypt(token);
+  let campaignId;
+  try {
+    campaignId = symmetricDecrypt(token);
+  } catch {
+    return res.status(400).send("bad token");
+  }
   const campaignPreviewHtml = await makeCampaignPreviewHtml(campaignId);
   return res.send(campaignPreviewHtml);
 });


### PR DESCRIPTION
## Description

Prevent Spoke crashing when provided a bad preview token.

## Motivation and Context

A bad preview token throws an unhandled `error:06065064:digital envelope routines:EVP_DecryptFinal_ex:bad decrypt`. This results in an unhandled promise rejection, killing the process.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
