### PR TITLE
refactor: breakout task wrapper

### DIFF
--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -787,13 +787,17 @@ const rootMutations = {
 
       if (exportType === CampaignExportType.SPOKE) {
         return addExportCampaign({
-          campaign_id: campaignId,
-          requester: user.id
+          campaignId,
+          requesterId: user.id
         });
       }
 
       if (exportType === CampaignExportType.VAN) {
-        return addExportForVan({ ...vanOptions, requesterId: user.id });
+        return addExportForVan({
+          ...vanOptions,
+          campaignId,
+          requesterId: user.id
+        });
       }
     },
 

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -790,6 +790,9 @@ const rootMutations = {
       jobTypes[CampaignExportType.SPOKE] = "export";
       jobTypes[CampaignExportType.VAN] = "van-export";
 
+      let payload = {};
+      let jobRequest;
+
       const jobRequestRecord = {
         queue_name: `${campaignId}:export`,
         job_type: jobTypes[exportType],
@@ -799,19 +802,14 @@ const rootMutations = {
         payload: JSON.stringify(payload)
       };
 
-      let payload = {};
-      let jobRequest;
       if (exportType === CampaignExportType.SPOKE) {
         payload = {
           campaign_id: campaignId,
           requester: user.id
         };
-        // jobResult = await addProgressJob("export-campaign", payload);
-        logger.info("schema jobRequestRecord", jobRequestRecord);
         jobRequest = exportCampaign(jobRequestRecord);
       } else if (exportType === CampaignExportType.VAN) {
         payload = { ...vanOptions, requesterId: user.id };
-        // jobRequest = await addProgressJob("export-for-van", payload);
         jobRequest = exportForVan(jobRequestRecord);
       }
 

--- a/src/server/tasks/export-campaign.ts
+++ b/src/server/tasks/export-campaign.ts
@@ -312,9 +312,9 @@ export const exportCampaign: Task = async (
   payload: JobRequestRecord,
   _helpers
 ) => {
-  const { payload: context, campaign_id, requester } = payload;
+  const { campaign_id, requester } = payload;
+  const job = await addProgressJob("export-campaign", payload);
 
-  await addProgressJob("export-campaign", payload);
   const {
     campaignId,
     campaignTitle,
@@ -469,12 +469,7 @@ export const exportCampaign: Task = async (
     logger.info("Finishing export process");
   }
 
-  // Attempt to delete job ("why would a job ever _not_ have an id?" - bchrobot)
-  if (payload.id) {
-    await deleteJob(payload.id);
-  } else {
-    logger.debug(payload);
-  }
+  await deleteJob(job.id);
 };
 
 export default exportCampaign;

--- a/src/server/tasks/export-campaign.ts
+++ b/src/server/tasks/export-campaign.ts
@@ -70,12 +70,12 @@ export const getUniqueQuestionsByStepId = (
  * @param {object} job The export job object to fetch data for.
  *                     Must have payload, campaign_id, and requester properties.
  */
-export const fetchExportData = async (job: JobRequestRecord) => {
-  const { campaign_id: campaignId, payload: rawPayload } = job;
-  const { requester: requesterId, isAutomatedExport = false } = JSON.parse(
-    rawPayload
-  );
 
+export const fetchExportData = async (
+  campaignId: number,
+  requesterId: string,
+  isAutomatedExport = false
+) => {
   const { title: campaignTitle } = await r
     .reader("campaign")
     .first("title")
@@ -312,6 +312,8 @@ export const exportCampaign: Task = async (
   payload: JobRequestRecord,
   _helpers
 ) => {
+  const { payload: context, campaign_id, requester } = payload;
+
   await addProgressJob("export-campaign", payload);
   const {
     campaignId,
@@ -320,7 +322,7 @@ export const exportCampaign: Task = async (
     interactionSteps,
     assignments: _assignments,
     isAutomatedExport
-  } = await fetchExportData(payload);
+  } = await fetchExportData(campaign_id, requester);
 
   const countQueryResult = await r
     .reader("campaign_contact")

--- a/src/server/tasks/export-campaign.ts
+++ b/src/server/tasks/export-campaign.ts
@@ -16,6 +16,7 @@ import {
 } from "../api/types";
 import { sendEmail } from "../mail";
 import { r } from "../models";
+import { addProgressJob } from "./utils";
 
 const CHUNK_SIZE = 1000;
 
@@ -311,6 +312,7 @@ export const exportCampaign: Task = async (
   payload: JobRequestRecord,
   _helpers
 ) => {
+  await addProgressJob("export-campaign", payload);
   const {
     campaignId,
     campaignTitle,

--- a/src/server/tasks/export-for-van.ts
+++ b/src/server/tasks/export-for-van.ts
@@ -10,6 +10,7 @@ import { JobRequestRecord } from "../api/types";
 import { sendEmail } from "../mail";
 import { r } from "../models";
 import { errToObj } from "../utils";
+import { addProgressJob } from "./utils";
 
 export interface ExportForVANOptions {
   requesterId: number;
@@ -34,15 +35,19 @@ export const exportForVan: Task = async (
   job: JobRequestRecord,
   _helpers: any
 ) => {
+  const { campaign_id } = job;
+  const exportJob = await addProgressJob("export-for-van", job);
   const { reader } = r;
-  const payload: ExportForVANOptions = JSON.parse(job.payload);
+  const payload: ExportForVANOptions = JSON.parse(exportJob.payload);
   const { requesterId, includeUnmessaged, vanIdField } = payload;
+
+  logger.info("exportJob", exportJob);
 
   const { email } = await reader("user")
     .where({ id: requesterId })
     .first(["email"]);
   const { title } = await reader("campaign")
-    .where({ id: job.campaign_id })
+    .where({ id: campaign_id })
     .first(["title"]);
 
   const vanIdSelector =

--- a/src/server/tasks/utils.ts
+++ b/src/server/tasks/utils.ts
@@ -1,0 +1,79 @@
+import { Task } from "graphile-worker/dist/interfaces";
+import { getWorker } from "../worker";
+import { r } from "../server/models";
+
+export const addProgressJob = async (
+  identifier: string,
+  payload: any,
+  initialResult: any = {},
+  context: any = {}
+) => {
+  const [jobResult] = await r
+    .knex("job_request")
+    .insert({
+      job_type: identifier,
+      status: 0,
+      payload: JSON.stringify(context),
+      result_message: JSON.stringify(initialResult)
+    })
+    .returning("*");
+
+  const wrappedPayload = { ...payload, _jobRequestId: jobResult.id };
+  const worker = await getWorker();
+  worker.addJob(identifier, wrappedPayload);
+  return jobResult;
+};
+
+interface ProgressTaskPayload {
+  _jobRequestId: string;
+}
+
+interface ProgressTaskOptions {
+  removeOnComplete: boolean;
+}
+
+export const wrappedProgressTask = (
+  task: Task,
+  options: ProgressTaskOptions
+) => async (payload: ProgressTaskPayload, helpers: any) => {
+  const jobId = payload._jobRequestId;
+  const jobRequest = await r
+    .knex("job_request")
+    .where({ id: jobId })
+    .first();
+  const updateStatus = async (status: number) =>
+    await r
+      .knex("job_request")
+      .update({ status })
+      .where({ id: jobId });
+  const updateResult = async (result: any) =>
+    await r
+      .knex("job_request")
+      .update({ result_message: result })
+      .where({ id: jobId });
+  const progressHelpers = {
+    ...helpers,
+    jobRequest,
+    updateStatus,
+    updateResult
+  };
+
+  try {
+    await task(payload, progressHelpers);
+
+    if (options.removeOnComplete) {
+      await r
+        .knex("job_request")
+        .where({ id: jobId })
+        .del();
+    }
+  } catch (err) {
+    const { attempts, maxAttempts } = helpers.job;
+    if (attempts === maxAttempts) {
+      // "Complete" graphile job by recording error on the final attempt
+      return updateResult({ error: err.message });
+    }
+    // throw error to trigger graphile retry
+    throw err;
+  }
+};

--- a/src/server/tasks/utils.ts
+++ b/src/server/tasks/utils.ts
@@ -1,6 +1,7 @@
 import { Task } from "graphile-worker/dist/interfaces";
 import { getWorker } from "../worker";
-import { r } from "../server/models";
+import { r } from "../models";
+import logger from "../../../src/logger";
 
 export const addProgressJob = async (
   identifier: string,
@@ -19,6 +20,9 @@ export const addProgressJob = async (
     .returning("*");
 
   const wrappedPayload = { ...payload, _jobRequestId: jobResult.id };
+
+  logger.info("addProgressJob wrappedPayload", wrappedPayload);
+
   const worker = await getWorker();
   worker.addJob(identifier, wrappedPayload);
   return jobResult;

--- a/src/server/tasks/utils.ts
+++ b/src/server/tasks/utils.ts
@@ -6,12 +6,13 @@ import logger from "../../../src/logger";
 export const addProgressJob = async (
   identifier: string,
   payload: any,
-  initialResult: any = {},
-  context: any = {}
+  initialResult: any = {}
 ) => {
   const { jobRequestRecord, requester } = payload;
   const { campaign_id, queue_name, locks_queue, assigned } = jobRequestRecord;
-  const jobPayload = { campaign_id, requester };
+  const jobRequestPayload = { campaign_id, requester };
+
+  logger.info("addprogressjob payload", payload);
 
   const [jobResult] = await r
     .knex("job_request")
@@ -22,7 +23,7 @@ export const addProgressJob = async (
       queue_name,
       locks_queue,
       assigned,
-      payload: JSON.stringify(jobPayload),
+      payload: JSON.stringify(jobRequestPayload),
       result_message: JSON.stringify(initialResult)
     })
     .returning("*");

--- a/src/server/tasks/utils.ts
+++ b/src/server/tasks/utils.ts
@@ -1,68 +1,95 @@
-import { Task } from "graphile-worker/dist/interfaces";
-import { getWorker } from "../worker";
+import { JobHelpers, TaskSpec } from "graphile-worker";
+
+import { JobRequestRecord } from "../api/types";
 import { r } from "../models";
-import logger from "../../../src/logger";
+import { getWorker } from "../worker";
 
-export const addProgressJob = async (
-  identifier: string,
-  payload: any,
-  initialResult: any = {}
+export interface ProgressJobPayload {
+  campaignId: number;
+}
+
+export interface ProgressJobOptions<P extends ProgressJobPayload> {
+  identifier: string;
+  payload: P;
+  taskSpec?: Omit<TaskSpec, "jobKey">;
+  initialResult?: Record<string, unknown>;
+  context?: Record<string, unknown>;
+}
+
+export const addProgressJob = async <P extends ProgressJobPayload>(
+  options: ProgressJobOptions<P>
 ) => {
-  const { jobRequestRecord, requester } = payload;
-  const { campaign_id, queue_name, locks_queue, assigned } = jobRequestRecord;
-  const jobRequestPayload = { campaign_id, requester };
+  const {
+    identifier,
+    taskSpec = {},
+    payload,
+    initialResult,
+    context
+  } = options;
+  const { campaignId } = payload;
+  const { queueName = `${campaignId}:${identifier}` } = taskSpec;
 
-  logger.info("addprogressjob payload", payload);
-
-  const [jobResult] = await r
+  const [jobResult]: [JobRequestRecord] = await r
     .knex("job_request")
     .insert({
       job_type: identifier,
       status: 0,
-      campaign_id,
-      queue_name,
-      locks_queue,
-      assigned,
-      payload: JSON.stringify(jobRequestPayload),
+      campaign_id: campaignId,
+      queue_name: queueName,
+      payload: JSON.stringify(context),
       result_message: JSON.stringify(initialResult)
     })
     .returning("*");
 
   const wrappedPayload = { ...payload, _jobRequestId: jobResult.id };
 
+  const innerSpec: TaskSpec = {
+    ...taskSpec,
+    jobKey: `${jobResult.id}`
+  };
+
   const worker = await getWorker();
-  worker.addJob(identifier, wrappedPayload);
+  worker.addJob(identifier, wrappedPayload, innerSpec);
   return jobResult;
 };
 
-interface ProgressTaskPayload {
+export interface ProgressTaskPayload {
   _jobRequestId: string;
 }
 
-interface ProgressTaskOptions {
+export interface ProgressTaskHelpers extends JobHelpers {
+  jobRequest: JobRequestRecord;
+  updateStatus(status: number): Promise<void>;
+  updateResult(result: Record<string, unknown>): Promise<void>;
+}
+
+export type ProgressTask<P = unknown> = (
+  payload: P,
+  helpers: ProgressTaskHelpers
+) => void | Promise<void>;
+
+export interface ProgressTaskOptions {
   removeOnComplete: boolean;
 }
 
-export const wrappedProgressTask = (
-  task: Task,
+export const wrapProgressTask = <P extends { [key: string]: any }>(
+  task: ProgressTask<P>,
   options: ProgressTaskOptions
-) => async (payload: ProgressTaskPayload, helpers: any) => {
-  const jobId = payload._jobRequestId;
-  const jobRequest = await r
-    .knex("job_request")
-    .where({ id: jobId })
-    .first();
+) => async (payload: ProgressTaskPayload & P, helpers: JobHelpers) => {
+  const { _jobRequestId: jobId, ...taskPayload } = payload;
+
+  const jobRequest = await r.knex("job_request").where({ id: jobId }).first();
+
   const updateStatus = async (status: number) =>
-    await r
-      .knex("job_request")
-      .update({ status })
-      .where({ id: jobId });
-  const updateResult = async (result: any) =>
-    await r
+    r.knex("job_request").update({ status }).where({ id: jobId });
+
+  const updateResult = async (result: Record<string, unknown>) =>
+    r
       .knex("job_request")
       .update({ result_message: result })
       .where({ id: jobId });
-  const progressHelpers = {
+
+  const progressHelpers: ProgressTaskHelpers = {
     ...helpers,
     jobRequest,
     updateStatus,
@@ -70,17 +97,14 @@ export const wrappedProgressTask = (
   };
 
   try {
-    await task(payload, progressHelpers);
-    logger.info("wrappedProgress runs payload", payload);
+    await task(taskPayload, progressHelpers);
+    helpers.logger.info("wrappedProgress runs payload", payload);
     if (options.removeOnComplete) {
-      await r
-        .knex("job_request")
-        .where({ id: jobId })
-        .del();
+      await r.knex("job_request").where({ id: jobId }).del();
     }
   } catch (err) {
-    const { attempts, maxAttempts } = helpers.job;
-    if (attempts === maxAttempts) {
+    const { attempts, max_attempts } = helpers.job;
+    if (attempts === max_attempts) {
       // "Complete" graphile job by recording error on the final attempt
       return updateResult({ error: err.message });
     }

--- a/src/server/tasks/utils.ts
+++ b/src/server/tasks/utils.ts
@@ -76,7 +76,7 @@ export const wrapProgressTask = <P extends { [key: string]: any }>(
   task: ProgressTask<P>,
   options: ProgressTaskOptions
 ) => async (payload: ProgressTaskPayload & P, helpers: JobHelpers) => {
-  const { _jobRequestId: jobId, ...taskPayload } = payload;
+  const { _jobRequestId: jobId } = payload;
 
   const jobRequest = await r.knex("job_request").where({ id: jobId }).first();
 
@@ -97,7 +97,7 @@ export const wrapProgressTask = <P extends { [key: string]: any }>(
   };
 
   try {
-    await task(taskPayload, progressHelpers);
+    await task(payload, progressHelpers);
     helpers.logger.info("wrappedProgress runs payload", payload);
     if (options.removeOnComplete) {
       await r.knex("job_request").where({ id: jobId }).del();

--- a/src/server/tasks/utils.ts
+++ b/src/server/tasks/utils.ts
@@ -23,8 +23,8 @@ export const addProgressJob = async <P extends ProgressJobPayload>(
     identifier,
     taskSpec = {},
     payload,
-    initialResult,
-    context
+    initialResult = {},
+    context = {}
   } = options;
   const { campaignId } = payload;
   const { queueName = `${campaignId}:${identifier}` } = taskSpec;

--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -61,7 +61,7 @@ export const getWorker = async (attempt = 0): Promise<PgComposeWorker> => {
   m.taskList!["export-campaign"] = wrappedProgressTask(exportCampaign, {
     removeOnComplete: true
   });
-  m.taskList!["export-campaign"] = wrappedProgressTask(exportForVan, {
+  m.taskList!["export-for-van"] = wrappedProgressTask(exportForVan, {
     removeOnComplete: true
   });
 

--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -5,8 +5,14 @@ import url from "url";
 
 import { config } from "../config";
 import logger from "../logger";
-import exportCampaign from "./tasks/export-campaign";
-import { exportForVan } from "./tasks/export-for-van";
+import {
+  exportCampaign,
+  TASK_IDENTIFIER as exportCampaignIdentifier
+} from "./tasks/export-campaign";
+import {
+  exportForVan,
+  TASK_IDENTIFIER as exportForVanIdentifier
+} from "./tasks/export-for-van";
 import fetchVANActivistCodes from "./tasks/fetch-van-activist-codes";
 import fetchVANResultCodes from "./tasks/fetch-van-result-codes";
 import fetchVANSurveyQuestions from "./tasks/fetch-van-survey-questions";
@@ -19,7 +25,7 @@ import {
 } from "./tasks/sync-campaign-contact-to-van";
 import syncSlackTeamMembers from "./tasks/sync-slack-team-members";
 import { trollPatrol, trollPatrolForOrganization } from "./tasks/troll-patrol";
-import { wrappedProgressTask } from "./tasks/utils";
+import { wrapProgressTask } from "./tasks/utils";
 
 const logFactory: LogFunctionFactory = (scope) => (level, message, meta) =>
   logger.log({ level, message, ...meta, ...scope });
@@ -50,18 +56,18 @@ export const getWorker = async (attempt = 0): Promise<PgComposeWorker> => {
   m.taskList!["handle-autoassignment-request"] = handleAutoassignmentRequest;
   m.taskList!["release-stale-replies"] = releaseStaleReplies;
   m.taskList!["handle-delivery-report"] = handleDeliveryReport;
-  // m.taskList!["troll-patrol"] = trollPatrol;
-  // m.taskList!["troll-patrol-for-org"] = trollPatrolForOrganization;
-  // m.taskList!["sync-slack-team-members"] = syncSlackTeamMembers;
-  // m.taskList!["van-get-survey-questions"] = fetchVANSurveyQuestions;
-  // m.taskList!["van-get-activist-codes"] = fetchVANActivistCodes;
-  // m.taskList!["van-get-result-codes"] = fetchVANResultCodes;
-  // m.taskList!["van-sync-campaign-contact"] = syncCampaignContactToVAN;
-  // m.taskList!["update-van-sync-statuses"] = updateVanSyncStatuses;
-  m.taskList!["export-campaign"] = wrappedProgressTask(exportCampaign, {
+  m.taskList!["troll-patrol"] = trollPatrol;
+  m.taskList!["troll-patrol-for-org"] = trollPatrolForOrganization;
+  m.taskList!["sync-slack-team-members"] = syncSlackTeamMembers;
+  m.taskList!["van-get-survey-questions"] = fetchVANSurveyQuestions;
+  m.taskList!["van-get-activist-codes"] = fetchVANActivistCodes;
+  m.taskList!["van-get-result-codes"] = fetchVANResultCodes;
+  m.taskList!["van-sync-campaign-contact"] = syncCampaignContactToVAN;
+  m.taskList!["update-van-sync-statuses"] = updateVanSyncStatuses;
+  m.taskList![exportCampaignIdentifier] = wrapProgressTask(exportCampaign, {
     removeOnComplete: true
   });
-  m.taskList!["export-for-van"] = wrappedProgressTask(exportForVan, {
+  m.taskList![exportForVanIdentifier] = wrapProgressTask(exportForVan, {
     removeOnComplete: true
   });
 

--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -50,14 +50,14 @@ export const getWorker = async (attempt = 0): Promise<PgComposeWorker> => {
   m.taskList!["handle-autoassignment-request"] = handleAutoassignmentRequest;
   m.taskList!["release-stale-replies"] = releaseStaleReplies;
   m.taskList!["handle-delivery-report"] = handleDeliveryReport;
-  m.taskList!["troll-patrol"] = trollPatrol;
-  m.taskList!["troll-patrol-for-org"] = trollPatrolForOrganization;
-  m.taskList!["sync-slack-team-members"] = syncSlackTeamMembers;
-  m.taskList!["van-get-survey-questions"] = fetchVANSurveyQuestions;
-  m.taskList!["van-get-activist-codes"] = fetchVANActivistCodes;
-  m.taskList!["van-get-result-codes"] = fetchVANResultCodes;
-  m.taskList!["van-sync-campaign-contact"] = syncCampaignContactToVAN;
-  m.taskList!["update-van-sync-statuses"] = updateVanSyncStatuses;
+  // m.taskList!["troll-patrol"] = trollPatrol;
+  // m.taskList!["troll-patrol-for-org"] = trollPatrolForOrganization;
+  // m.taskList!["sync-slack-team-members"] = syncSlackTeamMembers;
+  // m.taskList!["van-get-survey-questions"] = fetchVANSurveyQuestions;
+  // m.taskList!["van-get-activist-codes"] = fetchVANActivistCodes;
+  // m.taskList!["van-get-result-codes"] = fetchVANResultCodes;
+  // m.taskList!["van-sync-campaign-contact"] = syncCampaignContactToVAN;
+  // m.taskList!["update-van-sync-statuses"] = updateVanSyncStatuses;
   m.taskList!["export-campaign"] = wrappedProgressTask(exportCampaign, {
     removeOnComplete: true
   });

--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -19,6 +19,7 @@ import {
 } from "./tasks/sync-campaign-contact-to-van";
 import syncSlackTeamMembers from "./tasks/sync-slack-team-members";
 import { trollPatrol, trollPatrolForOrganization } from "./tasks/troll-patrol";
+import { wrappedProgressTask } from "./tasks/utils";
 
 const logFactory: LogFunctionFactory = (scope) => (level, message, meta) =>
   logger.log({ level, message, ...meta, ...scope });
@@ -57,8 +58,12 @@ export const getWorker = async (attempt = 0): Promise<PgComposeWorker> => {
   m.taskList!["van-get-result-codes"] = fetchVANResultCodes;
   m.taskList!["van-sync-campaign-contact"] = syncCampaignContactToVAN;
   m.taskList!["update-van-sync-statuses"] = updateVanSyncStatuses;
-  m.taskList!["export-campaign"] = exportCampaign;
-  m.taskList!["export-campaign-for-van"] = exportForVan;
+  m.taskList!["export-campaign"] = wrappedProgressTask(exportCampaign, {
+    removeOnComplete: true
+  });
+  m.taskList!["export-campaign"] = wrappedProgressTask(exportForVan, {
+    removeOnComplete: true
+  });
 
   m.cronJobs!.push({
     name: "release-stale-replies",


### PR DESCRIPTION
## Description

Introduces a wrapper around transient Graphile Worker tasks to manage persistent `job_request` records.

Needs to be rebased on `master` after #726 is merged!

## Motivation and Context

In the pre-Graphile Worker world the `job_request` table was used as both the queue and for recording client-facing status and result messages. We now use Graphile Worker to manage the queue but we also want to keep the client-facing status and result messages (as Graphile jobs are deleted upon completion).

The `job_request` record's lifecycle will be the same in most cases and should happen automatically.

Ref https://github.com/politics-rewired/Spoke/pull/738#pullrequestreview-501510937

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This has been tested locally:

- Export Campaign still works
- Export for VAN still works
- Errors within campaign export jobs
    1. Retry if `attempts > maxAttempts`
    1. Finish in Graphile Worker and update `job_request` with error message if `attempts === maxAttempts`

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
