### PR TITLE
fix: per-org graphile secret refs

### DIFF
--- a/src/server/api/lib/utils.ts
+++ b/src/server/api/lib/utils.ts
@@ -5,14 +5,14 @@ import moment from "moment-timezone";
  * Returns resolvers mapping GraphQL-style properties to their Postgres-style columns
  * @param {string[]} gqlKeys The lower camel case GraphQL keys to map
  */
-export const sqlResolvers = gqlKeys =>
+export const sqlResolvers = (gqlKeys: string[]) =>
   gqlKeys.reduce((accumulator, gqlKey) => {
     const sqlKey = humps.decamelize(gqlKey, { separator: "_" });
-    const resolver = instance => instance[sqlKey];
+    const resolver = (instance: { [key: string]: unknown }) => instance[sqlKey];
     return Object.assign(accumulator, { [gqlKey]: resolver });
   }, {});
 
-export const capitalizeWord = word => {
+export const capitalizeWord = (word?: string) => {
   if (word) {
     return word[0].toUpperCase() + word.slice(1);
   }
@@ -24,7 +24,7 @@ export const capitalizeWord = word => {
  * @param {string} timezoneName The timezone name
  * @returns {number} UTC offset in hours
  */
-export const getTzOffset = timezoneName => {
+export const getTzOffset = (timezoneName: string) => {
   // POSIX compatibility requires that the offsets are inverted
   // See: https://momentjs.com/timezone/docs/#/zone-object/offset/
   return moment.tz.zone(timezoneName).utcOffset(Date.now()) / -60;

--- a/src/server/api/lib/utils.ts
+++ b/src/server/api/lib/utils.ts
@@ -29,3 +29,6 @@ export const getTzOffset = (timezoneName: string) => {
   // See: https://momentjs.com/timezone/docs/#/zone-object/offset/
   return moment.tz.zone(timezoneName).utcOffset(Date.now()) / -60;
 };
+
+export const graphileSecretRef = (organizationId: string, ref: string) =>
+  `${organizationId}|${ref}`;

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -3125,9 +3125,7 @@ const rootMutations = {
       { organizationId, externalSystem },
       { user }
     ) => {
-      console.log("Doing creation");
       await accessRequired(user, organizationId, "ADMIN");
-      console.log(externalSystem);
 
       const truncatedKey = externalSystem.apiKey.slice(0, 5) + "********";
       const apiKeyRef = graphileSecretRef(organizationId, truncatedKey);


### PR DESCRIPTION
## Description

Adds the organization ID as part of the Graphile Secrets reference name.

## Motivation and Context

This allows using the same external system API key in multiple organizations.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
