### PR TITLE
feat: allow filtering campaign overlaps by archived state

### DIFF
--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -176,6 +176,11 @@ const rootSchema = `
     found: Boolean
   }
 
+  input FetchCampaignOverlapInput {
+    targetCampaignId: String!
+    includeArchived: Boolean!
+  }
+
   type FetchCampaignOverlapResult {
     campaign: Campaign!,
     overlapCount: Int!
@@ -241,7 +246,7 @@ const rootSchema = `
     campaigns(organizationId:String!, cursor:OffsetLimitCursor, campaignsFilter: CampaignsFilter): CampaignsReturn
     people(organizationId:String!, cursor:OffsetLimitCursor, campaignsFilter:CampaignsFilter, role: String, userIds:[String]): UsersReturn
     peopleByUserIds(userIds:[String], organizationId:String!): UsersList
-    fetchCampaignOverlaps(organizationId: String!, campaignId: String!): [FetchCampaignOverlapResult]!
+    fetchCampaignOverlaps(input: FetchCampaignOverlapInput!): [FetchCampaignOverlapResult]!
     assignmentRequests(organizationId: String!, status: String): [AssignmentRequest]
     trollAlarms(organizationId: String!, limit: Int!, offset: Int!, token: String, dismissed: Boolean!): TrollAlarmPage!
     trollTokens(organizationId: String!): [TrollTrigger]

--- a/src/containers/AdminCampaignEdit/sections/CampaignOverlapManager.jsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignOverlapManager.jsx
@@ -6,6 +6,7 @@ import DataTable from "material-ui-datatables";
 import CircularProgress from "material-ui/CircularProgress";
 import RaisedButton from "material-ui/RaisedButton";
 import TextField from "material-ui/TextField";
+import Toggle from "material-ui/Toggle";
 
 import { loadData } from "../../hoc/with-operations";
 import LoadingIndicator from "../../../components/LoadingIndicator";
@@ -263,14 +264,8 @@ class CampaignOverlapManager extends React.Component {
 const queries = {
   fetchCampaignOverlaps: {
     query: gql`
-      query fetchCampaignOverlaps(
-        $organizationId: String!
-        $campaignId: String!
-      ) {
-        fetchCampaignOverlaps(
-          organizationId: $organizationId
-          campaignId: $campaignId
-        ) {
+      query fetchCampaignOverlaps($input: FetchCampaignOverlapInput!) {
+        fetchCampaignOverlaps(input: $input) {
           campaign {
             id
             title
@@ -282,8 +277,10 @@ const queries = {
     `,
     options: ownProps => ({
       variables: {
-        campaignId: ownProps.campaignId,
-        organizationId: ownProps.organizationId
+        input: {
+          targetCampaignId: ownProps.campaignId,
+          includeArchived: ownProps.includeArchived
+        }
       }
     })
   }
@@ -313,7 +310,35 @@ const mutations = {
   })
 };
 
-export default loadData({
+const WrappedCampaignOverlapManager = loadData({
   queries,
   mutations
 })(CampaignOverlapManager);
+
+class StateWrapper extends React.Component {
+  state = {
+    includeArchived: false
+  }
+
+  handleAutoReleaseToggle = (_e, includeArchived) =>
+    this.setState({ includeArchived });
+
+  render() {
+    const { includeArchived } = this.state;
+    return (
+      <div>
+        <Toggle
+          label={"Archived Campaigns"}
+          onToggle={this.handleAutoReleaseToggle}
+          toggled={includeArchived}
+        />
+        <WrappedCampaignOverlapManager
+          {...this.props}
+          includeArchived={includeArchived}
+        />
+      </div>
+    );
+  }
+}
+
+export default StateWrapper;

--- a/src/containers/AdminCampaignEdit/sections/CampaignOverlapManager.jsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignOverlapManager.jsx
@@ -328,7 +328,7 @@ class StateWrapper extends React.Component {
     return (
       <div>
         <Toggle
-          label={"Archived Campaigns"}
+          label={"Include archived campaigns"}
           onToggle={this.handleAutoReleaseToggle}
           toggled={includeArchived}
         />

--- a/src/server/api/campaign-overlap.js
+++ b/src/server/api/campaign-overlap.js
@@ -7,10 +7,11 @@ import { r } from "../models";
  * @param {Knex=} knexObject - Optional Knex instance to execute query with (for use within transaction).
  */
 export const queryCampaignOverlaps = async (
-  campaignId,
-  organizationId,
+  options,
   knexObject = undefined
 ) => {
+  const { campaignId, organizationId, includeArchived } = options;
+
   if (knexObject === undefined) knexObject = r.knex;
 
   const result = await knexObject.raw(
@@ -18,7 +19,9 @@ export const queryCampaignOverlaps = async (
     with campaign_ids_in_organization as (
       select id
       from campaign
-      where organization_id = ?
+      where
+        organization_id = ?
+        ${includeArchived ? "" : "and is_archived = false"}
     )
     select
       overlapping_cc.campaign_id,

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -3399,14 +3399,20 @@ const rootResolvers = {
       await accessRequired(user, organizationId, "SUPERVOLUNTEER");
       return getUsersById(userIds);
     },
-    fetchCampaignOverlaps: async (
-      _,
-      { organizationId, campaignId },
-      { user }
-    ) => {
+    fetchCampaignOverlaps: async (_, { input }, { user }) => {
+      const { targetCampaignId: campaignId, includeArchived } = input;
+      const { organization_id: organizationId } = await r
+        .knex("campaign")
+        .where({ id: campaignId })
+        .first(["organization_id"]);
+
       await accessRequired(user, organizationId, "ADMIN");
 
-      const { rows } = await queryCampaignOverlaps(campaignId, organizationId);
+      const { rows } = await queryCampaignOverlaps({
+        organizationId,
+        campaignId,
+        includeArchived
+      });
 
       const toReturn = rows.map(
         ({ campaign_id, count, campaign_title, last_activity }) => ({


### PR DESCRIPTION
## Description

Allow filtering campaign contact overlap results by archived status.

## Motivation and Context

Overlap query currently times out without additional backend campaign filtering.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<img width="1121" alt="Screen Shot 2020-09-10 at 4 06 03 PM" src="https://user-images.githubusercontent.com/2145526/92798007-976ba880-f380-11ea-8e9f-e18d31c2d391.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
