### PR TITLE
fix: format sendBefore as string

### DIFF
--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -617,7 +617,8 @@ async function sendMessage(
     .tz(timezone)
     .startOf("day")
     .hour(endHour)
-    .utc();
+    .utc()
+    .toISOString();
 
   const { contactNumber, text } = message;
 


### PR DESCRIPTION
## Description

See title.

## Motivation and Context

Otherwise the raw Moment object is passed as an argument and never string-ified.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
