### PR TITLE
fix(trollbot): make primary key compound

### DIFF
--- a/migrations/20201004135336_fix_trollbot_pk.js
+++ b/migrations/20201004135336_fix_trollbot_pk.js
@@ -1,0 +1,15 @@
+exports.up = function(knex) {
+  return knex.schema.raw(`
+    alter table public.troll_trigger
+      drop constraint troll_trigger_pkey,
+      add primary key (token, organization_id);
+  `);
+};
+
+exports.down = function(knex) {
+  return knex.schema.raw(`
+    alter table public.troll_trigger
+      drop constraint troll_trigger_pkey,
+      add primary key (token);
+  `);
+};


### PR DESCRIPTION
## Description

The primary key on `token` alone prevented the same token from being added to multiple organizations.

## Motivation and Context

Token lists should be organization-scoped.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
