### PR TITLE
fix: set default text request type for General team

### DIFF
--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1491,7 +1491,9 @@ const rootMutations = {
 
       const newOrganization = await r.knex.transaction(async trx => {
         const orgFeatures = {
+          textRequestFormEnabled: false,
           textRequestType: TextRequestType.UNSENT,
+          maxRequestCount: 100,
           defaulTexterApprovalStatus: RequestAutoApproveType.APPROVAL_REQUIRED
         };
         if (payload.org_features) {

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -15,6 +15,7 @@ import { getWorker } from "../worker";
 import { processContactsFile } from "./lib/edit-campaign";
 import { formatPage } from "./lib/pagination";
 import { emptyRelayPage } from "../../api/pagination";
+import { TextRequestType } from "../../api/organization";
 import { gzip, makeTree } from "../../lib";
 import { applyScript } from "../../lib/scripts";
 import { hasRole } from "../../lib/permissions";
@@ -1490,6 +1491,7 @@ const rootMutations = {
 
       const newOrganization = await r.knex.transaction(async trx => {
         const orgFeatures = {
+          textRequestType: TextRequestType.UNSENT,
           defaulTexterApprovalStatus: RequestAutoApproveType.APPROVAL_REQUIRED
         };
         if (payload.org_features) {


### PR DESCRIPTION
## Description

Set the default request type for the General team at organization creation time.

## Motivation and Context

If this is not set, the General team will not pick up autoassignment targets. Fixing this currently requires toggling the general team request type and saving after each switch.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
