### PR TITLE
feat(tags): expose script, color and webhook url editing in tag editor

### DIFF
--- a/src/containers/AdminTagEditor/TagEditorList.jsx
+++ b/src/containers/AdminTagEditor/TagEditorList.jsx
@@ -41,7 +41,10 @@ class TagEditorList extends Component {
         {tags.map(tag => (
           <Paper key={tag.id} style={styles.card}>
             <div style={{ display: "flex" }}>
-              <Chip backgroundColor={"#DDEEEE"} style={styles.chip}>
+              <Chip
+                backgroundColor={tag.backgroundColor || "#DDEEEE"}
+                style={styles.chip}
+              >
                 {tag.title}
               </Chip>
             </div>

--- a/src/containers/AdminTagEditor/TagEditorList.jsx
+++ b/src/containers/AdminTagEditor/TagEditorList.jsx
@@ -41,7 +41,11 @@ class TagEditorList extends Component {
         {tags.map(tag => (
           <Paper key={tag.id} style={styles.card}>
             <div style={{ display: "flex" }}>
-              <Chip backgroundColor={tag.backgroundColor} style={styles.chip}>
+              <Chip
+                backgroundColor={tag.backgroundColor}
+                labelColor={tag.textColor}
+                style={styles.chip}
+              >
                 {tag.title}
               </Chip>
             </div>

--- a/src/containers/AdminTagEditor/TagEditorList.jsx
+++ b/src/containers/AdminTagEditor/TagEditorList.jsx
@@ -41,10 +41,7 @@ class TagEditorList extends Component {
         {tags.map(tag => (
           <Paper key={tag.id} style={styles.card}>
             <div style={{ display: "flex" }}>
-              <Chip
-                backgroundColor={tag.backgroundColor || "#DDEEEE"}
-                style={styles.chip}
-              >
+              <Chip backgroundColor={tag.backgroundColor} style={styles.chip}>
                 {tag.title}
               </Chip>
             </div>

--- a/src/containers/AdminTagEditor/index.jsx
+++ b/src/containers/AdminTagEditor/index.jsx
@@ -98,9 +98,9 @@ class AdminTagEditor extends Component {
     this.setState({ isEditingScript: !this.state.isEditingScript });
   };
 
-  handleEditTagScript = values => {
+  handleEditTagScript = script => {
     this.setState({
-      editingTag: { ...this.state.editingTag, onApplyScript: values },
+      editingTag: { ...this.state.editingTag, onApplyScript: script },
       isEditingScript: false
     });
   };
@@ -114,6 +114,12 @@ class AdminTagEditor extends Component {
   handleEditBackgroundColor = color => {
     this.setState({
       editingTag: { ...this.state.editingTag, backgroundColor: color }
+    });
+  };
+
+  handleEditWebhookUrl = url => {
+    this.setState({
+      editingTag: { ...this.state.editingTag, webhookUrl: url }
     });
   };
 
@@ -179,7 +185,6 @@ class AdminTagEditor extends Component {
                   value={editingTag.title || ""}
                   onChange={this.createTagEditorHandle}
                 />
-                <br />
                 <TextField
                   name="description"
                   floatingLabelText="Tag description"
@@ -187,7 +192,6 @@ class AdminTagEditor extends Component {
                   value={editingTag.description || ""}
                   onChange={this.createTagEditorHandle}
                 />
-                <br />
                 <GSScriptField
                   name="Script"
                   label="Tag script"
@@ -197,7 +201,6 @@ class AdminTagEditor extends Component {
                   onChange={this.handleEditTagScript}
                   onClick={this.handleOpenScriptEditor}
                 />
-                <br />
               </div>
               <div>
                 <ColorPicker
@@ -207,13 +210,18 @@ class AdminTagEditor extends Component {
                   value={editingTag.textColor || ""}
                   onChange={this.handleEditTextColor}
                 />
-                <br />
                 <ColorPicker
                   name="Background Color"
                   floatingLabelText="Background color"
                   defaultValue={editingTag.backgroundColor}
                   value={editingTag.backgroundColor || ""}
                   onChange={this.handleEditBackgroundColor}
+                />
+                <TextField
+                  name="webhookUrl"
+                  floatingLabelText="Webhook url"
+                  value={editingTag.webhookUrl || ""}
+                  onChange={this.createTagEditorHandle}
                 />
               </div>
             </div>
@@ -261,6 +269,7 @@ const queries = {
             onApplyScript
             textColor
             backgroundColor
+            webhookUrl
             createdAt
           }
         }

--- a/src/containers/AdminTagEditor/index.jsx
+++ b/src/containers/AdminTagEditor/index.jsx
@@ -175,7 +175,7 @@ class AdminTagEditor extends Component {
               style={{
                 display: "flex",
                 flexDirection: "row",
-                justifyContent: "space-evenly"
+                justifyContent: "space-between"
               }}
             >
               <div>
@@ -183,13 +183,6 @@ class AdminTagEditor extends Component {
                   name="title"
                   floatingLabelText="Tag title"
                   value={editingTag.title || ""}
-                  onChange={this.createTagEditorHandle}
-                />
-                <TextField
-                  name="description"
-                  floatingLabelText="Tag description"
-                  multiLine={true}
-                  value={editingTag.description || ""}
                   onChange={this.createTagEditorHandle}
                 />
                 <GSScriptField
@@ -210,6 +203,13 @@ class AdminTagEditor extends Component {
                 />
               </div>
               <div>
+                <TextField
+                  name="description"
+                  floatingLabelText="Tag description"
+                  multiLine={true}
+                  value={editingTag.description || ""}
+                  onChange={this.createTagEditorHandle}
+                />
                 <ColorPicker
                   name="Text Color"
                   floatingLabelText="Text color"
@@ -224,14 +224,16 @@ class AdminTagEditor extends Component {
                   value={editingTag.backgroundColor || ""}
                   onChange={this.handleEditBackgroundColor}
                 />
-                <TextField
-                  name="webhookUrl"
-                  floatingLabelText="Webhook url"
-                  value={editingTag.webhookUrl || ""}
-                  onChange={this.createTagEditorHandle}
-                />
               </div>
             </div>
+            <TextField
+              name="webhookUrl"
+              floatingLabelText="Webhook url"
+              hintText="If set, a request will be sent to this URL whenever this tag is applied."
+              value={editingTag.webhookUrl || ""}
+              onChange={this.createTagEditorHandle}
+              fullWidth
+            />
           </Dialog>
         )}
         <Dialog

--- a/src/containers/AdminTagEditor/index.jsx
+++ b/src/containers/AdminTagEditor/index.jsx
@@ -9,6 +9,7 @@ import TextField from "material-ui/TextField";
 import Toggle from "material-ui/Toggle";
 import FlatButton from "material-ui/FlatButton";
 import ContentAddIcon from "material-ui/svg-icons/content/add";
+import ColorPicker from "material-ui-color-picker";
 
 import { formatErrorMessage, withOperations } from "../hoc/with-operations";
 import LoadingIndicator from "../../components/LoadingIndicator";
@@ -104,6 +105,18 @@ class AdminTagEditor extends Component {
     });
   };
 
+  handleEditTextColor = color => {
+    this.setState({
+      editingTag: { ...this.state.editingTag, textColor: color }
+    });
+  };
+
+  handleEditBackgroundColor = color => {
+    this.setState({
+      editingTag: { ...this.state.editingTag, backgroundColor: color }
+    });
+  };
+
   render() {
     const { organizationTags } = this.props;
     const { editingTag, isWorking, error } = this.state;
@@ -152,30 +165,58 @@ class AdminTagEditor extends Component {
             open={true}
             onRequestClose={this.handleCancelEditTag}
           >
-            <TextField
-              name="title"
-              floatingLabelText="Tag title"
-              value={editingTag.title || ""}
-              onChange={this.createTagEditorHandle}
-            />
-            <br />
-            <TextField
-              name="description"
-              floatingLabelText="Tag description"
-              multiLine={true}
-              value={editingTag.description || ""}
-              onChange={this.createTagEditorHandle}
-            />
-            <br />
-            <GSScriptField
-              name="Script"
-              label="Tag Script"
-              context="tagEditor"
-              customFields={customFields}
-              value={editingTag.onApplyScript || ""}
-              onChange={this.handleEditTagScript}
-              onClick={this.handleOpenScriptEditor}
-            />
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "row",
+                justifyContent: "space-evenly"
+              }}
+            >
+              <div>
+                <TextField
+                  name="title"
+                  floatingLabelText="Tag title"
+                  value={editingTag.title || ""}
+                  onChange={this.createTagEditorHandle}
+                />
+                <br />
+                <TextField
+                  name="description"
+                  floatingLabelText="Tag description"
+                  multiLine={true}
+                  value={editingTag.description || ""}
+                  onChange={this.createTagEditorHandle}
+                />
+                <br />
+                <GSScriptField
+                  name="Script"
+                  label="Tag script"
+                  context="tagEditor"
+                  customFields={customFields}
+                  value={editingTag.onApplyScript || ""}
+                  onChange={this.handleEditTagScript}
+                  onClick={this.handleOpenScriptEditor}
+                />
+                <br />
+              </div>
+              <div>
+                <ColorPicker
+                  name="Text Color"
+                  floatingLabelText="Text color"
+                  defaultValue={editingTag.textColor}
+                  value={editingTag.textColor || ""}
+                  onChange={this.handleEditTextColor}
+                />
+                <br />
+                <ColorPicker
+                  name="Background Color"
+                  floatingLabelText="Background color"
+                  defaultValue={editingTag.backgroundColor}
+                  value={editingTag.backgroundColor || ""}
+                  onChange={this.handleEditBackgroundColor}
+                />
+              </div>
+            </div>
             <br />
             <br />
             <Toggle
@@ -218,6 +259,8 @@ const queries = {
             isSystem
             isAssignable
             onApplyScript
+            textColor
+            backgroundColor
             createdAt
           }
         }

--- a/src/containers/AdminTagEditor/index.jsx
+++ b/src/containers/AdminTagEditor/index.jsx
@@ -201,6 +201,13 @@ class AdminTagEditor extends Component {
                   onChange={this.handleEditTagScript}
                   onClick={this.handleOpenScriptEditor}
                 />
+                <br />
+                <Toggle
+                  name="isAssignable"
+                  label="Allow assignment?"
+                  toggled={editingTag.isAssignable}
+                  onToggle={this.createTagEditorHandle}
+                />
               </div>
               <div>
                 <ColorPicker
@@ -225,14 +232,6 @@ class AdminTagEditor extends Component {
                 />
               </div>
             </div>
-            <br />
-            <br />
-            <Toggle
-              name="isAssignable"
-              label="Allow assignment?"
-              toggled={editingTag.isAssignable}
-              onToggle={this.createTagEditorHandle}
-            />
           </Dialog>
         )}
         <Dialog

--- a/src/containers/AdminTagEditor/index.jsx
+++ b/src/containers/AdminTagEditor/index.jsx
@@ -93,13 +93,14 @@ class AdminTagEditor extends Component {
     this.setState({ editingTag });
   };
 
-  handleSetEditingScript = () => {
+  handleOpenScriptEditor = () => {
     this.setState({ isEditingScript: !this.state.isEditingScript });
   };
 
   handleEditTagScript = values => {
     this.setState({
-      editingTag: { ...this.state.editingTag, onApplyScript: values }
+      editingTag: { ...this.state.editingTag, onApplyScript: values },
+      isEditingScript: false
     });
   };
 
@@ -121,7 +122,8 @@ class AdminTagEditor extends Component {
       <FlatButton label={tagVerb} primary={true} onClick={this.handleSaveTag} />
     ];
 
-    // required in GSScriptField
+    // Custom fields are campaign-specific and thus cannot be used in Tag scripts.
+    // However, this is a required prop for GSScriptField
     const customFields = [""];
 
     const errorActions = [
@@ -172,7 +174,7 @@ class AdminTagEditor extends Component {
               customFields={customFields}
               value={editingTag.onApplyScript || ""}
               onChange={this.handleEditTagScript}
-              onClick={this.handleSetEditingScript}
+              onClick={this.handleOpenScriptEditor}
             />
             <br />
             <br />

--- a/src/containers/AdminTagEditor/index.jsx
+++ b/src/containers/AdminTagEditor/index.jsx
@@ -1,6 +1,4 @@
 import React, { Component } from "react";
-import * as yup from "yup";
-import Form from "react-formal";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
 import pick from "lodash/pick";
@@ -17,8 +15,6 @@ import LoadingIndicator from "../../components/LoadingIndicator";
 import TagEditorList from "./TagEditorList";
 import theme from "../../styles/theme";
 
-import { dataTest } from "../../lib/attributes";
-import GSForm from "../../components/forms/GSForm";
 import GSScriptField from "../../components/forms/GSScriptField";
 
 class AdminTagEditor extends Component {

--- a/src/containers/AdminTagEditor/index.jsx
+++ b/src/containers/AdminTagEditor/index.jsx
@@ -19,12 +19,12 @@ import theme from "../../styles/theme";
 
 import { dataTest } from "../../lib/attributes";
 import GSForm from "../../components/forms/GSForm";
+import GSScriptField from "../../components/forms/GSScriptField";
 
 class AdminTagEditor extends Component {
   state = {
     editingTag: undefined,
     isWorking: false,
-    isEditingScript: false,
     error: undefined
   };
 
@@ -51,7 +51,8 @@ class AdminTagEditor extends Component {
 
   handleEditTag = tagId => this.setState({ editingTag: this.getTag(tagId) });
 
-  handleCancelEditTag = () => this.setState({ editingTag: undefined });
+  handleCancelEditTag = () =>
+    this.setState({ editingTag: undefined, isEditingScript: false });
 
   handleSaveTag = async () => {
     const { editingTag } = this.state;
@@ -100,13 +101,15 @@ class AdminTagEditor extends Component {
     this.setState({ isEditingScript: !this.state.isEditingScript });
   };
 
-  handleSaveScript = formValues => {
-    console.log("save script formValues", formValues);
+  handleEditTagScript = values => {
+    this.setState({
+      editingTag: { ...this.state.editingTag, onApplyScript: values }
+    });
   };
 
   render() {
     const { organizationTags } = this.props;
-    const { editingTag, isWorking, error, isEditingScript } = this.state;
+    const { editingTag, isWorking, error } = this.state;
 
     if (organizationTags.loading) return <LoadingIndicator />;
     if (organizationTags.errors) {
@@ -122,15 +125,13 @@ class AdminTagEditor extends Component {
       <FlatButton label={tagVerb} primary={true} onClick={this.handleSaveTag} />
     ];
 
-    const editScriptSchema = yup.object({
-      text: yup.string().required()
-    });
+    // required in GSScriptField
+    const customFields = [""];
 
     const errorActions = [
       <FlatButton label="Ok" primary={true} onClick={this.handleCancelError} />
     ];
 
-    console.log("admin tag editor state", this.state, "tags", organizationTags);
     return (
       <div>
         <TagEditorList
@@ -168,29 +169,15 @@ class AdminTagEditor extends Component {
               onChange={this.createTagEditorHandle}
             />
             <br />
-            <TextField
-              name="onApplyScript"
-              floatingLabelText="Tag script"
-              multiLine={true}
+            <GSScriptField
+              name="Script"
+              label="Tag Script"
+              context="tagEditor"
+              customFields={customFields}
               value={editingTag.onApplyScript || ""}
+              onChange={this.handleEditTagScript}
               onClick={this.handleSetEditingScript}
             />
-            {isEditingScript && (
-              <GSForm
-                ref="form"
-                schema={editScriptSchema}
-                onSubmit={this.handleSaveScript}
-              >
-                <Form.Field
-                  {...dataTest("editorResponse")} // customFields={customFields}
-                  name="text"
-                  type="script"
-                  label="Script"
-                  multiLine
-                  fullWidth
-                />
-              </GSForm>
-            )}
             <br />
             <br />
             <Toggle

--- a/src/containers/AdminTagEditor/index.jsx
+++ b/src/containers/AdminTagEditor/index.jsx
@@ -1,4 +1,6 @@
 import React, { Component } from "react";
+import * as yup from "yup";
+import Form from "react-formal";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
 import pick from "lodash/pick";
@@ -15,10 +17,14 @@ import LoadingIndicator from "../../components/LoadingIndicator";
 import TagEditorList from "./TagEditorList";
 import theme from "../../styles/theme";
 
+import { dataTest } from "../../lib/attributes";
+import GSForm from "../../components/forms/GSForm";
+
 class AdminTagEditor extends Component {
   state = {
     editingTag: undefined,
     isWorking: false,
+    isEditingScript: false,
     error: undefined
   };
 
@@ -90,9 +96,17 @@ class AdminTagEditor extends Component {
     this.setState({ editingTag });
   };
 
+  handleSetEditingScript = () => {
+    this.setState({ isEditingScript: !this.state.isEditingScript });
+  };
+
+  handleSaveScript = formValues => {
+    console.log("save script formValues", formValues);
+  };
+
   render() {
     const { organizationTags } = this.props;
-    const { editingTag, isWorking, error } = this.state;
+    const { editingTag, isWorking, error, isEditingScript } = this.state;
 
     if (organizationTags.loading) return <LoadingIndicator />;
     if (organizationTags.errors) {
@@ -108,10 +122,15 @@ class AdminTagEditor extends Component {
       <FlatButton label={tagVerb} primary={true} onClick={this.handleSaveTag} />
     ];
 
+    const editScriptSchema = yup.object({
+      text: yup.string().required()
+    });
+
     const errorActions = [
       <FlatButton label="Ok" primary={true} onClick={this.handleCancelError} />
     ];
 
+    console.log("admin tag editor state", this.state, "tags", organizationTags);
     return (
       <div>
         <TagEditorList
@@ -148,6 +167,30 @@ class AdminTagEditor extends Component {
               value={editingTag.description || ""}
               onChange={this.createTagEditorHandle}
             />
+            <br />
+            <TextField
+              name="onApplyScript"
+              floatingLabelText="Tag script"
+              multiLine={true}
+              value={editingTag.onApplyScript || ""}
+              onClick={this.handleSetEditingScript}
+            />
+            {isEditingScript && (
+              <GSForm
+                ref="form"
+                schema={editScriptSchema}
+                onSubmit={this.handleSaveScript}
+              >
+                <Form.Field
+                  {...dataTest("editorResponse")} // customFields={customFields}
+                  name="text"
+                  type="script"
+                  label="Script"
+                  multiLine
+                  fullWidth
+                />
+              </GSForm>
+            )}
             <br />
             <br />
             <Toggle
@@ -189,6 +232,7 @@ const queries = {
             description
             isSystem
             isAssignable
+            onApplyScript
             createdAt
           }
         }

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -2886,7 +2886,8 @@ const rootMutations = {
             is_assignable: tag.isAssignable,
             on_apply_script: tag.onApplyScript,
             text_color: tag.textColor,
-            background_color: tag.backgroundColor
+            background_color: tag.backgroundColor,
+            webhook_url: tag.webhookUrl
           })
           .where({
             id: tag.id,
@@ -2909,7 +2910,8 @@ const rootMutations = {
           is_assignable: tag.isAssignable,
           on_apply_script: tag.onApplyScript,
           text_color: tag.textColor,
-          background_color: tag.backgroundColor
+          background_color: tag.backgroundColor,
+          webhook_url: tag.webhookUrl
         })
         .returning("*");
 

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -2876,6 +2876,8 @@ const rootMutations = {
     saveTag: async (_, { organizationId, tag }, { user }) => {
       await accessRequired(user, organizationId, "ADMIN");
 
+      logger.info("tag", tag);
+
       // Update existing tag
       if (tag.id) {
         const [updatedTag] = await r
@@ -2883,7 +2885,8 @@ const rootMutations = {
           .update({
             title: tag.title,
             description: tag.description,
-            is_assignable: tag.isAssignable
+            is_assignable: tag.isAssignable,
+            on_apply_script: tag.onApplyScript
           })
           .where({
             id: tag.id,
@@ -2903,7 +2906,8 @@ const rootMutations = {
           author_id: user.id,
           title: tag.title,
           description: tag.description,
-          is_assignable: tag.isAssignable
+          is_assignable: tag.isAssignable,
+          on_apply_script: tag.onApplyScript
         })
         .returning("*");
 

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -2876,8 +2876,6 @@ const rootMutations = {
     saveTag: async (_, { organizationId, tag }, { user }) => {
       await accessRequired(user, organizationId, "ADMIN");
 
-      logger.info("tag", tag);
-
       // Update existing tag
       if (tag.id) {
         const [updatedTag] = await r

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -2884,7 +2884,9 @@ const rootMutations = {
             title: tag.title,
             description: tag.description,
             is_assignable: tag.isAssignable,
-            on_apply_script: tag.onApplyScript
+            on_apply_script: tag.onApplyScript,
+            text_color: tag.textColor,
+            background_color: tag.backgroundColor
           })
           .where({
             id: tag.id,
@@ -2905,7 +2907,9 @@ const rootMutations = {
           title: tag.title,
           description: tag.description,
           is_assignable: tag.isAssignable,
-          on_apply_script: tag.onApplyScript
+          on_apply_script: tag.onApplyScript,
+          text_color: tag.textColor,
+          background_color: tag.backgroundColor
         })
         .returning("*");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pr allows spoke admins to apply scripts, text and background color, and webhook urls to tags via the tagEditor ui.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Per #406, the backend functionality for applying tag scripts exists, we want to expose it to admins via the tagEditor UI

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Behaviorally 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [x ] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
