### PR TITLE
feat(trollbot): support all-string payloads

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -55,10 +55,6 @@ const validators = {
     desc: "Webhook URL to notify when a texter assignment is requested.",
     default: undefined
   }),
-  ASSIGNMENT_REQUESTED_ALL_STRINGS: bool({
-    desc: "If true, all payload values will be converted to strings.",
-    default: false
-  }),
   ASSIGNMENT_REQUESTED_URL_REQUIRED: bool({
     desc:
       "Require successful assignment requested webhook to persist assignment request in Spoke.",
@@ -769,6 +765,10 @@ const validators = {
   WAREHOUSE_DB_LAMBDA_ITERATION: bool({
     desc:
       "If the WAREHOUSE_DB connection/feature is enabled, then on AWS Lambda, queries that take longer than 5min can expire. This will enable incrementing through queries on new lambda invocations to avoid timeouts.",
+    default: false
+  }),
+  WEBHOOK_PAYLOAD_ALL_STRINGS: bool({
+    desc: "If true, all payload values will be converted to strings.",
     default: false
   }),
   WORKER_CONCURRENCY: num({

--- a/src/server/api/lib/alerts.js
+++ b/src/server/api/lib/alerts.js
@@ -28,7 +28,7 @@ const notifyAssignmentCreated = async options => {
     payload.externalUserId = externalUserId;
   }
 
-  if (config.ASSIGNMENT_REQUESTED_ALL_STRINGS) {
+  if (config.WEBHOOK_PAYLOAD_ALL_STRINGS) {
     payload = Object.fromEntries(
       Object.entries(payload).map(([key, value]) => [key, `${value}`])
     );

--- a/src/server/tasks/troll-patrol.ts
+++ b/src/server/tasks/troll-patrol.ts
@@ -81,7 +81,14 @@ export const trollPatrolForOrganization: Task = async (payload, helpers) => {
       [messageIds]
     );
     await Promise.all(
-      fullAlarms.map(alarm => request.post(trollbotWebhookUrl).send(alarm))
+      fullAlarms.map(alarm => {
+        const payload = config.WEBHOOK_PAYLOAD_ALL_STRINGS
+          ? Object.fromEntries(
+              Object.entries(alarm).map(([key, value]) => [key, `${value}`])
+            )
+          : alarm;
+        return request.post(trollbotWebhookUrl).send(payload);
+      })
     );
   }
 };


### PR DESCRIPTION
## Description

Extend string-only payload functionality to TrollBot alarm webhooks.

## Motivation and Context

Slack webhooks only accept payloads with string values.

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
