### PR TITLE
fix(escalationtags): check tags in assignment row chip input component

### DIFF
--- a/src/containers/AdminAssignmentControl/AssignmentRow.jsx
+++ b/src/containers/AdminAssignmentControl/AssignmentRow.jsx
@@ -42,6 +42,20 @@ const AssignmentRow = props => {
     onChange({ escalationTags: newEscalationTags });
   };
 
+  const handleCheckEscalationTag = newTag => {
+    // when a tag is added by search, newTag will be a string,
+    // not the tag object within escalationTagList -
+    // here we trim possible whitespace, then find and verify the tag
+    // before calling handleAddEscalationTag
+    const trimmedTag = newTag.id ? newTag : newTag.trim();
+    const foundTag = escalationTagList.find(
+      tag => tag.title === trimmedTag || tag.title === trimmedTag.title
+    );
+    if (foundTag) {
+      handleAddEscalationTag(foundTag);
+    }
+  };
+
   return (
     <div style={{ display: "flex", alignItems: "center" }}>
       <div style={{ minWidth: "200px" }}>
@@ -96,6 +110,7 @@ const AssignmentRow = props => {
         dataSource={escalationTagList}
         value={escalationTags}
         openOnFocus={true}
+        onBeforeRequestAdd={handleCheckEscalationTag}
         onRequestAdd={handleAddEscalationTag}
         onRequestDelete={handleRemoveEscalationTag}
         dataSourceConfig={{ text: "title", value: "id" }}

--- a/src/containers/AdminAssignmentControl/AssignmentRow.jsx
+++ b/src/containers/AdminAssignmentControl/AssignmentRow.jsx
@@ -33,7 +33,11 @@ const AssignmentRow = props => {
     onChange({ maxRequestCount: parseInt(maxRequestCount, 10) });
 
   const handleAddEscalationTag = newTag => {
-    const newEscalationTags = uniqBy(escalationTags.concat(newTag), t => t.id);
+    // when a tag is added by search, ChipInput coerces it to an object -
+    // we want to find the tag within escalationTagList that matches
+    // newTag object's title, not add the new object to escalationTags
+    const foundTag = escalationTagList.find(tag => tag.title === newTag.title);
+    const newEscalationTags = uniqBy(escalationTags.concat(foundTag), t => t.id);
     onChange({ escalationTags: newEscalationTags });
   };
 
@@ -45,15 +49,12 @@ const AssignmentRow = props => {
   const handleCheckEscalationTag = newTag => {
     // when a tag is added by search, newTag will be a string,
     // not the tag object within escalationTagList -
-    // here we trim possible whitespace, then find and verify the tag
-    // before calling handleAddEscalationTag
-    const trimmedTag = newTag.id ? newTag : newTag.trim();
-    const foundTag = escalationTagList.find(
-      tag => tag.title === trimmedTag || tag.title === trimmedTag.title
-    );
-    if (foundTag) {
-      handleAddEscalationTag(foundTag);
-    }
+    // here we trim possible whitespace, then verify the tag
+    const formattedTag = newTag.id ? newTag.title : newTag.trim();
+    const tagNames = escalationTagList.map(tag => tag.title);
+    const tagExists = tagNames.includes(formattedTag);
+
+    return tagExists;
   };
 
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes an issue raised by this [ticket](https://secure.helpscout.net/conversation/1343368005/3413?folderId=4118236), where the Chip Input component allows creation of new tags via text input, which aren't currently being checked against escalationTagList. When the user tries to save the new tag, it generates an error - even if the user is entering a tag via text that should be selectable.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Chip Input default behavior is leading to confusion among users about how they can add tags within the AssignmentRow component, as well as what kind of tags they can add. This resolves that confusion in a minimal way.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Behaviorally 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
