### PR TITLE
fix: handle very large exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "express-basic-auth": "^1.2.0",
     "express-rate-limit": "^5.1.3",
     "express-winston": "^3.1.0",
+    "fast-csv": "^4.3.1",
     "fs": "^0.0.2",
     "google-libphonenumber": "^3.2.6",
     "graphile-scheduler": "^0.5.0",

--- a/src/workers/exports/gs-json.js
+++ b/src/workers/exports/gs-json.js
@@ -49,6 +49,14 @@ const upload = async (bucket, key, payload) => {
   });
 };
 
+const getUploadStream = async (bucket, key) => {
+  const uploadStream = await storage()
+    .bucket(bucket)
+    .file(key)
+    .createWriteStream({ gzip: true });
+  return uploadStream;
+};
+
 /**
  * Get a signed URL for an object that is valid for 24 hours.
  *
@@ -70,5 +78,6 @@ const getDownloadUrl = async (bucket, key) => {
 
 module.exports = {
   upload,
+  getUploadStream,
   getDownloadUrl
 };

--- a/src/workers/exports/gs-json.js
+++ b/src/workers/exports/gs-json.js
@@ -35,10 +35,7 @@ const storage = () => {
 const upload = async (bucket, key, payload) => {
   return new Promise(async (resolve, reject) => {
     try {
-      const uploadStream = await storage()
-        .bucket(bucket)
-        .file(key)
-        .createWriteStream({ gzip: true });
+      const uploadStream = await getUploadStream(bucket, key);
       uploadStream.write(payload);
       uploadStream.end();
       uploadStream.on("finish", resolve);

--- a/src/workers/exports/s3.js
+++ b/src/workers/exports/s3.js
@@ -1,5 +1,6 @@
 const AWS = require("aws-sdk");
 const { config } = require("../../config");
+const stream = require("stream");
 
 const { AWS_ENDPOINT: awsEndpoint } = config;
 
@@ -36,6 +37,21 @@ const upload = async (bucket, key, payload, endpointUrl) => {
 };
 
 /**
+ * Get a writeable upload stream
+ *
+ * @param {string} bucket Name of the S3 bucket to upload the object to
+ * @param {string} key Name of key of destination object
+ */
+const getUploadStream = async (bucket, key, endpointUrl) => {
+  const s3Client = createS3(bucket, endpointUrl);
+  const passThrough = new stream.PassThrough();
+  const uploadParams = { Key: key, Body: passThrough };
+  s3Client.upload(uploadParams);
+
+  return passThrough;
+};
+
+/**
  * Get a signed URL for an object that is valid for 24 hours.
  *
  * @param {string} bucket Name of the S3 bucket to upload the object to
@@ -56,5 +72,6 @@ const getDownloadUrl = async (bucket, key) => {
 
 module.exports = {
   upload,
+  getUploadStream,
   getDownloadUrl
 };

--- a/src/workers/exports/upload.ts
+++ b/src/workers/exports/upload.ts
@@ -31,3 +31,23 @@ export const uploadToCloud = async (key: string, payload: string) => {
   await upload(config.AWS_S3_BUCKET_NAME, prefixedKey, payload);
   return getDownloadUrl(config.AWS_S3_BUCKET_NAME, prefixedKey) as string;
 };
+
+export const getUploadStream = async (key: string) => {
+  if (!validS3Config && !validGcpHmacConfig && !validGcpConfig) {
+    logger.debug(`Would have saved ${key} to cloud storage`);
+    throw new Error("Invalid cloud storage configuration!");
+  }
+
+  const exportDriver = config.EXPORT_DRIVER as "s3" | "gs-json";
+  const { getUploadStream } = exporters[exportDriver];
+
+  const prefixedKey = `${config.AWS_S3_KEY_PREFIX}${key}`;
+  return await getUploadStream(config.AWS_S3_BUCKET_NAME, prefixedKey);
+};
+
+export const getDownloadUrl = async (key: string) => {
+  const exportDriver = config.EXPORT_DRIVER as "s3" | "gs-json";
+  const { getDownloadUrl } = exporters[exportDriver];
+  const prefixedKey = `${config.AWS_S3_KEY_PREFIX}${key}`;
+  return getDownloadUrl(config.AWS_S3_BUCKET_NAME, prefixedKey) as string;
+};

--- a/src/workers/jobs/index.js
+++ b/src/workers/jobs/index.js
@@ -13,6 +13,7 @@ import {
   saveNewIncomingMessage
 } from "../../server/api/lib/message-sending";
 import NumbersClient from "assemble-numbers-client";
+import { format } from "fast-csv";
 
 import AWS from "aws-sdk";
 import Papa from "papaparse";
@@ -23,7 +24,11 @@ import {
   Notifications,
   sendUserNotification
 } from "../../server/notifications";
-import { uploadToCloud } from "../exports/upload";
+import {
+  uploadToCloud,
+  getUploadStream,
+  getDownloadUrl
+} from "../exports/upload";
 import zipCodeToTimeZone from "zipcode-to-timezone";
 
 const CHUNK_SIZE = 1000;
@@ -539,10 +544,6 @@ export async function loadContactsFromDataWarehouseFragment(jobEvent) {
     .where("id", jobEvent.jobId)
     .select("status")
     .first();
-  logger.error("loadContactsFromDataWarehouseFragment toward end", {
-    completed,
-    jobEvent
-  });
 
   if (!completed) {
     logger.error("loadContactsFromDataWarehouseFragment job has been deleted", {
@@ -1415,8 +1416,33 @@ export async function exportCampaign(job) {
 
   const uniqueQuestionsByStepId = getUniqueQuestionsByStepId(interactionSteps);
 
+  // Attempt upload to cloud storage
+  let campaignContactsKey = campaignTitle
+    .replace(/ /g, "_")
+    .replace(/\//g, "_");
+
+  if (!isAutomatedExport) {
+    const timestamp = moment().format("YYYY-MM-DD-HH-mm-ss");
+    campaignContactsKey = `${campaignContactsKey}-${timestamp}`;
+  }
+  const messagesKey = `${campaignContactsKey}-messages`;
+
+  const campaignContactsUploadStream = await getUploadStream(
+    `${campaignContactsKey}.csv`
+  );
+  const campaignContactsWriteStream = format({
+    headers: true,
+    writeHeaders: true
+  });
+
+  campaignContactsWriteStream.pipe(campaignContactsUploadStream);
+
+  const messagesUploadStream = await getUploadStream(`${messagesKey}.csv`);
+  const messagesWriteStream = format({ headers: true, writeHeaders: true });
+
+  messagesWriteStream.pipe(messagesUploadStream);
+
   // Message rows
-  let messageRows = [];
   let lastContactId;
   try {
     let chunkMessageResult = undefined;
@@ -1428,14 +1454,22 @@ export async function exportCampaign(job) {
       ))
     ) {
       lastContactId = chunkMessageResult.lastContactId;
-      messageRows = messageRows.concat(chunkMessageResult.messages);
+      logger.info(
+        `Processing export for ${campaignId} chunk part`,
+        lastContactId
+      );
+      for (const m of chunkMessageResult.messages) {
+        messagesWriteStream.write(m);
+      }
     }
   } catch (exc) {
     logger.error("Error building message rows: ", exc);
   }
 
+  messagesWriteStream.end();
+  messagesUploadStream.end();
+
   // Contact rows
-  let contactRows = [];
   try {
     let chunkContactResult = undefined;
     lastContactId = 0;
@@ -1448,36 +1482,25 @@ export async function exportCampaign(job) {
       ))
     ) {
       lastContactId = chunkContactResult.lastContactId;
-      contactRows = contactRows.concat(chunkContactResult.contacts);
+      logger.info(
+        `Processing export for ${campaignId} chunk part`,
+        lastContactId
+      );
+      for (const c of chunkContactResult.contacts) {
+        campaignContactsWriteStream.write(c);
+      }
     }
   } catch (exc) {
     logger.error("Error building campaign contact rows: ", exc);
   }
 
-  // Create the CSV paylaods
-  let campaignsCsv = undefined,
-    messagesCsv = undefined;
-  try {
-    campaignsCsv = Papa.unparse(contactRows);
-    messagesCsv = Papa.unparse(messageRows);
-  } catch (exc) {
-    logger.error("Error building CSVs: ", exc);
-  }
-
-  // Attempt upload to cloud storage
-  let campaignContactsKey = campaignTitle
-    .replace(/ /g, "_")
-    .replace(/\//g, "_");
-  if (!isAutomatedExport) {
-    const timestamp = moment().format("YYYY-MM-DD-HH-mm-ss");
-    campaignContactsKey = `${campaignContactsKey}-${timestamp}`;
-  }
-  const messagesKey = `${campaignContactsKey}-messages`;
+  campaignContactsWriteStream.end();
+  campaignContactsUploadStream.end();
 
   try {
     const [campaignExportUrl, campaignMessagesExportUrl] = await Promise.all([
-      uploadToCloud(`${campaignContactsKey}.csv`, campaignsCsv),
-      uploadToCloud(`${messagesKey}.csv`, messagesCsv)
+      getDownloadUrl(`${campaignContactsKey}.csv`),
+      getDownloadUrl(`${messagesKey}.csv`)
     ]);
     if (!isAutomatedExport) {
       await sendEmail({

--- a/src/workers/jobs/index.js
+++ b/src/workers/jobs/index.js
@@ -539,6 +539,12 @@ export async function loadContactsFromDataWarehouseFragment(jobEvent) {
     .where("id", jobEvent.jobId)
     .increment("status", 1);
   const validationStats = {};
+
+  logger.error("loadContactsFromDataWarehouseFragment toward end", {
+    completed,
+    jobEvent
+  });
+
   const completed = await r
     .reader("job_request")
     .where("id", jobEvent.jobId)
@@ -1454,7 +1460,7 @@ export async function exportCampaign(job) {
       ))
     ) {
       lastContactId = chunkMessageResult.lastContactId;
-      logger.info(
+      logger.debug(
         `Processing export for ${campaignId} chunk part`,
         lastContactId
       );
@@ -1482,7 +1488,7 @@ export async function exportCampaign(job) {
       ))
     ) {
       lastContactId = chunkContactResult.lastContactId;
-      logger.info(
+      logger.debug(
         `Processing export for ${campaignId} chunk part`,
         lastContactId
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1232,10 +1232,33 @@
     lodash.isfunction "^3.0.9"
     lodash.isnil "^4.0.0"
 
+"@fast-csv/format@4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@fast-csv/format/-/format-4.3.1.tgz#e550731487002e0d1bac13422dd8506cdfd60f50"
+  integrity sha512-Ap6KSt0iJlzrivZU4grQzDGGOQ+vN5kvUeOHLF1BE7nWri1auiodgS3SCffvLe1Zvu79tACe1tw3dyBADk1NsA==
+  dependencies:
+    lodash.escaperegexp "^4.1.2"
+    lodash.isboolean "^3.0.3"
+    lodash.isequal "^4.5.0"
+    lodash.isfunction "^3.0.9"
+    lodash.isnil "^4.0.0"
+
 "@fast-csv/parse@4.3.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@fast-csv/parse/-/parse-4.3.0.tgz#3136c2c7cbe1933bd62f4f8dd3fb77eeaa11cd44"
   integrity sha512-uY4BARoVJtywTb4yI5b2vs7P+YGhwicKIIp0jAWSXhP8a5RuMwSVULkmqqj7pcICZmAUlfJytRjJFHXt39sRXw==
+  dependencies:
+    lodash.escaperegexp "^4.1.2"
+    lodash.groupby "^4.6.0"
+    lodash.isfunction "^3.0.9"
+    lodash.isnil "^4.0.0"
+    lodash.isundefined "^3.0.1"
+    lodash.uniq "^4.5.0"
+
+"@fast-csv/parse@4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@fast-csv/parse/-/parse-4.3.1.tgz#77db0e1dabb4df2946dca6a325ec334a96a06c6d"
+  integrity sha512-C73N77St4IHfVmT8Z2mWvLfvLyHWHyvGZVSG5mbhGefkmg9JztoaYpelf8ciqv99JzZ1ModpfuMWLwKEDTRL9A==
   dependencies:
     lodash.escaperegexp "^4.1.2"
     lodash.groupby "^4.6.0"
@@ -7364,6 +7387,15 @@ fast-csv@^4.3.0:
   dependencies:
     "@fast-csv/format" "4.3.0"
     "@fast-csv/parse" "4.3.0"
+    "@types/node" "^14.0.1"
+
+fast-csv@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/fast-csv/-/fast-csv-4.3.1.tgz#be7100756e4a168503e7937cb564f37a0aa58ec8"
+  integrity sha512-hCvT77K9fEVvR9iKt8OsOwbci/r1BHn8qcVOghjnllkHaKkpzjrc96IcLHC/2jpuPcPrzXpshk/TOqaRQZK8bA==
+  dependencies:
+    "@fast-csv/format" "4.3.1"
+    "@fast-csv/parse" "4.3.1"
     "@types/node" "^14.0.1"
 
 fast-deep-equal@^1.0.0:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changes exportCampaign to stream the entire export process. I also included some progress logs, which I think will help debug production exports in the future.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Our previous export code loaded all of the contents of the CSV into memory before writing them to S3. This would crash the Node VM for very large (500k+ contacts) campaigns, even on my local machine with 8GB of RAM.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has been tested locally with a very large campaign.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
