### PR TITLE
fix(load-van-list): filter opt outs

### DIFF
--- a/migrations/20200804192137_fix-van-list-loading-opt-outs.js
+++ b/migrations/20200804192137_fix-van-list-loading-opt-outs.js
@@ -1,0 +1,47 @@
+exports.up = function(knex) {
+  return knex.schema.raw(`
+    create or replace function "public".insert_van_contact_batch_to_campaign_contact(record_list json) returns void as $$
+      insert into campaign_contact (campaign_id, external_id, first_name, last_name, zip, custom_fields, cell)
+      select
+        (r ->> 'campaign_id')::integer,
+        r ->> 'external_id',
+        r ->> 'first_name',
+        r ->> 'last_name',
+        r ->> 'zip',
+        r ->> 'custom_fields',
+        r ->> 'cell'
+      from json_array_elements(record_list) as r
+      where r ->> 'first_name' is not null
+        and r ->> 'last_name' is not null
+        and r ->> 'cell' is not null
+        and not exists (
+          select 1
+          from opt_out
+          where opt_out.cell = r->>'cell'
+            and opt_out.organization_id = ( select organization_id from campaign where id = campaign_id )
+        )
+      on conflict (campaign_id, cell) do nothing
+    $$ language sql volatile SECURITY definer SET search_path = "public";
+  `);
+};
+
+exports.down = function(knex) {
+  return knex.schema.raw(`
+    create or replace function "public".insert_van_contact_batch_to_campaign_contact(record_list json) returns void as $$
+    insert into campaign_contact (campaign_id, external_id, first_name, last_name, zip, custom_fields, cell)
+    select
+      (r ->> 'campaign_id')::integer,
+      r ->> 'external_id',
+      r ->> 'first_name',
+      r ->> 'last_name',
+      r ->> 'zip',
+      r ->> 'custom_fields',
+      r ->> 'cell'
+    from json_array_elements(record_list) as r
+    where r ->> 'first_name' is not null
+      and r ->> 'last_name' is not null
+      and r ->> 'cell' is not null
+    on conflict (campaign_id, cell) do nothing
+    $$ language sql volatile SECURITY definer SET search_path = "public";
+  `);
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Filter out opt outs when loading a list in from VAN.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When originally creating VAN list loading, we forgot to filter out opt outs. Opt outs were not being texted because of additional runtime checks, but texters would get served these contacts and then get errors when trying to text them. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
