### PR TITLE
fix(assignable_campaigns): add due_by clause

### DIFF
--- a/migrations/20200903111251_exclude-overdue-campaigns-from-autoassignment.js
+++ b/migrations/20200903111251_exclude-overdue-campaigns-from-autoassignment.js
@@ -1,0 +1,27 @@
+
+exports.up = function(knex) {
+  return knex.schema.raw(`
+    create or replace view assignable_campaigns as (
+      select id, title, organization_id, limit_assignment_to_teams
+      from campaign
+      where is_started = true
+        and is_archived = false
+        and is_autoassign_enabled = true
+        and texting_hours_end > extract(hour from (CURRENT_TIMESTAMP at time zone campaign.timezone))
+        and now() < date_trunc('day', (due_by + interval '24 hours') at time zone campaign.timezone)
+    );
+  `)
+};
+
+exports.down = function(knex) {
+  return knex.schema.raw(`
+    create or replace view assignable_campaigns as (
+      select id, title, organization_id, limit_assignment_to_teams
+      from campaign
+      where is_started = true
+        and is_archived = false
+        and is_autoassign_enabled = true
+        and texting_hours_end > extract(hour from (CURRENT_TIMESTAMP at time zone campaign.timezone))
+    );
+  `)
+};

--- a/migrations/20200903111251_exclude-overdue-campaigns-from-autoassignment.js
+++ b/migrations/20200903111251_exclude-overdue-campaigns-from-autoassignment.js
@@ -1,7 +1,7 @@
 
 exports.up = function(knex) {
   return knex.schema.raw(`
-    create view assignable_campaigns_with_needs_message as (
+    create or replace view assignable_campaigns_with_needs_message as (
       select *
       from assignable_campaigns
       where
@@ -22,7 +22,7 @@ exports.up = function(knex) {
 
 exports.down = function(knex) {
   return knex.schema.raw(`
-    create view assignable_campaigns_with_needs_message as (
+    create or replace view assignable_campaigns_with_needs_message as (
       select *
       from assignable_campaigns
       where exists (

--- a/migrations/20200903111251_exclude-overdue-campaigns-from-autoassignment.js
+++ b/migrations/20200903111251_exclude-overdue-campaigns-from-autoassignment.js
@@ -1,27 +1,35 @@
 
 exports.up = function(knex) {
   return knex.schema.raw(`
-    create or replace view assignable_campaigns as (
-      select id, title, organization_id, limit_assignment_to_teams
-      from campaign
-      where is_started = true
-        and is_archived = false
-        and is_autoassign_enabled = true
-        and texting_hours_end > extract(hour from (CURRENT_TIMESTAMP at time zone campaign.timezone))
-        and now() < date_trunc('day', (due_by + interval '24 hours') at time zone campaign.timezone)
+    create view assignable_campaigns_with_needs_message as (
+      select *
+      from assignable_campaigns
+      where
+        exists (
+          select 1
+          from assignable_needs_message
+          where campaign_id = assignable_campaigns.id
+        )
+        and not exists (
+          select 1
+          from campaign
+          where campaign.id = assignable_campaigns.id
+            and now() > date_trunc('day', (due_by + interval '24 hours') at time zone campaign.timezone)
+        )
     );
   `)
 };
 
 exports.down = function(knex) {
   return knex.schema.raw(`
-    create or replace view assignable_campaigns as (
-      select id, title, organization_id, limit_assignment_to_teams
-      from campaign
-      where is_started = true
-        and is_archived = false
-        and is_autoassign_enabled = true
-        and texting_hours_end > extract(hour from (CURRENT_TIMESTAMP at time zone campaign.timezone))
+    create view assignable_campaigns_with_needs_message as (
+      select *
+      from assignable_campaigns
+      where exists (
+        select 1
+        from assignable_needs_message
+        where campaign_id = assignable_campaigns.id
+      )
     );
   `)
 };


### PR DESCRIPTION
This change prevents assignment to overdue campaigns. We had already intended this to be the correct behavior, but it appears had not implemented it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've tested the view definition locally as well as the correctness of the specific date_trunc / interval semantics on several production databases.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
