### PR TITLE
feat: allow hiding of campaign tags on archived campaigns via env var

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -397,6 +397,11 @@ const validators = {
     default: "/graphql",
     isClient: true
   }),
+  HIDE_CAMPAIGN_STATE_VARS_ON_ARCHIVED_CAMPAIGNS: bool({
+    desc:
+      "If true, campaign state tags on the campaigns list page will be hidden for archived campaigns",
+    default: false
+  }),
   CONTACT_FIELDS_TO_HIDE: str({
     desc:
       "A comma separated list of contact fields to not ship to the client. Can include 'external_id, cell, and lastName'",

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -323,6 +323,13 @@ export const resolvers = {
         return false;
       }
 
+      if (
+        config.HIDE_CAMPAIGN_STATE_VARS_ON_ARCHIVED_CAMPAIGNS &&
+        campaign.is_archived
+      ) {
+        return false;
+      }
+
       const getHasUnassignedContacts = memoizer.memoize(
         async ({ campaignId, archived }) => {
           // SQL injection for archived = to enable use of partial index
@@ -359,6 +366,13 @@ export const resolvers = {
       });
     },
     hasUnsentInitialMessages: async campaign => {
+      if (
+        config.HIDE_CAMPAIGN_STATE_VARS_ON_ARCHIVED_CAMPAIGNS &&
+        campaign.is_archived
+      ) {
+        return false;
+      }
+
       const getHasUnsentInitialMessages = memoizer.memoize(
         async ({ campaignId, archived }) => {
           const contacts = await r
@@ -382,6 +396,13 @@ export const resolvers = {
       });
     },
     hasUnhandledMessages: async campaign => {
+      if (
+        config.HIDE_CAMPAIGN_STATE_VARS_ON_ARCHIVED_CAMPAIGNS &&
+        campaign.is_archived
+      ) {
+        return false;
+      }
+
       const getHasUnhandledMessages = memoizer.memoize(
         async ({ campaignId, archived, organizationId }) => {
           let contactsQuery = r


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds an environment variable that hides attributes from the campaigns list page that are expensive to compute for archived campaigns.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows the archived campaigns list to predictably load even for instances with very large (500k+ archived campaigns).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
