### PR TITLE
fix: prevent clearing campaign logo image url

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     "hot-shots": "^6.3.0",
     "humps": "^1.1.0",
     "iconv-lite": "^0.5.1",
-    "is-url": "^1.2.2",
     "isomorphic-fetch": "^2.2.1",
     "knex": "^0.21.1",
     "lodash": "^4.13.1",

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -6,7 +6,6 @@ import camelCaseKeys from "camelcase-keys";
 import GraphQLDate from "graphql-date";
 import GraphQLJSON from "graphql-type-json";
 import { GraphQLError } from "graphql/error";
-import isUrl from "is-url";
 import request from "superagent";
 import _ from "lodash";
 import moment from "moment-timezone";
@@ -187,7 +186,7 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
     organization_id: organizationId,
     // TODO: re-enable once dynamic assignment is fixed (#548)
     // use_dynamic_assignment: useDynamicAssignment,
-    logo_image_url: isUrl(logoImageUrl) ? logoImageUrl : "",
+    logo_image_url: logoImageUrl,
     primary_color: primaryColor,
     intro_html: introHtml,
     texting_hours_start: textingHoursStart,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9639,11 +9639,6 @@ is-unc-path@^1.0.0:
   dependencies:
     unc-path-regex "^0.1.2"
 
-is-url@^1.2.2:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
-  integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
-
 is-utf8@^0.2.0, is-utf8@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Prevent clearing a campaign's logo image URL on save.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The logo was being cleared on every save unless it was explicitly being set to a valid URL in that
save. This removes the valid URL check (this should, if anything, be happening on the client) and
fixes the issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
