### PR TITLE
refactor: use unique constraint to prevent duplicates

### DIFF
--- a/migrations/20201019133129_unique_canned_response.js
+++ b/migrations/20201019133129_unique_canned_response.js
@@ -1,0 +1,12 @@
+exports.up = function(knex) {
+  return knex.schema.raw(`
+    alter table canned_response
+      add constraint unique_per_campaign unique (campaign_id, title);
+  `);
+};
+
+exports.down = function(knex) {
+  return knex.schema.raw(`
+    alter table canned_response drop constraint unique_per_campaign;
+  `);
+};

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1490,32 +1490,21 @@ const rootMutations = {
       return { id };
     },
 
-    createCannedResponse: async (_, { cannedResponse }, { user, loaders }) => {
-      authRequired(user);
+    createCannedResponse: async (_, { cannedResponse }, { user }) => {
+      const campaignId = parseInt(cannedResponse.campaignId, 10);
+      const { organization_id } = await r
+        .knex("campaign")
+        .where({ id: campaignId })
+        .first(["organization_id"]);
+      await accessRequired(user, organization_id, "TEXTER");
 
       await r.knex("canned_response").insert({
-        campaign_id: cannedResponse.campaignId,
+        campaign_id: campaignId,
         user_id: cannedResponse.userId,
         title: cannedResponse.title,
         text: cannedResponse.text
       });
-      // deletes duplicate created canned_responses
-      let query = r
-        .knex("canned_response")
-        .where(
-          "text",
-          "in",
-          r
-            .knex("canned_response")
-            .where({
-              text: cannedResponse.text,
-              campaign_id: cannedResponse.campaignId
-            })
-            .select("text")
-        )
-        .andWhere({ user_id: cannedResponse.userId })
-        .del();
-      await query;
+
       cacheableData.cannedResponse.clearQuery({
         campaignId: cannedResponse.campaignId,
         userId: cannedResponse.userId


### PR DESCRIPTION
## Description

Replace potentially-problematic de-duplication query with Postgres constraint.

## Motivation and Context

We do not allow texters to add canned responses from the UI. The GraphQL mutation could still be called, however. The previous delete duplicates query shouldn't have caused mass-deletion of canned responses as it was user-scoped but better to prevent duplicates using constraints.

## How Has This Been Tested?

This mutation is not currently used in our fork and thus was not tested.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
