### PR TITLE
feat: deprioritize handling delivery reports

### DIFF
--- a/migrations/20200804190149_deprioritize-handle-delivery-reports.js
+++ b/migrations/20200804190149_deprioritize-handle-delivery-reports.js
@@ -1,0 +1,30 @@
+exports.up = function(knex) {
+  return knex.schema.raw(`
+    create or replace function public.tg__log__handle_delivery_report() returns trigger as $$
+    begin
+      perform graphile_worker.add_job(
+        'handle-delivery-report',
+        row_to_json(NEW),
+        priority := 5
+      );
+
+      return NEW;
+    end;
+    $$ language plpgsql;
+  `);
+};
+
+exports.down = function(knex) {
+  return knex.schema.raw(`
+    create or replace function public.tg__log__handle_delivery_report() returns trigger as $$
+    begin
+      perform graphile_worker.add_job(
+        'handle-delivery-report',
+        row_to_json(NEW)
+      );
+
+      return NEW;
+    end;
+    $$ language plpgsql;
+  `);
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When `handle-delivery-report` is queued now, it's priority is lower (a higher number) so that a build up of delivery reports doesn't affect more important jobs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
