### PR TITLE
chore: backfill org memberships for superadmins

### DIFF
--- a/migrations/20200723072159_backfill_superadmin_roles.js
+++ b/migrations/20200723072159_backfill_superadmin_roles.js
@@ -1,0 +1,33 @@
+exports.up = function(knex) {
+  return knex.schema.raw(`
+    create or replace function public.tg__user__backfill_superadmin_membership() returns trigger as $$
+    begin
+      insert into user_organization (user_id, organization_id, role)
+      select
+        NEW.id as user_id,
+        organization.id as organization_id,
+        'OWNER' as role
+      from organization
+      on conflict (user_id, organization_id)
+        do update set role = EXCLUDED.role;
+
+      return NEW;
+    end;
+    $$ language plpgsql;
+
+    create trigger _500_backfill_superadmin_membership
+      after update
+      on public.user
+      for each row
+      when (NEW.is_superadmin and NEW.is_superadmin is distinct from OLD.is_superadmin)
+      execute procedure tg__user__backfill_superadmin_membership();
+  `);
+};
+
+exports.down = function(knex) {
+  return knex.schema.raw(`
+    drop trigger _500_backfill_superadmin_membership on public.user;
+
+    drop function public.tg__user__backfill_superadmin_membership;
+  `);
+};


### PR DESCRIPTION
## Description

Making a user a superadmin now backfills `user_organization` memberships as `'OWNER'` for all organizations.

## Motivation and Context

This previously needed to be done manually.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
