### PR TITLE
fix(message-review): filter out empty messages

### DIFF
--- a/src/components/IncomingMessageList/MessageColumn/MessageList.jsx
+++ b/src/components/IncomingMessageList/MessageColumn/MessageList.jsx
@@ -25,11 +25,31 @@ class MessageList extends Component {
   }
 
   render() {
+    const messageContainerStyle = {
+      flex: "1 1 auto",
+      height: "0px",
+      overflowY: "scroll"
+    };
+
+    if (this.props.messages.length === 0) {
+      return (
+        <div style={messageContainerStyle}>
+          <p
+            style={{
+              backgroundColor: "#EEEEEE",
+              margin: "0 60px",
+              padding: "10px 0",
+              textAlign: "center"
+            }}
+          >
+            No messages yet
+          </p>
+        </div>
+      );
+    }
+
     return (
-      <div
-        ref="messageWindow"
-        style={{ flex: "1 1 auto", height: "0px", overflowY: "scroll" }}
-      >
+      <div ref="messageWindow" style={messageContainerStyle}>
         {this.props.messages.map((message, index) => {
           const isFromContact = message.isFromContact;
           const containerStyle = {

--- a/src/components/IncomingMessageList/index.jsx
+++ b/src/components/IncomingMessageList/index.jsx
@@ -162,20 +162,15 @@ export class IncomingMessageList extends Component {
           overflow: "scroll",
           whiteSpace: "pre-line"
         },
-        render: (columnKey, row) => {
-          if (row.messages && row.messages.length > 0) {
-            return (
-              <FlatButton
-                onClick={event => {
-                  event.stopPropagation();
-                  this.handleOpenConversation(row.index);
-                }}
-                icon={<ActionOpenInNew />}
-              />
-            );
-          }
-          return "";
-        }
+        render: (columnKey, row) => (
+          <FlatButton
+            onClick={event => {
+              event.stopPropagation();
+              this.handleOpenConversation(row.index);
+            }}
+            icon={<ActionOpenInNew />}
+          />
+        )
       }
     ];
   };

--- a/src/server/api/conversations.js
+++ b/src/server/api/conversations.js
@@ -293,8 +293,8 @@ export async function getConversations(
       }
 
       conversation.messages = contactMessages
-        // Sort ASC to display most recent _messages_ last
         .filter(messageRow => messageRow.mess_id !== null)
+        // Sort ASC to display most recent _messages_ last
         .sort((messageA, messageB) => messageA.created_at - messageB.created_at)
         .map(message => {
           return mapQueryFieldsToResolverFields(

--- a/src/server/api/conversations.js
+++ b/src/server/api/conversations.js
@@ -288,12 +288,13 @@ export async function getConversations(
 
       const conversation = _.omit(firstRow, messageFields);
 
-      if (firstRow) {
+      if (firstRow.created_at) {
         conversation.updated_at = firstRow.created_at;
       }
 
       conversation.messages = contactMessages
         // Sort ASC to display most recent _messages_ last
+        .filter(messageRow => messageRow.mess_id !== null)
         .sort((messageA, messageB) => messageA.created_at - messageB.created_at)
         .map(message => {
           return mapQueryFieldsToResolverFields(


### PR DESCRIPTION
## Description

Filter empty message records to fix UX issues.

## Motivation and Context

Grouping by campaign contact ID will always return at least one row, regardless of whether there are any messages. This caused `conversation.updated_at` to always be set to `message.created_at` even if that was `null`. `new Date(null).toLocaleString()` prints a nicely formatted UNIX epoch.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<table border="1"><tr><td>

![Screen Shot 2020-08-24 at 4 41 51 PM](https://user-images.githubusercontent.com/2145526/91094410-be0fac80-e628-11ea-997a-99a74d2c1782.png)

</td></tr></table>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
