### PR TITLE
fix: invalidate cached external lists

### DIFF
--- a/migrations/20200801094746_clear_external_list_cache_on_refresh.js
+++ b/migrations/20200801094746_clear_external_list_cache_on_refresh.js
@@ -1,0 +1,66 @@
+exports.up = function(knex) {
+  return knex.raw(`
+    -- Delete existing external list records before kicking off fetch
+    create or replace function "public".queue_refresh_saved_lists(van_system_id uuid) returns void as $$
+    declare
+      v_username text;
+      v_api_key_ref text;
+      v_secret graphile_secrets.secrets;
+    begin
+      select username, api_key_ref
+      into v_username, v_api_key_ref
+      from external_system
+      where id = queue_refresh_saved_lists.van_system_id;
+
+      if v_api_key_ref is null then
+        raise 'No API key configured for with id %', queue_refresh_saved_lists.van_system_id;
+      end if;
+
+      delete from external_list
+      where system_id = queue_refresh_saved_lists.van_system_id;
+
+      perform graphile_worker.add_job(
+        'van-get-saved-lists',
+        json_build_object(
+          'username', v_username,
+          'api_key', json_build_object('__secret', v_api_key_ref),
+          'van_system_id', queue_refresh_saved_lists.van_system_id,
+          '__after', 'insert_saved_lists'
+        )
+      );
+    end;
+    $$ language plpgsql volatile SECURITY definer SET search_path = "public";
+  `);
+};
+
+exports.down = function(knex) {
+  return knex.raw(`
+    -- Revert function
+    create or replace function "public".queue_refresh_saved_lists(van_system_id uuid) returns void as $$
+    declare
+      v_username text;
+      v_api_key_ref text;
+      v_secret graphile_secrets.secrets;
+    begin
+      select username, api_key_ref
+      into v_username, v_api_key_ref
+      from external_system
+      where id = queue_refresh_saved_lists.van_system_id;
+
+      if v_api_key_ref is null then
+        raise 'No API key configured for with id %', queue_refresh_saved_lists.van_system_id;
+      end if;
+
+      perform graphile_worker.add_job(
+        'van-get-saved-lists',
+        json_build_object(
+          'username', v_username,
+          'api_key', json_build_object('__secret', v_api_key_ref),
+          'van_system_id', queue_refresh_saved_lists.van_system_id,
+          '__after', 'insert_saved_lists'
+        )
+      );
+    end;
+    $$ language plpgsql volatile SECURITY definer SET search_path = "public";
+  `);
+};

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -3215,11 +3215,6 @@ const rootMutations = {
       // Completely refresh external lists after auth credentials change to make sure we're
       // not caching lists the new credentials do not have access to
       if (authDidChange) {
-        await r
-          .knex("external_list")
-          .where({ system_id: savedSystem.id })
-          .del();
-
         await r.knex.raw("select * from public.queue_refresh_saved_lists(?)", [
           savedSystem.id
         ]);

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -3180,6 +3180,9 @@ const rootMutations = {
 
       await accessRequired(user, savedSystem.organization_id, "ADMIN");
 
+      // We will check if the password/API key changed below
+      let authDidChange = externalSystem.username !== savedSystem.username;
+
       const payload = {
         name: externalSystem.name,
         type: externalSystem.type.toLowerCase(),
@@ -3187,6 +3190,7 @@ const rootMutations = {
       };
 
       if (!externalSystem.apiKey.includes("*")) {
+        authDidChange = true;
         const truncatedKey = externalSystem.apiKey.slice(0, 5) + "********";
         const apiKeyRef = graphileSecretRef(
           savedSystem.organization_id,
@@ -3207,6 +3211,19 @@ const rootMutations = {
         .update(payload)
         .where({ id: externalSystemId })
         .returning("*");
+
+      // Completely refresh external lists after auth credentials change to make sure we're
+      // not caching lists the new credentials do not have access to
+      if (authDidChange) {
+        await r
+          .knex("external_list")
+          .where({ system_id: savedSystem.id })
+          .del();
+
+        await r.knex.raw("select * from public.queue_refresh_saved_lists(?)", [
+          savedSystem.id
+        ]);
+      }
 
       return updated;
     },

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -3166,6 +3166,11 @@ const rootMutations = {
         })
         .returning("*");
 
+      // Kick off initial list load
+      await r.knex.raw("select * from public.queue_refresh_saved_lists(?)", [
+        created.id
+      ]);
+
       return created;
     },
     editExternalSystem: async (


### PR DESCRIPTION
## Description

Clear cached external lists a) when the external system credentials have changed, and b) prior to re-fetching lists.

## Motivation and Context

Many users have been confused by VAN permissions. A common path is to:
1. Create a Spoke API key
1. Share VAN folder with Spoke API key
1. Create Integration with Spoke API key
1. Sync lists from VAN
1. Attempt to load list, but fail due to wrong API key type
1. Create new Hustle API key
1. DO NOT share VAN folder with Hustle API key
1. Re-fetch VAN lists
    - Hustle API key returns 0 lists (no shared folders)
    - Existing external lists from Spoke API key persist
1. Attempt to load list, but fail due to "invalid savedListId in context" -- Hustle API key does not have access to the saved list that the Spoke key fetched

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
