### PR TITLE
feat: add link warning to script field

### DIFF
--- a/src/components/forms/GSScriptField.jsx
+++ b/src/components/forms/GSScriptField.jsx
@@ -9,9 +9,9 @@ import React from "react";
 import { dataTest } from "../../lib/attributes";
 import { allScriptFields } from "../../lib/scripts";
 import ScriptEditor from "../ScriptEditor";
+import ScriptLinkWarningDialog from "../ScriptLinkWarningDialog";
 import GSFormField from "./GSFormField";
-import ScriptLinkWarningDialog from '../ScriptLinkWarningDialog';
-import { getWarningContextForScript } from './utils'
+import { getWarningContextForScript } from "./utils";
 
 const styles = {
   dialog: {
@@ -59,29 +59,29 @@ class GSScriptField extends GSFormField {
   wrapSaveScript = () => {
     const { script } = this.state;
     const warningContext = getWarningContextForScript(script);
-    
+
     if (warningContext) {
       this.setState({ scriptWarningOpen: true });
     } else {
       this.handleSaveScript();
     }
-  }
+  };
 
   // confirm draft with links, save script and close editor
   handleConfirmLinkWarning = () => {
-    this.setState({ scriptWarningOpen: false }, () => this.handleSaveScript())
-  }
+    this.setState({ scriptWarningOpen: false }, () => this.handleSaveScript());
+  };
 
   // cancel draft with links, reset script draft
   handleCloseLinkWarning = () => {
-    this.setState({ scriptWarningOpen: false })
-  }
+    this.setState({ scriptWarningOpen: false });
+  };
 
   renderDialog() {
     const { name, customFields } = this.props;
     const { open, scriptWarningOpen, script } = this.state;
     const scriptFields = allScriptFields(customFields);
-    const warningContext = script && getWarningContextForScript(script)
+    const warningContext = script && getWarningContextForScript(script);
 
     return (
       <Dialog
@@ -114,11 +114,11 @@ class GSScriptField extends GSFormField {
           onChange={(val) => this.setState({ script: val })}
         />
         <ScriptLinkWarningDialog
-          open={scriptWarningOpen}  
-          warningContext={warningContext} 
-          handleConfirm={this.handleConfirmLinkWarning} 
+          open={scriptWarningOpen}
+          warningContext={warningContext}
+          handleConfirm={this.handleConfirmLinkWarning}
           handleClose={this.handleCloseLinkWarning}
-        /> 
+        />
       </Dialog>
     );
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pr extends the ScriptLinkWarningDialog and the related logic from GSScriptOptionsField into GSScriptField

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The script link warning is currently only displayed when users edit interaction steps - now it will be displayed when users add a script to a tag and edit canned responses as well 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has been tested locally.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [x ] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
