### PR TITLE
feat(shortlinkdomains): hide shortlink domains behind envvar

### DIFF
--- a/src/components/AdminDashboard.jsx
+++ b/src/components/AdminDashboard.jsx
@@ -110,6 +110,11 @@ class AdminDashboard extends React.Component {
       sections.splice(index, 1);
     }
 
+    if (!window.ENABLE_SHORTLINK_DOMAINS) {
+      const index = sections.findIndex(s => s.name === "Short Link Domains");
+      sections.splice(index, 1);
+    }
+
     let currentSection = sections.filter(section =>
       location.pathname.match(`/${section.path}`)
     );

--- a/src/config.js
+++ b/src/config.js
@@ -314,6 +314,11 @@ const validators = {
       "The interval length in minutes that each troll patrol sweep will examine messages within.",
     default: 6
   }),
+  ENABLE_SHORTLINK_DOMAINS: bool({
+    desc: "Whether to enable shortlink domains",
+    default: false,
+    isClient: true
+  }),
   DISABLE_TEXTER_NOTIFICATIONS: bool({
     desc:
       "Whether to disable texter notifications – if true, should be implemented externally.",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Hides short link domains behind an envvar, a la the trollbot. Closes #769, part of Q4 feature freeze

I'm not sure if we want to include a toggle in settings that would allow owners to turn on the feature, or if this fix is good as-is

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Per @bchrobot "The Short Link Domains feature is only useful for organizations sending at very high volume. For the vast majority of users this feature is unnecessary and confusing even."

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Behaviorally 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
