### PR TITLE
fix: make disabled buttons unclickable

### DIFF
--- a/src/containers/AdminCampaignEdit/sections/CampaignBasicsForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignBasicsForm.tsx
@@ -121,7 +121,7 @@ class CampaignBasicsForm extends React.Component<
           value={value}
           onChange={this.handleChange}
         >
-          <CampaignFormSectionHeading title="What's your campaign about?" />
+          <CampaignFormSectionHeading title="What&#39;s your campaign about?" />
           <Form.Field
             {...dataTest("title")}
             name="title"

--- a/src/containers/AdminCampaignEdit/sections/CampaignBasicsForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignBasicsForm.tsx
@@ -2,6 +2,7 @@ import { ApolloQueryResult } from "apollo-client";
 import gql from "graphql-tag";
 import isEmpty from "lodash/isEmpty";
 import ColorPicker from "material-ui-color-picker";
+import RaisedButton from "material-ui/RaisedButton";
 import moment from "moment";
 import React from "react";
 import Form from "react-formal";
@@ -114,58 +115,59 @@ class CampaignBasicsForm extends React.Component<
     const finalSaveLabel = isWorking ? "Working..." : saveLabel;
 
     return (
-      <GSForm
-        schema={schemaForIsStarted(isStarted)}
-        value={value}
-        onChange={this.handleChange}
-        onSubmit={this.handleSubmit}
-      >
-        <CampaignFormSectionHeading title="What's your campaign about?" />
-        <Form.Field
-          {...dataTest("title")}
-          name="title"
-          label="Title"
-          hintText="e.g. Election Day 2016"
-          fullWidth
-        />
-        <Form.Field
-          {...dataTest("description")}
-          name="description"
-          label="Description"
-          hintText="Get out the vote"
-          fullWidth
-        />
-        <Form.Field
-          {...dataTest("dueBy")}
-          name="dueBy"
-          label="Due date"
-          type="date"
-          locale="en-US"
-          shouldDisableDate={(date: Date) => moment(date).diff(moment()) < 0}
-          autoOk
-          fullWidth
-          utcOffset={0}
-        />
-        <Form.Field name="introHtml" label="Intro HTML" multiLine fullWidth />
-        <Form.Field
-          name="logoImageUrl"
-          label="Logo Image URL"
-          hintText="https://www.mysite.com/images/logo.png"
-          fullWidth
-        />
-        <p>Primary color</p>
-        <Form.Field
-          name="primaryColor"
-          label="Primary color"
-          defaultValue={value.primaryColor || "#ffffff"}
-          type={ColorPicker}
-        />
-        <Form.Button
-          type="submit"
+      <div>
+        <GSForm
+          schema={schemaForIsStarted(isStarted)}
+          value={value}
+          onChange={this.handleChange}
+        >
+          <CampaignFormSectionHeading title="What's your campaign about?" />
+          <Form.Field
+            {...dataTest("title")}
+            name="title"
+            label="Title"
+            hintText="e.g. Election Day 2016"
+            fullWidth
+          />
+          <Form.Field
+            {...dataTest("description")}
+            name="description"
+            label="Description"
+            hintText="Get out the vote"
+            fullWidth
+          />
+          <Form.Field
+            {...dataTest("dueBy")}
+            name="dueBy"
+            label="Due date"
+            type="date"
+            locale="en-US"
+            shouldDisableDate={(date: Date) => moment(date).diff(moment()) < 0}
+            autoOk
+            fullWidth
+            utcOffset={0}
+          />
+          <Form.Field name="introHtml" label="Intro HTML" multiLine fullWidth />
+          <Form.Field
+            name="logoImageUrl"
+            label="Logo Image URL"
+            hintText="https://www.mysite.com/images/logo.png"
+            fullWidth
+          />
+          <p>Primary color</p>
+          <Form.Field
+            name="primaryColor"
+            label="Primary color"
+            defaultValue={value.primaryColor || "#ffffff"}
+            type={ColorPicker}
+          />
+        </GSForm>
+        <RaisedButton
           label={finalSaveLabel}
           disabled={isSaveDisabled}
+          onClick={this.handleSubmit}
         />
-      </GSForm>
+      </div>
     );
   }
 }

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm.jsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm.jsx
@@ -226,7 +226,7 @@ class CampaignInteractionStepsForm extends React.Component {
     });
   };
 
-  hasUnsavedChanges = () => {
+  checkUnsavedChanges = () => {
     const { interactionSteps: pendingSteps } = this.state;
     const { interactionSteps } = this.props.formValues;
 
@@ -400,7 +400,7 @@ class CampaignInteractionStepsForm extends React.Component {
     });
 
     const hasEmptyScripts = emptyScriptSteps.length > 0;
-    const hasUnsavedSteps = this.hasUnsavedChanges();
+    const hasUnsavedSteps = this.checkUnsavedChanges();
 
     const shouldDisableSave = !hasUnsavedSteps || hasEmptyScripts;
 

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm.jsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm.jsx
@@ -1,3 +1,4 @@
+import isEqual from "lodash/isEqual";
 import { Dialog } from "material-ui";
 import { Card, CardActions, CardHeader, CardText } from "material-ui/Card";
 import FlatButton from "material-ui/FlatButton";
@@ -225,6 +226,15 @@ class CampaignInteractionStepsForm extends React.Component {
     });
   };
 
+  hasUnsavedChanges = () => {
+    const { interactionSteps: pendingSteps } = this.state;
+    const { interactionSteps } = this.props.formValues;
+
+    const hasUnsavedChanges = !isEqual(pendingSteps, interactionSteps);
+
+    return hasUnsavedChanges;
+  };
+
   renderInteractionStep(interactionStep, title = "Start") {
     const { availableActions, customFields } = this.props;
 
@@ -378,6 +388,7 @@ class CampaignInteractionStepsForm extends React.Component {
   }
 
   render() {
+    const { saveLabel } = this.props;
     const tree = makeTree(this.state.interactionSteps);
 
     const emptyScriptSteps = this.state.interactionSteps.filter((step) => {
@@ -389,6 +400,9 @@ class CampaignInteractionStepsForm extends React.Component {
     });
 
     const hasEmptyScripts = emptyScriptSteps.length > 0;
+    const hasUnsavedSteps = this.hasUnsavedChanges();
+
+    const shouldDisableSave = !hasUnsavedSteps || hasEmptyScripts;
 
     return (
       <div
@@ -424,9 +438,9 @@ class CampaignInteractionStepsForm extends React.Component {
         <RaisedButton
           {...dataTest("interactionSubmit")}
           primary
-          label={this.props.saveLabel}
-          disabled={hasEmptyScripts}
-          onTouchTap={this.onSave}
+          label={saveLabel}
+          disabled={shouldDisableSave}
+          onClick={this.onSave}
         />
         {hasEmptyScripts && (
           <p style={{ color: "#DD0000" }}>

--- a/src/containers/AdminCampaignEdit/sections/CampaignTeamsForm.jsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignTeamsForm.jsx
@@ -1,4 +1,5 @@
 import ChipInput from "material-ui-chip-input";
+import RaisedButton from "material-ui/RaisedButton";
 import Toggle from "material-ui/Toggle";
 import PropTypes from "prop-types";
 import React from "react";
@@ -11,6 +12,13 @@ import CampaignFormSectionHeading from "../components/CampaignFormSectionHeading
 const formSchema = yup.object({
   isAssignmentLimitedToTeams: yup.boolean()
 });
+
+const styles = {
+  button: {
+    display: "inline-block",
+    marginTop: 15
+  }
+};
 
 class CampaignTeamsForm extends React.Component {
   onIsAssignmentLimitedToTeamsDidToggle = (
@@ -58,46 +66,46 @@ class CampaignTeamsForm extends React.Component {
       saveDisabled,
       formValues,
       orgTeams,
-      onChange,
-      onSubmit
+      onChange
     } = this.props;
 
     return (
-      <GSForm
-        schema={formSchema}
-        value={formValues}
-        onChange={onChange}
-        onSubmit={onSubmit}
-      >
-        <CampaignFormSectionHeading
-          title="Teams for campaign"
-          subtitle="Optionally prioritize assigning texters from specific teams for this campaign by selecting them below. Restrict assignment solely to members of selected teams by using the toggle below."
+      <div>
+        <GSForm schema={formSchema} value={formValues} onChange={onChange}>
+          <CampaignFormSectionHeading
+            title="Teams for campaign"
+            subtitle="Optionally prioritize assigning texters from specific teams for this campaign by selecting them below. Restrict assignment solely to members of selected teams by using the toggle below."
+          />
+
+          <ChipInput
+            value={formValues.teams}
+            dataSourceConfig={{ text: "title", value: "id" }}
+            dataSource={orgTeams}
+            placeholder="Select teams"
+            fullWidth
+            openOnFocus
+            onBeforeRequestAdd={this.handleBeforeRequestAdd}
+            onRequestAdd={this.handleAddTeam}
+            onRequestDelete={this.handleRemoveTeam}
+          />
+
+          <br />
+
+          <Form.Field
+            name="isAssignmentLimitedToTeams"
+            type={Toggle}
+            toggled={formValues.isAssignmentLimitedToTeams}
+            label="Restrict assignment solely to members of these teams?"
+            onToggle={this.onIsAssignmentLimitedToTeamsDidToggle}
+          />
+        </GSForm>
+        <RaisedButton
+          label={saveLabel}
+          disabled={saveDisabled}
+          onClick={this.props.onSubmit}
+          style={styles.button}
         />
-
-        <ChipInput
-          value={formValues.teams}
-          dataSourceConfig={{ text: "title", value: "id" }}
-          dataSource={orgTeams}
-          placeholder="Select teams"
-          fullWidth
-          openOnFocus
-          onBeforeRequestAdd={this.handleBeforeRequestAdd}
-          onRequestAdd={this.handleAddTeam}
-          onRequestDelete={this.handleRemoveTeam}
-        />
-
-        <br />
-
-        <Form.Field
-          name="isAssignmentLimitedToTeams"
-          type={Toggle}
-          toggled={formValues.isAssignmentLimitedToTeams}
-          label="Restrict assignment solely to members of these teams?"
-          onToggle={this.onIsAssignmentLimitedToTeamsDidToggle}
-        />
-
-        <Form.Button type="submit" disabled={saveDisabled} label={saveLabel} />
-      </GSForm>
+      </div>
     );
   }
 }

--- a/src/containers/AdminCampaignEdit/sections/CampaignTextersForm.jsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignTextersForm.jsx
@@ -105,6 +105,10 @@ const inlineStyles = {
   splitAssignmentToggle: {
     width: "auto",
     marginLeft: "auto"
+  },
+  button: {
+    display: "inline-block",
+    marginTop: 15
   }
 };
 
@@ -479,7 +483,7 @@ export default class CampaignTextersForm extends React.Component {
     this.setState({ snackbarOpen: false, snackbarMessage: "" });
 
   render() {
-    const { isOverdue } = this.props;
+    const { isOverdue, saveLabel, saveDisabled } = this.props;
 
     const assignedContacts = this.formValues().texters.reduce(
       (prev, texter) => prev + texter.assignment.contactsCount,
@@ -522,7 +526,6 @@ export default class CampaignTextersForm extends React.Component {
           schema={this.formSchema}
           value={this.formValues()}
           onChange={this.onChange}
-          onSubmit={this.props.onSubmit}
         >
           <div style={{ display: "flex", justifyContent: "space-between" }}>
             {this.showSearch()}
@@ -580,12 +583,13 @@ export default class CampaignTextersForm extends React.Component {
             </div>
             {this.showTexters()}
           </div>
-          <Form.Button
-            type="submit"
-            label={this.props.saveLabel}
-            disabled={this.props.saveDisabled}
-          />
         </GSForm>
+        <RaisedButton
+          label={saveLabel}
+          disabled={saveDisabled}
+          onClick={this.props.onSubmit}
+          style={inlineStyles.button}
+        />
         <Snackbar
           open={this.state.snackbarOpen}
           message={this.state.snackbarMessage}

--- a/src/containers/AdminCampaignEdit/sections/CampaignTextingHoursForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignTextingHoursForm.tsx
@@ -2,6 +2,7 @@ import { ApolloQueryResult } from "apollo-client";
 import gql from "graphql-tag";
 import isEmpty from "lodash/isEmpty";
 import Autocomplete from "material-ui/AutoComplete";
+import RaisedButton from "material-ui/RaisedButton";
 import moment from "moment";
 import React from "react";
 import Form from "react-formal";
@@ -193,50 +194,46 @@ class CampaignTextingHoursForm extends React.Component<
     const finalSaveLabel = isWorking ? "Working..." : saveLabel;
 
     return (
-      <GSForm
-        schema={formSchema}
-        value={value}
-        onChange={this.handleChange}
-        onSubmit={this.handleSubmit}
-      >
-        <CampaignFormSectionHeading
-          title="Texting hours for campaign"
-          subtitle="Please configure texting hours for each campaign, noting the time zone of the individuals in the list you are uploading."
-        />
+      <div>
+        <GSForm schema={formSchema} value={value} onChange={this.handleChange}>
+          <CampaignFormSectionHeading
+            title="Texting hours for campaign"
+            subtitle="Please configure texting hours for each campaign, noting the time zone of the individuals in the list you are uploading."
+          />
 
-        {this.addAutocompleteFormField(
-          "textingHoursStart",
-          "textingHoursStartSearchText",
-          formatHour(value.textingHoursStart),
-          "Start time",
-          "Start typing a start time",
-          hourChoices
-        )}
+          {this.addAutocompleteFormField(
+            "textingHoursStart",
+            "textingHoursStartSearchText",
+            formatHour(value.textingHoursStart),
+            "Start time",
+            "Start typing a start time",
+            hourChoices
+          )}
 
-        {this.addAutocompleteFormField(
-          "textingHoursEnd",
-          "textingHoursEndSearchText",
-          formatHour(value.textingHoursEnd),
-          "End time",
-          "Start typing an end time",
-          hourChoices
-        )}
+          {this.addAutocompleteFormField(
+            "textingHoursEnd",
+            "textingHoursEndSearchText",
+            formatHour(value.textingHoursEnd),
+            "End time",
+            "Start typing an end time",
+            hourChoices
+          )}
 
-        {this.addAutocompleteFormField(
-          "timezone",
-          "timezoneSearchText",
-          value.timezone,
-          "Timezone to use for contacts without ZIP code and to determine daylight savings",
-          "Start typing a timezone",
-          timezoneChoices
-        )}
-
-        <Form.Button
-          type="submit"
-          disabled={isSaveDisabled}
+          {this.addAutocompleteFormField(
+            "timezone",
+            "timezoneSearchText",
+            value.timezone,
+            "Timezone to use for contacts without ZIP code and to determine daylight savings",
+            "Start typing a timezone",
+            timezoneChoices
+          )}
+        </GSForm>
+        <RaisedButton
           label={finalSaveLabel}
+          disabled={isSaveDisabled}
+          onClick={this.handleSubmit}
         />
-      </GSForm>
+      </div>
     );
   }
 }

--- a/src/containers/Settings/components/General.jsx
+++ b/src/containers/Settings/components/General.jsx
@@ -151,6 +151,8 @@ class Settings extends React.Component {
 
   checkUnsavedOptOutMessage = () => {
     const { optOutMessage } = this.state;
+    // if optOutMessage field is untouched,
+    // check optOutMessage against itself to return false and disable save
     const newMessage =
       optOutMessage || this.props.data.organization.settings.optOutMessage;
     const {

--- a/src/containers/Settings/components/General.jsx
+++ b/src/containers/Settings/components/General.jsx
@@ -68,16 +68,6 @@ class Settings extends React.Component {
     error: undefined
   };
 
-  // // optOutMessage is controlled via defaultValue in GSForm
-  // // to track changes to optOutMessage, in order to determine whether button
-  // // should be  we initiate it in state on mount
-
-  // // initialize via props instead
-  // componentDidMount = () => {
-  //   const { optOutMessage } = this.props.data.organization.settings;
-  //   this.setState({ optOutMessage })
-  // };
-
   editSettings = async (name, input) => {
     this.setState({ isWorking: true, error: undefined });
     let success = false;

--- a/src/containers/Settings/components/General.jsx
+++ b/src/containers/Settings/components/General.jsx
@@ -401,7 +401,6 @@ class Settings extends React.Component {
           <Card className={css(styles.sectionCard)}>
             <GSForm
               schema={trollbotSettingsSchema}
-              onSubmit={this.handleSaveTrollbotUrl}
               value={{ trollbotWebhookUrl }}
               onChange={({ trollbotWebhookUrl: newValue }) =>
                 this.setState({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Closes #781, part of Q4 feature freeze

## Motivation and Context

Unclickable buttons should be unclickable!

NB: For the edit campaign sections, It seems like there should be a better solution than extracting the form submit functionality into a button outside of the GSForm, but I spent a lot of time trying to properly disable the GSSubmitButton within the component itself and within the GSForm component, but couldn't crack it. 


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] My code follows the code style of this project.
- [x ] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
