### PR TITLE
fix: add authz check to myCurrentAssignmentTargets resolver

### DIFF
--- a/src/server/api/errors.js
+++ b/src/server/api/errors.js
@@ -1,4 +1,4 @@
-import { GraphQLError } from "graphql/error";
+import { AuthenticationError, ForbiddenError } from "apollo-server-express";
 
 import { cacheOpts, memoizer } from "../memoredis";
 import { r } from "../models";
@@ -7,10 +7,7 @@ const accessHierarchy = ["TEXTER", "SUPERVOLUNTEER", "ADMIN", "OWNER"];
 
 export function authRequired(user) {
   if (!user) {
-    throw new GraphQLError({
-      status: 401,
-      message: "You must login to access that resource."
-    });
+    throw new AuthenticationError("You must login to access that resource.");
   }
 }
 
@@ -47,7 +44,7 @@ export async function accessRequired(
     accessHierarchy.indexOf(userRole) >= accessHierarchy.indexOf(role);
 
   if (!hasRole) {
-    throw new GraphQLError("You are not authorized to access that resource.");
+    throw new ForbiddenError("You are not authorized to access that resource.");
   }
 }
 
@@ -67,7 +64,7 @@ export async function assignmentRequired(user, assignmentId) {
     .limit(1);
 
   if (typeof assignment === "undefined") {
-    throw new GraphQLError("You are not authorized to access that resource.");
+    throw new ForbiddenError("You are not authorized to access that resource.");
   }
 }
 
@@ -106,7 +103,9 @@ export async function assignmentRequiredOrHasOrgRoleForCampaign(
       accessHierarchy.indexOf(userRole) >= accessHierarchy.indexOf(role);
 
     if (!hasRole) {
-      throw new GraphQLError("You are not authorized to access that resource.");
+      throw new ForbiddenError(
+        "You are not authorized to access that resource."
+      );
     }
   }
 }
@@ -115,6 +114,6 @@ export function superAdminRequired(user) {
   authRequired(user);
 
   if (!user.is_superadmin) {
-    throw new GraphQLError("You are not authorized to access that resource.");
+    throw new ForbiddenError("You are not authorized to access that resource.");
   }
 }

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -232,6 +232,12 @@ export const resolvers = {
         : null;
     },
     myCurrentAssignmentTargets: async (organization, _, context) => {
+      await accessRequired(
+        context.user,
+        organization.id,
+        "TEXTER",
+        /* allowSuperadmin= */ true
+      );
       try {
         const assignmentTargets = await cachedMyCurrentAssignmentTargets(
           context.user.id,

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -3507,7 +3507,8 @@ const rootResolvers = {
       }
       return assignment;
     },
-    organization: async (_root, { id }, { loaders }) => {
+    organization: async (_root, { id }, { loaders, user }) => {
+      await accessRequired(user, id, "TEXTER", /* allowSuperadmin= */ true);
       const getOrganization = memoizer.memoize(async ({ organizationId }) => {
         return loaders.organization.load(organizationId);
       }, cacheOpts.OrganizationSingleTon);

--- a/src/server/routes/graphql.js
+++ b/src/server/routes/graphql.js
@@ -1,4 +1,4 @@
-import { ApolloServer } from "apollo-server-express";
+import { ApolloError, ApolloServer } from "apollo-server-express";
 import express from "express";
 import { addMockFunctionsToSchema, makeExecutableSchema } from "graphql-tools";
 
@@ -18,6 +18,11 @@ const executableSchema = makeExecutableSchema({
 });
 
 const formatError = (err) => {
+  // Ignore intentional ApolloErrors
+  if (err.originalError instanceof ApolloError) {
+    return err;
+  }
+
   // node-postgres does not use an Error subclass so we check for schema property
   const hasSchema = Object.prototype.hasOwnProperty.call(
     err.originalError,


### PR DESCRIPTION
## Description

This adds an authorization check to the organization.myCurrentAssignmentTargets resolver.

It also refactors authn/authz util methods to use `ApolloError`s rather than incorrectly using `GraphQLError`.

Closes #775 

This will need to be rebased on `master` after #726 is merged.

## Motivation and Context

This resolver routinely logs `TypeError: Cannot read property 'id' of undefined` errors when `context.user === undefined`.

## How Has This Been Tested?

This has been tested locally, as in things continue to run fine with the changes. I have not been able to discover reproduction steps for triggering the error itself, however.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
