### PR TITLE
fix: check if returned record is an empty record

### DIFF
--- a/src/server/api/lib/message-sending.js
+++ b/src/server/api/lib/message-sending.js
@@ -121,7 +121,10 @@ export const getContactMessagingService = async (
   );
 
   // Return an existing match if there is one - this is the vast majority of cases
-  if (existingMessagingService) {
+  if (
+    existingMessagingService &&
+    existingMessagingService.messaging_service_sid
+  ) {
     return existingMessagingService;
   }
 


### PR DESCRIPTION
## Description

Ensure that existing messaging service actually contains values.

## Motivation and Context
The SQL function `get_messaging_service_for_campaign_contact_in_organization()` will always return a record. That record may be a real record, or it may consist of all null values. We must check for these null values in addition to just the presence of a record.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
