### PR TITLE
fix(campaigns): wrap long campaign descriptions

### DIFF
--- a/src/containers/CampaignList/CampaignList.jsx
+++ b/src/containers/CampaignList/CampaignList.jsx
@@ -36,6 +36,9 @@ const inlineStyles = {
   },
   warnUnsent: {
     color: theme.colors.blue
+  },
+  secondaryText: {
+    whiteSpace: "pre-wrap"
   }
 };
 
@@ -185,7 +188,7 @@ export class CampaignList extends React.Component {
       </div>
     );
     const secondaryText = (
-      <span>
+      <span style={inlineStyles.secondaryText}>
         <span>
           Campaign ID: {campaign.id}
           <br />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
closes #682, party of Q4 feature freeze

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Campaign descriptions don't wrap, so long ones push the campaign actions toggle off the screen in the CampaignList component. Now the text wraps, so the toggles stay visible.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] My code follows the code style of this project.
- [x ] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
