### PR TITLE
fix: copy campaign deleted interactions

### DIFF
--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1172,44 +1172,28 @@ const rootMutations = {
         const newCampaignId = newCampaign.id;
         const oldCampaignId = campaign.id;
 
-        const interactions = await trx("interaction_step").where({
-          campaign_id: oldCampaignId,
-          is_deleted: false
-        });
+        // copy interactions
+        const interactions = (
+          await trx("interaction_step").where({
+            campaign_id: oldCampaignId,
+            is_deleted: false
+          })
+        ).map((interaction) => ({
+          id: `new${interaction.id}`,
+          questionText: interaction.question,
+          scriptOptions: interaction.script_options,
+          answerOption: interaction.answer_option,
+          answerActions: interaction.answer_actions,
+          isDeleted: interaction.is_deleted,
+          campaign_id: newCampaignId,
+          parentInteractionId: interaction.parent_interaction_id
+            ? `new${interaction.parent_interaction_id}`
+            : interaction.parent_interaction_id
+        }));
 
-        const interactionsArr = [];
-        interactions.forEach((interaction, _index) => {
-          if (interaction.parent_interaction_id) {
-            const is = {
-              id: `new${interaction.id}`,
-              questionText: interaction.question,
-              scriptOptions: interaction.script_options,
-              answerOption: interaction.answer_option,
-              answerActions: interaction.answer_actions,
-              isDeleted: interaction.is_deleted,
-              campaign_id: newCampaignId,
-              parentInteractionId: `new${interaction.parent_interaction_id}`
-            };
-            interactionsArr.push(is);
-          } else if (!interaction.parent_interaction_id) {
-            const is = {
-              id: `new${interaction.id}`,
-              questionText: interaction.question,
-              scriptOptions: interaction.script_options,
-              answerOption: interaction.answer_option,
-              answerActions: interaction.answer_actions,
-              isDeleted: interaction.is_deleted,
-              campaign_id: newCampaignId,
-              parentInteractionId: interaction.parent_interaction_id
-            };
-            interactionsArr.push(is);
-          }
-        });
-
-        const interactionStepTree = makeTree(interactionsArr, (id = null));
         await persistInteractionStepTree(
           newCampaignId,
-          interactionStepTree,
+          makeTree(interactions, (id = null)),
           campaign,
           trx
         );

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1173,7 +1173,8 @@ const rootMutations = {
         const oldCampaignId = campaign.id;
 
         const interactions = await trx("interaction_step").where({
-          campaign_id: oldCampaignId
+          campaign_id: oldCampaignId,
+          is_deleted: false
         });
 
         const interactionsArr = [];


### PR DESCRIPTION
added `is_deleted: false` to the query that gets the interaction steps to copy to a newly copied campaign

## Description
just added another where clause


## Motivation and Context
https://github.com/politics-rewired/Spoke/issues/772

## How Has This Been Tested?
in browser 

## Screenshots (if appropriate):

## Types of changes

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [i think so ] My code follows the code style of this project.
- [i think so ] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [i don't think so] My change requires a change to the documentation.
- [i think so] I have included updates for the documentation accordingly.
