### PR TITLE
fix(slack): decrease sync rate to fix rate limiting

### DIFF
--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -75,7 +75,7 @@ export const getWorker = async (attempt = 0): Promise<PgComposeWorker> => {
       m.cronJobs!.push({
         name: "sync-slack-team-members",
         task_name: "sync-slack-team-members",
-        pattern: `*/1 * * * *`,
+        pattern: `*/10 * * * *`,
         time_zone: config.TZ
       });
     } else {


### PR DESCRIPTION
## Description

Slack sync jobs are erroring with `ratelimited` error. In the past we have been fine with a 10 minute window so revert back to that.

## Motivation and Context

Slack's [rate limiting rules](https://api.slack.com/docs/rate-limits) for the requests we make:

- [`admin.users.list`](https://api.slack.com/methods/admin.users.list) - Tier 3 (50+ per minute)
- [`conversations.list`](https://api.slack.com/methods/conversations.list) - Tier 2 (20+ per minute)
- [`conversations.members`](https://api.slack.com/methods/conversations.members) - Tier 4 (100+ per minute)

It seems like we should be fine, but obviously we are not. A 10-minute sync window is plenty.

## How Has This Been Tested?

This has been tested in that it has worked previously.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
