### PR TITLE
improvement: source first_name, last_name, cell from Slack profile

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -598,7 +598,7 @@ const validators = {
   SLACK_SCOPES: str({
     desc: "Comma separated list Slack scopes to request.",
     example: "groups:read",
-    default: "identity.basic,identity.email,identity.team"
+    default: "users.profile:read"
   }),
   SLACK_CONVERT_EXISTING: bool({
     desc:


### PR DESCRIPTION
## Description

Default to sourcing first and last name from Slack profile.

## Motivation and Context

Slack provides these values, why not use them?

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

How Spoke names are determined for Slack should probably be documented as this is heavily used in script building.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
