### PR TITLE
feat: better auto vacuum parameters

### DIFF
--- a/migrations/20200727165444_better-autovacuum-parameters.js
+++ b/migrations/20200727165444_better-autovacuum-parameters.js
@@ -1,0 +1,25 @@
+exports.up = function(knex) {
+  return knex.schema.raw(`
+    alter table campaign_contact set (autovacuum_vacuum_scale_factor = 0, autovacuum_vacuum_threshold = 20000);
+    alter table message set (autovacuum_vacuum_scale_factor = 0, autovacuum_vacuum_threshold = 20000);
+    alter table messaging_service_stick set (autovacuum_vacuum_scale_factor = 0, autovacuum_vacuum_threshold = 20000);
+    alter table assignment_request set (autovacuum_vacuum_scale_factor = 0, autovacuum_vacuum_threshold = 5000);
+    alter table all_question_response set (autovacuum_vacuum_scale_factor = 0, autovacuum_vacuum_threshold = 2000);
+
+    alter table public.campaign_contact set (fillfactor = 50);
+    alter table public.message set (fillfactor = 50);
+  `);
+};
+
+exports.down = function(knex) {
+  return knex.schema.raw(`
+    alter table campaign_contact set (autovacuum_vacuum_scale_factor = 0.2, autovacuum_vacuum_threshold = 50);
+    alter table message set (autovacuum_vacuum_scale_factor = 0.2, autovacuum_vacuum_threshold = 50);
+    alter table messaging_service_stick set (autovacuum_vacuum_scale_factor = 0.2, autovacuum_vacuum_threshold = 50);
+    alter table assignment_request set (autovacuum_vacuum_scale_factor = 0.2, autovacuum_vacuum_threshold = 50);
+    alter table all_question_response set (autovacuum_vacuum_scale_factor = 0.2, autovacuum_vacuum_threshold = 50);
+
+    alter table public.campaign_contact set (fillfactor = 100);
+    alter table public.message set (fillfactor = 100);
+  `);
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Better autovacuum parameters for larger (50-100 million+ message) databases.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The default `autovacuum_scale_factor` of 0.2 leads to too infrequent autovacuum's of heavily updated tables, particularly campaign_contact. This makes many queries very CPU intensive with lots of scanning through dead tuples.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Many databases run these settings in production. This formalizes it to keep it standard across all deployments.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
