### PR TITLE
feat: remove 'GraphQl Error:' from error messages

### DIFF
--- a/src/components/IncomingMessageList/MessageColumn/MessageOptOut.jsx
+++ b/src/components/IncomingMessageList/MessageColumn/MessageOptOut.jsx
@@ -11,7 +11,6 @@ import {
   PrettyErrors,
   withOperations
 } from "../../../containers/hoc/with-operations";
-import { formatError } from "graphql";
 
 class MessageOptOut extends Component {
   constructor(props) {

--- a/src/components/IncomingMessageList/MessageColumn/MessageOptOut.jsx
+++ b/src/components/IncomingMessageList/MessageColumn/MessageOptOut.jsx
@@ -8,7 +8,6 @@ import Dialog from "material-ui/Dialog";
 
 import {
   formatErrorMessage,
-  PrettyErrors,
   withOperations
 } from "../../../containers/hoc/with-operations";
 
@@ -65,7 +64,7 @@ class MessageOptOut extends Component {
     try {
       const response = await this.props.mutations.removeOptOut(cell);
       if (response.errors) {
-        return <PrettyErrors errors={response.errors} />;
+        throw response.errors;
       }
       this.props.optOutChanged(false);
       this.handleCloseAlert();

--- a/src/components/IncomingMessageList/MessageColumn/MessageOptOut.jsx
+++ b/src/components/IncomingMessageList/MessageColumn/MessageOptOut.jsx
@@ -6,7 +6,12 @@ import FlatButton from "material-ui/FlatButton";
 import RaisedButton from "material-ui/RaisedButton";
 import Dialog from "material-ui/Dialog";
 
-import { withOperations } from "../../../containers/hoc/with-operations";
+import {
+  formatErrorMessage,
+  PrettyErrors,
+  withOperations
+} from "../../../containers/hoc/with-operations";
+import { formatError } from "graphql";
 
 class MessageOptOut extends Component {
   constructor(props) {
@@ -61,7 +66,7 @@ class MessageOptOut extends Component {
     try {
       const response = await this.props.mutations.removeOptOut(cell);
       if (response.errors) {
-        throw response.errors;
+        return <PrettyErrors errors={response.errors} />;
       }
       this.props.optOutChanged(false);
       this.handleCloseAlert();
@@ -75,7 +80,7 @@ class MessageOptOut extends Component {
       ];
       this.setState({
         dialogTitle: "Error Submitting",
-        dialogText: error.message,
+        dialogText: formatErrorMessage(error.message),
         dialogActions
       });
     } finally {
@@ -110,7 +115,7 @@ class MessageOptOut extends Component {
       ];
       this.setState({
         dialogTitle: "Error Opting Out",
-        dialogText: error.message,
+        dialogText: formatErrorMessage(error.message),
         dialogActions
       });
     } finally {

--- a/src/components/IncomingMessageList/SurveyColumn/ManageSurveyResponses.jsx
+++ b/src/components/IncomingMessageList/SurveyColumn/ManageSurveyResponses.jsx
@@ -7,7 +7,11 @@ import MenuItem from "material-ui/MenuItem";
 import Dialog from "material-ui/Dialog";
 import FlatButton from "material-ui/FlatButton";
 
-import { withOperations } from "../../../containers/hoc/with-operations";
+import {
+  formatErrorMessage,
+  PrettyErrors,
+  withOperations
+} from "../../../containers/hoc/with-operations";
 import LoadingIndicator from "../../LoadingIndicator";
 
 class ManageSurveyResponses extends Component {
@@ -83,7 +87,7 @@ class ManageSurveyResponses extends Component {
           questionResponses[iStepId] = value;
         }
       } catch (error) {
-        this.setState({ requestError: error.message });
+        this.setState({ requestError: formatErrorMessage(error) });
       } finally {
         this.setState({
           isMakingRequest: false,
@@ -168,7 +172,9 @@ const ManageSurveyResponsesWrapper = props => {
     <div>
       <h4>Survey Responses</h4>
       {surveyQuestions.loading && <LoadingIndicator />}
-      {surveyQuestions.errors && <p>{surveyQuestions.errors.message}</p>}
+      {surveyQuestions.errors && (
+        <PrettyErrors errors={surveyQuestions.errors} />
+      )}
       {surveyQuestions.campaign && (
         <ManageSurveyResponses
           campaign={surveyQuestions.campaign}

--- a/src/containers/AdminBulkScriptEditor/index.jsx
+++ b/src/containers/AdminBulkScriptEditor/index.jsx
@@ -94,9 +94,7 @@ class AdminBulkScriptEditor extends Component {
       const response = await this.props.mutations.bulkUpdateScript(
         findAndReplace
       );
-      if (response.errors) {
-        throw response.errors;
-      }
+      if (response.errors) throw response.errors;
       this.setState({ result: response.data.bulkUpdateScript });
     } catch (error) {
       this.setState({ error: formatErrorMessage(error.message) });

--- a/src/containers/AdminBulkScriptEditor/index.jsx
+++ b/src/containers/AdminBulkScriptEditor/index.jsx
@@ -9,11 +9,7 @@ import Dialog from "material-ui/Dialog";
 import FlatButton from "material-ui/FlatButton";
 import RaisedButton from "material-ui/RaisedButton";
 
-import {
-  formatErrorMessage,
-  PrettyErrors,
-  withOperations
-} from "../hoc/with-operations";
+import { formatErrorMessage, withOperations } from "../hoc/with-operations";
 import CampaignPrefixSelector from "./CampaignPrefixSelector";
 
 const PROTECTED_CHARACTERS = ["/"];
@@ -99,7 +95,7 @@ class AdminBulkScriptEditor extends Component {
         findAndReplace
       );
       if (response.errors) {
-        return <PrettyErrors errors={response.errors} />;
+        throw response.errors;
       }
       this.setState({ result: response.data.bulkUpdateScript });
     } catch (error) {

--- a/src/containers/AdminBulkScriptEditor/index.jsx
+++ b/src/containers/AdminBulkScriptEditor/index.jsx
@@ -9,7 +9,11 @@ import Dialog from "material-ui/Dialog";
 import FlatButton from "material-ui/FlatButton";
 import RaisedButton from "material-ui/RaisedButton";
 
-import { withOperations } from "../hoc/with-operations";
+import {
+  formatErrorMessage,
+  PrettyErrors,
+  withOperations
+} from "../hoc/with-operations";
 import CampaignPrefixSelector from "./CampaignPrefixSelector";
 
 const PROTECTED_CHARACTERS = ["/"];
@@ -94,10 +98,12 @@ class AdminBulkScriptEditor extends Component {
       const response = await this.props.mutations.bulkUpdateScript(
         findAndReplace
       );
-      if (response.errors) throw response.errors;
+      if (response.errors) {
+        return <PrettyErrors errors={response.errors} />;
+      }
       this.setState({ result: response.data.bulkUpdateScript });
     } catch (error) {
-      this.setState({ error: error.message });
+      this.setState({ error: formatErrorMessage(error.message) });
     } finally {
       this.setState({ isSubmitting: false });
     }

--- a/src/containers/AdminShortLinkDomains/index.jsx
+++ b/src/containers/AdminShortLinkDomains/index.jsx
@@ -9,7 +9,6 @@ import RaisedButton from "material-ui/RaisedButton";
 import ContentAddIcon from "material-ui/svg-icons/content/add";
 import CloudUploadIcon from "material-ui/svg-icons/file/cloud-upload";
 
-import { PrettyErrors, withOperations } from "../hoc/with-operations";
 import theme from "../../styles/theme";
 import LoadingIndicator from "../../components/LoadingIndicator";
 import ShortLinkDomainList from "./ShortLinkDomainList";
@@ -34,7 +33,7 @@ class AdminShortLinkDomains extends Component {
         isManuallyDisabled
       );
       if (response.errors) {
-        return <PrettyErrors errors={response.errors} />;
+        throw response.errors;
       }
     } catch (exc) {
       this.setState({ webRequestError: exc });
@@ -61,7 +60,7 @@ class AdminShortLinkDomains extends Component {
         maxUsageCount
       );
       if (response.errors) {
-        return <PrettyErrors errors={response.errors} />;
+        throw response.errors;
       }
       await this.props.shortLinkDomains.refetch();
     } catch (exc) {
@@ -85,7 +84,7 @@ class AdminShortLinkDomains extends Component {
     try {
       const response = await this.props.mutations.deleteLinkDomain(domainId);
       if (response.errors) {
-        return <PrettyErrors errors={response.errors} />;
+        throw response.errors;
       }
       await this.props.shortLinkDomains.refetch();
     } catch (exc) {
@@ -114,7 +113,7 @@ class AdminShortLinkDomains extends Component {
     }
 
     if (shortLinkDomains.errors) {
-      return <p>{shortLinkDomains.errors}</p>;
+      return <PrettyErrors errors={shortLinkDomains.errors} />;
     }
 
     const { linkDomains } = shortLinkDomains.organization;

--- a/src/containers/AdminShortLinkDomains/index.jsx
+++ b/src/containers/AdminShortLinkDomains/index.jsx
@@ -9,7 +9,7 @@ import RaisedButton from "material-ui/RaisedButton";
 import ContentAddIcon from "material-ui/svg-icons/content/add";
 import CloudUploadIcon from "material-ui/svg-icons/file/cloud-upload";
 
-import { withOperations } from "../hoc/with-operations";
+import { PrettyErrors, withOperations } from "../hoc/with-operations";
 import theme from "../../styles/theme";
 import LoadingIndicator from "../../components/LoadingIndicator";
 import ShortLinkDomainList from "./ShortLinkDomainList";
@@ -33,7 +33,9 @@ class AdminShortLinkDomains extends Component {
         domainId,
         isManuallyDisabled
       );
-      if (response.errors) throw new Error(response.errors);
+      if (response.errors) {
+        return <PrettyErrors errors={response.errors} />;
+      }
     } catch (exc) {
       this.setState({ webRequestError: exc });
     } finally {
@@ -58,7 +60,9 @@ class AdminShortLinkDomains extends Component {
         domain,
         maxUsageCount
       );
-      if (response.errors) throw new Error(response.errors);
+      if (response.errors) {
+        return <PrettyErrors errors={response.errors} />;
+      }
       await this.props.shortLinkDomains.refetch();
     } catch (exc) {
       this.setState({ webRequestError: exc });
@@ -80,7 +84,9 @@ class AdminShortLinkDomains extends Component {
     });
     try {
       const response = await this.props.mutations.deleteLinkDomain(domainId);
-      if (response.errors) throw new Error(response.errors);
+      if (response.errors) {
+        return <PrettyErrors errors={response.errors} />;
+      }
       await this.props.shortLinkDomains.refetch();
     } catch (exc) {
       this.setState({ webRequestError: exc });

--- a/src/containers/AdminShortLinkDomains/index.jsx
+++ b/src/containers/AdminShortLinkDomains/index.jsx
@@ -32,9 +32,7 @@ class AdminShortLinkDomains extends Component {
         domainId,
         isManuallyDisabled
       );
-      if (response.errors) {
-        throw response.errors;
-      }
+      if (response.errors) throw new Error(response.errors);
     } catch (exc) {
       this.setState({ webRequestError: exc });
     } finally {
@@ -59,9 +57,7 @@ class AdminShortLinkDomains extends Component {
         domain,
         maxUsageCount
       );
-      if (response.errors) {
-        throw response.errors;
-      }
+      if (response.errors) throw new Error(response.errors);
       await this.props.shortLinkDomains.refetch();
     } catch (exc) {
       this.setState({ webRequestError: exc });
@@ -83,9 +79,7 @@ class AdminShortLinkDomains extends Component {
     });
     try {
       const response = await this.props.mutations.deleteLinkDomain(domainId);
-      if (response.errors) {
-        throw response.errors;
-      }
+      if (response.errors) throw new Error(response.errors);
       await this.props.shortLinkDomains.refetch();
     } catch (exc) {
       this.setState({ webRequestError: exc });

--- a/src/containers/AdminTagEditor/index.jsx
+++ b/src/containers/AdminTagEditor/index.jsx
@@ -63,9 +63,7 @@ class AdminTagEditor extends Component {
     this.setState({ isWorking: true });
     try {
       const result = await this.props.mutations.saveTag(tag);
-      if (result.errors) {
-        return <PrettyErrors errors={result.errors} />;
-      }
+      if (result.errors) throw new Error(result.errors);
     } catch (error) {
       this.setState({ error: formatErrorMessage(error.message) });
     } finally {
@@ -97,7 +95,9 @@ class AdminTagEditor extends Component {
     const { editingTag, isWorking, error } = this.state;
 
     if (organizationTags.loading) return <LoadingIndicator />;
-    if (organizationTags.errors) return <p>{organizationTags.errors}</p>;
+    if (organizationTags.errors) {
+      return <PrettyErrors errors={organizationTags.errors} />;
+    }
 
     const { tagList } = organizationTags.organization;
 

--- a/src/containers/AdminTagEditor/index.jsx
+++ b/src/containers/AdminTagEditor/index.jsx
@@ -10,7 +10,7 @@ import Toggle from "material-ui/Toggle";
 import FlatButton from "material-ui/FlatButton";
 import ContentAddIcon from "material-ui/svg-icons/content/add";
 
-import { withOperations } from "../hoc/with-operations";
+import { formatErrorMessage, withOperations } from "../hoc/with-operations";
 import LoadingIndicator from "../../components/LoadingIndicator";
 import TagEditorList from "./TagEditorList";
 import theme from "../../styles/theme";
@@ -63,9 +63,11 @@ class AdminTagEditor extends Component {
     this.setState({ isWorking: true });
     try {
       const result = await this.props.mutations.saveTag(tag);
-      if (result.errors) throw new Error(result.errors);
+      if (result.errors) {
+        return <PrettyErrors errors={result.errors} />;
+      }
     } catch (error) {
-      this.setState({ error: error.message });
+      this.setState({ error: formatErrorMessage(error.message) });
     } finally {
       this.setState({ isWorking: false });
       this.handleCancelEditTag();
@@ -78,7 +80,7 @@ class AdminTagEditor extends Component {
       const result = await this.props.mutations.deleteTag(tagId);
       if (result.errors) throw new Error(result.errors);
     } catch (error) {
-      this.setState({ error: error.message });
+      this.setState({ error: formatErrorMessage(error.message) });
     } finally {
       this.setState({ isWorking: false });
     }

--- a/src/containers/AdminTeamEditor/index.jsx
+++ b/src/containers/AdminTeamEditor/index.jsx
@@ -9,7 +9,7 @@ import TextField from "material-ui/TextField";
 import FlatButton from "material-ui/FlatButton";
 import ContentAddIcon from "material-ui/svg-icons/content/add";
 
-import { withOperations } from "../hoc/with-operations";
+import { formatErrorMessage, withOperations } from "../hoc/with-operations";
 import LoadingIndicator from "../../components/LoadingIndicator";
 import TeamEditorList from "./TeamEditorList";
 import theme from "../../styles/theme";
@@ -57,9 +57,11 @@ class AdminTeamEditor extends Component {
     this.setState({ isWorking: true });
     try {
       const result = await this.props.mutations.saveTeams([team]);
-      if (result.errors) throw new Error(result.errors);
+      if (result.errors) {
+        return <PrettyErrors errors={result.errors} />;
+      }
     } catch (error) {
-      this.setState({ error: error.message });
+      this.setState({ error: formatErrorMessage(error.message) });
     } finally {
       this.setState({ isWorking: false });
       this.handleCancelEditTeam();
@@ -70,9 +72,11 @@ class AdminTeamEditor extends Component {
     this.setState({ isWorking: true });
     try {
       const result = await this.props.mutations.deleteTeam(teamId);
-      if (result.errors) throw new Error(result.errors);
+      if (result.errors) {
+        return <PrettyErrors errors={result.errors} />;
+      }
     } catch (error) {
-      this.setState({ error: error.message });
+      this.setState({ error: formatErrorMessage(error.message) });
     } finally {
       this.setState({ isWorking: false });
     }

--- a/src/containers/AdminTeamEditor/index.jsx
+++ b/src/containers/AdminTeamEditor/index.jsx
@@ -9,7 +9,11 @@ import TextField from "material-ui/TextField";
 import FlatButton from "material-ui/FlatButton";
 import ContentAddIcon from "material-ui/svg-icons/content/add";
 
-import { formatErrorMessage, withOperations } from "../hoc/with-operations";
+import {
+  formatErrorMessage,
+  PrettyErrors,
+  withOperations
+} from "../hoc/with-operations";
 import LoadingIndicator from "../../components/LoadingIndicator";
 import TeamEditorList from "./TeamEditorList";
 import theme from "../../styles/theme";
@@ -57,9 +61,7 @@ class AdminTeamEditor extends Component {
     this.setState({ isWorking: true });
     try {
       const result = await this.props.mutations.saveTeams([team]);
-      if (result.errors) {
-        return <PrettyErrors errors={result.errors} />;
-      }
+      if (result.errors) throw new Error(result.errors);
     } catch (error) {
       this.setState({ error: formatErrorMessage(error.message) });
     } finally {
@@ -72,9 +74,7 @@ class AdminTeamEditor extends Component {
     this.setState({ isWorking: true });
     try {
       const result = await this.props.mutations.deleteTeam(teamId);
-      if (result.errors) {
-        return <PrettyErrors errors={result.errors} />;
-      }
+      if (result.errors) throw new Error(result.errors);
     } catch (error) {
       this.setState({ error: formatErrorMessage(error.message) });
     } finally {
@@ -98,7 +98,9 @@ class AdminTeamEditor extends Component {
     const { editingTeam, isWorking, error } = this.state;
 
     if (organizationTeams.loading) return <LoadingIndicator />;
-    if (organizationTeams.errors) return <p>{organizationTeams.errors}</p>;
+    if (organizationTeams.errors) {
+      return <PrettyErrors errors={organizationTeams.errors} />;
+    }
 
     const { teams } = organizationTeams.organization;
 

--- a/src/containers/hoc/with-operations.jsx
+++ b/src/containers/hoc/with-operations.jsx
@@ -67,14 +67,21 @@ export const withOperations = options => {
   );
 };
 
-const PrettyErrors = ({ errors }) => (
-  <Card style={{ margin: "10px" }}>
-    <CardHeader title="Encountered errors" />
-    <CardText>
-      <ul>{errors.map((err, index) => <li key={index}>{err.message}</li>)}</ul>
-    </CardText>
-  </Card>
-);
+const PrettyErrors = ({ errors }) => {
+  return (
+    <Card style={{ margin: "10px" }}>
+      <CardHeader title="Encountered errors" />
+      <CardText>
+        <ul>
+          {errors.map((err, index) => {
+            const errMessageWithoutGraphQlPrefix = err.message.substring(14);
+            return <li key={index}>{errMessageWithoutGraphQlPrefix}</li>;
+          })}
+        </ul>
+      </CardText>
+    </Card>
+  );
+};
 
 /**
  * Similar to {@link withOperations}, but shows a loading indicator if any of the queries are loading.

--- a/src/containers/hoc/with-operations.jsx
+++ b/src/containers/hoc/with-operations.jsx
@@ -67,6 +67,7 @@ export const withOperations = options => {
   );
 };
 
+// remove 'GraphQL Error:' from error messages, per client request
 export const formatErrorMessage = error => {
   return error.message.substring(14);
 };

--- a/src/containers/hoc/with-operations.jsx
+++ b/src/containers/hoc/with-operations.jsx
@@ -69,7 +69,7 @@ export const withOperations = options => {
 
 // remove 'GraphQL Error:' from error messages, per client request
 export const formatErrorMessage = error => {
-  return error.message.substring(14);
+  return error.message.replaceAll("GraphQL Error:", "").trim();
 };
 
 export const PrettyErrors = ({ errors }) => {

--- a/src/containers/hoc/with-operations.jsx
+++ b/src/containers/hoc/with-operations.jsx
@@ -67,15 +67,18 @@ export const withOperations = options => {
   );
 };
 
-const PrettyErrors = ({ errors }) => {
+export const formatErrorMessage = error => {
+  return error.message.substring(14);
+};
+
+export const PrettyErrors = ({ errors }) => {
   return (
     <Card style={{ margin: "10px" }}>
       <CardHeader title="Encountered errors" />
       <CardText>
         <ul>
           {errors.map((err, index) => {
-            const errMessageWithoutGraphQlPrefix = err.message.substring(14);
-            return <li key={index}>{errMessageWithoutGraphQlPrefix}</li>;
+            return <li key={index}>{formatErrorMessage(err.message)}</li>;
           })}
         </ul>
       </CardText>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pr removes the 'GraphQl Error:' prefix from graphql error messages

## Motivation and Context
Per client request

## How Has This Been Tested?

Behaviorally.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [x ] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
