### PR TITLE
fix: invoke scrollTo only if conversation has messages

### DIFF
--- a/src/components/IncomingMessageList/MessageColumn/MessageList.jsx
+++ b/src/components/IncomingMessageList/MessageColumn/MessageList.jsx
@@ -17,11 +17,15 @@ const styles = StyleSheet.create({
 
 class MessageList extends Component {
   componentDidMount() {
-    this.refs.messageWindow.scrollTo(0, this.refs.messageWindow.scrollHeight);
+    if (this.refs.messageWindow) {
+      this.refs.messageWindow.scrollTo(0, this.refs.messageWindow.scrollHeight);
+    }
   }
 
   componentDidUpdate() {
-    this.refs.messageWindow.scrollTo(0, this.refs.messageWindow.scrollHeight);
+    if (this.refs.messageWindow) {
+      this.refs.messageWindow.scrollTo(0, this.refs.messageWindow.scrollHeight);
+    }
   }
 
   render() {


### PR DESCRIPTION
## Description

Invoke `scrollTo()` only if the `messageWindow` ref actually exists.

## Motivation and Context

The introduction of the "No messages yet" render branch means that the `messageWindow` ref may be undefined.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
