### PR TITLE
fix: delivery report handling

### DIFF
--- a/migrations/20200625084204_trigger_delivery_report_job.js
+++ b/migrations/20200625084204_trigger_delivery_report_job.js
@@ -1,0 +1,33 @@
+exports.up = function(knex) {
+  return knex.schema.raw(`
+    alter table public.log
+      add column service_type messaging_service_type;
+
+    create or replace function public.tg__log__handle_delivery_report() returns trigger as $$
+    begin
+      perform graphile_worker.add_job(
+        'handle-delivery-report',
+        row_to_json(NEW)
+      );
+
+      return NEW;
+    end;
+    $$ language plpgsql;
+
+    create trigger _500_handle_delivery_report
+      after insert
+      on log
+      for each row
+      execute procedure tg__log__handle_delivery_report();
+  `);
+};
+
+exports.down = function(knex) {
+  return knex.schema.raw(`
+    drop trigger _500_handle_delivery_report on log;
+
+    drop function public.tg__log__handle_delivery_report;
+
+    alter table public.log drop column service_type;
+  `);
+};

--- a/src/server/api/lib/twilio.js
+++ b/src/server/api/lib/twilio.js
@@ -316,7 +316,7 @@ const getMessageStatus = twilioStatus => {
 const handleDeliveryReport = async report =>
   r.knex("log").insert({
     message_sid: report.MessageSid,
-    service_type: ServiceTypes.AssembleNumbers,
+    service_type: ServiceTypes.Twilio,
     body: JSON.stringify(report)
   });
 

--- a/src/server/api/lib/twilio.js
+++ b/src/server/api/lib/twilio.js
@@ -1,9 +1,11 @@
-import { config } from "../../../config";
-import logger from "../../../logger";
-import { errToObj } from "../../utils";
 import Twilio from "twilio";
 import _ from "lodash";
 import moment from "moment-timezone";
+
+import { config } from "../../../config";
+import logger from "../../../logger";
+import { symmetricDecrypt } from "./crypto";
+import { errToObj } from "../../utils";
 import { getFormattedPhoneNumber } from "../../../lib/phone-format";
 import { r } from "../../models";
 import { sleep } from "../../../lib/utils";
@@ -16,7 +18,6 @@ import {
   saveNewIncomingMessage,
   messageComponents
 } from "./message-sending";
-import { symmetricDecrypt } from "./crypto";
 
 const MAX_SEND_ATTEMPTS = 5;
 const MESSAGE_VALIDITY_PADDING_SECONDS = 30;

--- a/src/server/api/lib/twilio.js
+++ b/src/server/api/lib/twilio.js
@@ -313,18 +313,12 @@ const getMessageStatus = twilioStatus => {
 // the delivery report itself rather than updating the message. We can then "replay"
 // the delivery reports back on the message table at a later date. We still attempt
 // to update the message record status (after a slight delay).
-async function handleDeliveryReport(report) {
-  const { MessageSid: service_id, MessageStatus } = report;
-
-  // Record the delivery report
-  const insertResult = await r.knex("log").insert({
-    message_sid: service_id,
+const handleDeliveryReport = async report =>
+  r.knex("log").insert({
+    message_sid: report.MessageSid,
     service_type: ServiceTypes.AssembleNumbers,
     body: JSON.stringify(report)
   });
-
-  return insertResult;
-}
 
 export const processDeliveryReport = async body => {
   const { MessageSid: service_id, MessageStatus } = body;

--- a/src/server/api/lib/types.ts
+++ b/src/server/api/lib/types.ts
@@ -1,0 +1,4 @@
+export const ServiceTypes = Object.freeze({
+  AssembleNumbers: "assemble-numbers",
+  Twilio: "twilio"
+});

--- a/src/server/tasks/handle-delivery-report.ts
+++ b/src/server/tasks/handle-delivery-report.ts
@@ -2,7 +2,8 @@ import { ServiceTypes } from "../api/lib/types";
 import { processDeliveryReport as processAssembleDeliveryReport } from "../api/lib/assemble-numbers";
 
 export const handleDeliveryReport = async (payload: any, _helpers: any) => {
-  const { service_type, body } = payload;
+  const { service_type, body: stringBody } = payload;
+  const body = JSON.parse(stringBody);
 
   if (service_type === ServiceTypes.AssembleNumbers) {
     await processAssembleDeliveryReport(body);

--- a/src/server/tasks/handle-delivery-report.ts
+++ b/src/server/tasks/handle-delivery-report.ts
@@ -1,0 +1,14 @@
+import { ServiceTypes } from "../api/lib/types";
+import { processDeliveryReport as processAssembleDeliveryReport } from "../api/lib/assemble-numbers";
+
+export const handleDeliveryReport = async (payload: any, _helpers: any) => {
+  const { service_type, body } = payload;
+
+  if (service_type === ServiceTypes.AssembleNumbers) {
+    await processAssembleDeliveryReport(body);
+  } else {
+    throw new Error(`Unknown service type ${service_type}`);
+  }
+};
+
+export default handleDeliveryReport;

--- a/src/server/tasks/handle-delivery-report.ts
+++ b/src/server/tasks/handle-delivery-report.ts
@@ -1,5 +1,6 @@
 import { ServiceTypes } from "../api/lib/types";
 import { processDeliveryReport as processAssembleDeliveryReport } from "../api/lib/assemble-numbers";
+import { processDeliveryReport as processTwilioDeliveryReport } from "../api/lib/twilio";
 
 export const handleDeliveryReport = async (payload: any, _helpers: any) => {
   const { service_type, body: stringBody } = payload;
@@ -7,6 +8,8 @@ export const handleDeliveryReport = async (payload: any, _helpers: any) => {
 
   if (service_type === ServiceTypes.AssembleNumbers) {
     await processAssembleDeliveryReport(body);
+  } else if (service_type === ServiceTypes.Twilio) {
+    await processTwilioDeliveryReport(body);
   } else {
     throw new Error(`Unknown service type ${service_type}`);
   }

--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -1,11 +1,11 @@
+import url from "url";
+import { Pool } from "pg";
 import { LogFunctionFactory, Logger, Runner } from "graphile-worker";
 import { run, loadYaml, PgComposeWorker } from "pg-compose";
 
 import { config } from "../config";
 import logger from "../logger";
 import handleAutoassignmentRequest from "./tasks/handle-autoassignment-request";
-import { Pool } from "pg";
-import url from "url";
 import { releaseStaleReplies } from "./tasks/release-stale-replies";
 
 const logFactory: LogFunctionFactory = scope => (level, message, meta) =>

--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -6,6 +6,7 @@ import { run, loadYaml, PgComposeWorker } from "pg-compose";
 import { config } from "../config";
 import logger from "../logger";
 import handleAutoassignmentRequest from "./tasks/handle-autoassignment-request";
+import handleDeliveryReport from "./tasks/handle-delivery-report";
 import { releaseStaleReplies } from "./tasks/release-stale-replies";
 
 const logFactory: LogFunctionFactory = scope => (level, message, meta) =>
@@ -36,6 +37,7 @@ export const getWorker = async (attempt = 0): Promise<PgComposeWorker> => {
 
   m.taskList!["handle-autoassignment-request"] = handleAutoassignmentRequest;
   m.taskList!["release-stale-replies"] = releaseStaleReplies;
+  m.taskList!["handle-delivery-report"] = handleDeliveryReport;
 
   m.cronJobs!.push({
     name: "release-stale-replies",


### PR DESCRIPTION
## Description

Handle delivery reports in a `graphile-worker` job rather than a delayed promise.

## Motivation and Context

Logs show many Postgres connection errors when trying to handle delivery reports. The problem seems to be related to the 5 second delay as a) the code is standard knex no different from elsewhere and b) we are not seeing a similar rate of connection errors elsewhere in the application.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
