### PR TITLE
fix: export for van pagination error

### DIFF
--- a/src/workers/jobs/export-for-van.ts
+++ b/src/workers/jobs/export-for-van.ts
@@ -72,7 +72,7 @@ export const exportForVan = async (job: JobRequestRecord) => {
            cc.first_name,
            cc.last_name,
            coalesce(result_values.value, 'canvassed, no response') as value,
-           to_char(result_values.created_at,'MM-DD-YYYY') as date
+           to_char(cc.created_at,'MM-DD-YYYY') as date
          from campaign_contact_ids cc
          left join (
            select campaign_contact_id, value, created_at

--- a/src/workers/jobs/export-for-van.ts
+++ b/src/workers/jobs/export-for-van.ts
@@ -77,7 +77,7 @@ export const exportForVan = async (job: JobRequestRecord) => {
          left join all_question_response aqr on cc.id = aqr.campaign_contact_id
          left join (
            select campaign_contact_id, value, created_at
-           from all_question_response
+           from question_response
            union
            select campaign_contact_id, title as value, cct.created_at
            from campaign_contact_tag cct

--- a/src/workers/jobs/export-for-van.ts
+++ b/src/workers/jobs/export-for-van.ts
@@ -74,7 +74,6 @@ export const exportForVan = async (job: JobRequestRecord) => {
            coalesce(result_values.value, 'canvassed, no response') as value,
            to_char(result_values.created_at,'MM-DD-YYYY') as date
          from campaign_contact_ids cc
-         left join all_question_response aqr on cc.id = aqr.campaign_contact_id
          left join (
            select campaign_contact_id, value, created_at
            from question_response

--- a/src/workers/jobs/export-for-van.ts
+++ b/src/workers/jobs/export-for-van.ts
@@ -78,7 +78,7 @@ export const exportForVan = async (job: JobRequestRecord) => {
          left join (
            select
             question_response.campaign_contact_id,
-            interaction_step.question || ': ' || question_response.value
+            interaction_step.question || ': ' || question_response.value as value
            from question_response
            join interaction_step on 
              question_response.interaction_step_id = interaction_step.id

--- a/src/workers/jobs/export-for-van.ts
+++ b/src/workers/jobs/export-for-van.ts
@@ -66,7 +66,7 @@ export const exportForVan = async (job: JobRequestRecord) => {
           limit ?
         )
         select
-          distinct on (cc.VAN_ID) VAN_ID,
+          cc.VAN_ID,
           cc.id as campaign_contact_id,
           cc.cell,
           cc.first_name,
@@ -78,6 +78,7 @@ export const exportForVan = async (job: JobRequestRecord) => {
           to_char(aqr.created_at,'MM-DD-YYYY') as date
         from campaign_contact_ids cc
         left join all_question_response aqr on cc.id = aqr.campaign_contact_id
+        order by cc.id asc
       `,
       [job.campaign_id, lastContactId, CHUNK_SIZE]
     );

--- a/src/workers/jobs/export-for-van.ts
+++ b/src/workers/jobs/export-for-van.ts
@@ -76,10 +76,16 @@ export const exportForVan = async (job: JobRequestRecord) => {
            to_char(cc.created_at,'MM-DD-YYYY') as date
          from campaign_contact_ids cc
          left join (
-           select campaign_contact_id, value, created_at
+           select
+            question_response.campaign_contact_id,
+            interaction_step.question || ': ' || question_response.value
            from question_response
+           join interaction_step on 
+             question_response.interaction_step_id = interaction_step.id
            union
-           select campaign_contact_id, title as value, cct.created_at
+           select
+            campaign_contact_id,
+            title as value
            from campaign_contact_tag cct
            join tag on cct.tag_id = tag.id
          ) result_values on result_values.campaign_contact_id = cc.id

--- a/src/workers/jobs/export-for-van.ts
+++ b/src/workers/jobs/export-for-van.ts
@@ -56,7 +56,8 @@ export const exportForVan = async (job: JobRequestRecord) => {
             cell,
             first_name,
             last_name,
-            ${vanIdSelector} as VAN_ID
+            ${vanIdSelector} as VAN_ID,
+            created_at
           from campaign_contact cc
           where
             campaign_id = ?


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a bug in the export for VAN pagination

## Description
<!--- Describe your changes in detail -->
Because we were using campaign_contact.id based pagination, but the outer query was not ordered by campaign_contact.id, we were iterating over some batches of contacts multiple times.

The removal of the distinct on was necessary to overcome [the issue described here](https://stackoverflow.com/questions/9795660/postgresql-distinct-on-with-different-order-by) - there are other solutions if we want it back, but my understanding of the VAN import process is that if there are multiple survey responses for a contact, we actually want multiple rows for that contact.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
