### PR TITLE
fix: use id as primary column

### DIFF
--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -66,8 +66,7 @@ export const resolvers = {
 
       const pagerOptions = {
         first,
-        after,
-        primaryColumn: "user_organization.id"
+        after
       };
 
       const { nameSearch, campaignId, campaignArchived } = filter || {};


### PR DESCRIPTION
## Description

Use `id` as primary ID column for pagination.

## Motivation and Context

`user_organization.id` is an invalid column name and thus all cursors were being set to base64-encoded `'undefined'`.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
