### PR TITLE
fix: add contact name filter to bulk assignment action filter

### DIFF
--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -314,7 +314,7 @@ const rootSchema = `
     assignUserToCampaign(organizationUuid: String!, campaignId: String!): Campaign
     userAgreeTerms(userId: String!): User
     megaReassignCampaignContacts(organizationId:String!, campaignIdsContactIds:[CampaignIdContactId]!, newTexterUserIds:[String]): Boolean!
-    megaBulkReassignCampaignContacts(organizationId:String!, campaignsFilter:CampaignsFilter, assignmentsFilter:AssignmentsFilter, tagsFilter: TagsFilter, contactsFilter:ContactsFilter, newTexterUserIds:[String]): Boolean!
+    megaBulkReassignCampaignContacts(organizationId:String!, campaignsFilter:CampaignsFilter, assignmentsFilter:AssignmentsFilter, tagsFilter: TagsFilter, contactsFilter:ContactsFilter, contactNameFilter: ContactNameFilter, newTexterUserIds:[String]): Boolean!
     requestTexts(count: Int!, email: String!, organizationId: String!, preferredTeamId: Int!): String!
     releaseMessages(campaignId: String!, target: ReleaseActionTarget!, ageInHours: Float): String!
     releaseAllUnhandledReplies(organizationId: String!, ageInHours: Float, releaseOnRestricted: Boolean, limitToCurrentlyTextableContacts: Boolean): ReleaseAllUnhandledRepliesResult!

--- a/src/containers/AdminIncomingMessageList/index.jsx
+++ b/src/containers/AdminIncomingMessageList/index.jsx
@@ -248,7 +248,8 @@ export class AdminIncomingMessageList extends Component {
         this.state.assignmentsFilter || {},
         this.state.tagsFilter || {},
         this.state.contactsFilter || {},
-        newTexterUserIds
+        newTexterUserIds,
+        this.state.contactNameFilter || {}
       );
     });
   };
@@ -271,7 +272,8 @@ export class AdminIncomingMessageList extends Component {
         this.state.assignmentsFilter || {},
         this.state.tagsFilter || {},
         this.state.contactsFilter || {},
-        null
+        null,
+        this.state.contactNameFilter || {}
       );
     });
   };
@@ -610,7 +612,8 @@ const mutations = {
     assignmentsFilter,
     tagsFilter,
     contactsFilter,
-    newTexterUserIds
+    newTexterUserIds,
+    contactNameFilter
   ) => ({
     mutation: gql`
       mutation megaBulkReassignCampaignContacts(
@@ -619,6 +622,7 @@ const mutations = {
         $campaignsFilter: CampaignsFilter
         $assignmentsFilter: AssignmentsFilter
         $tagsFilter: TagsFilter
+        $contactNameFilter: ContactNameFilter
         $newTexterUserIds: [String]
       ) {
         megaBulkReassignCampaignContacts(
@@ -627,6 +631,7 @@ const mutations = {
           campaignsFilter: $campaignsFilter
           assignmentsFilter: $assignmentsFilter
           tagsFilter: $tagsFilter
+          contactNameFilter: $contactNameFilter
           newTexterUserIds: $newTexterUserIds
         )
       }
@@ -637,6 +642,7 @@ const mutations = {
       assignmentsFilter,
       tagsFilter,
       contactsFilter,
+      contactNameFilter,
       newTexterUserIds
     }
   })

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -2428,6 +2428,7 @@ const rootMutations = {
         assignmentsFilter,
         tagsFilter,
         contactsFilter,
+        contactNameFilter,
         newTexterUserIds
       },
       { user }
@@ -2445,7 +2446,8 @@ const rootMutations = {
         campaignsFilter,
         assignmentsFilter,
         tagsFilter,
-        contactsFilter
+        contactsFilter,
+        contactNameFilter
       );
 
       if (newTexterUserIds == null) {


### PR DESCRIPTION
## Description

This adds the contact name filter to the payload sent for bulk assignment operations.

## Motivation and Context

Bulk assignment operations should act on the conversations returned by the active filter set. Ignoring any of the displayed filters leads to unexpected behavior.

Closes #796

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
