### PR TITLE
improvement: allow per-messaging service base url

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,6 +1,7 @@
 import transform from "lodash/transform";
 import isEqual from "lodash/isEqual";
 import isObject from "lodash/isObject";
+import { URL } from "url";
 
 export const sleep = (ms = 0) =>
   new Promise(resolve => setTimeout(resolve, ms));
@@ -24,3 +25,12 @@ export function difference(object, base) {
   }
   return changes(object, base);
 }
+
+export const stringIsAValidUrl = s => {
+  try {
+    new URL(s);
+    return true;
+  } catch (err) {
+    return false;
+  }
+};

--- a/src/server/api/lib/assemble-numbers.ts
+++ b/src/server/api/lib/assemble-numbers.ts
@@ -4,6 +4,7 @@ import isEmpty from "lodash/isEmpty";
 import { config } from "../../../config";
 import logger from "../../../logger";
 import { errToObj } from "../../utils";
+import { stringIsAValidUrl } from "../../../lib/utils";
 import { r } from "../../models";
 import { SendMessagePayload } from './types';
 import { MessagingServiceType, MessagingServiceRecord, RequestHandlerFactory } from "../types";
@@ -70,9 +71,16 @@ interface NumbersDeliveryReportPayload {
  * @returns Assemble Numbers JS client
  */
 export const numbersClient = async (service: MessagingServiceRecord) => {
-  const encryptedApiKey = service.encrypted_auth_token;
+  const {
+    account_sid: endpointBaseUrlMaybe,
+    encrypted_auth_token: encryptedApiKey
+  } = service;
+  const endpointBaseUrl =
+    stringIsAValidUrl(endpointBaseUrlMaybe)
+      ? endpointBaseUrlMaybe
+      : undefined;
   const apiKey = symmetricDecrypt(encryptedApiKey);
-  const client = makeNumbersClient(apiKey);
+  const client = makeNumbersClient({ apiKey, endpointBaseUrl });
   return client;
 };
 

--- a/src/server/lib/assemble-numbers.ts
+++ b/src/server/lib/assemble-numbers.ts
@@ -7,9 +7,8 @@ interface NumbersClientOptions {
   endpointBaseUrl?: string;
 }
 
-export const makeNumbersClient = (apiKey: string) => {
-  const options: NumbersClientOptions = { apiKey };
-  if (config.SWITCHBOARD_BASE_URL) {
+export const makeNumbersClient = (options: NumbersClientOptions) => {
+  if (!options.endpointBaseUrl && config.SWITCHBOARD_BASE_URL) {
     options.endpointBaseUrl = config.SWITCHBOARD_BASE_URL;
   }
   return new NumbersClient(options);

--- a/src/workers/jobs/index.js
+++ b/src/workers/jobs/index.js
@@ -359,7 +359,7 @@ export async function filterLandlines(job) {
     throw new Error("Cannot filter landlines - no numbers api key configured");
   }
 
-  const numbersClient = makeNumbersClient(numbersApiKey);
+  const numbersClient = makeNumbersClient({ apiKey: numbersApiKey });
   const numbersRequest = await numbersClient.lookup.createRequest();
 
   let highestId = 0;


### PR DESCRIPTION
## Description

Allow setting Switchboard base URL per-messaging profile.

## Motivation and Context

This may be necessary for load balancing extremely high throughput Spoke instances.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
