### PR TITLE
fix(auth): remove incorrect local login error

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "camelcase-keys": "^4.1.0",
     "chart.js": "^1.1.1",
     "connect-datadog-graphql": "^0.0.11",
-    "cookie-session": "^2.0.0-alpha.1",
+    "cookie-session": "^1.4.0",
     "create-react-context": "^0.3.0",
     "dataloader": "^1.2.0",
     "dotenv": "^8.0.0",

--- a/src/server/auth-passport.ts
+++ b/src/server/auth-passport.ts
@@ -282,7 +282,6 @@ function setupLocalAuthPassport() {
 
       // eslint-disable-next-line no-useless-escape
       const uuidMatch = nextUrl.match(/\w{8}-(\w{4}\-){3}\w{12}/);
-      if (!uuidMatch) return done(new LocalAuthError("Could not match uuid"));
 
       const lowerCaseEmail = username.toLowerCase();
       const existingUser = await db

--- a/src/server/local-auth-helpers.ts
+++ b/src/server/local-auth-helpers.ts
@@ -17,7 +17,7 @@ interface AuthHelperOptions {
   password: string;
   existingUser: UserRecord;
   nextUrl: string;
-  uuidMatch: RegExpMatchArray;
+  uuidMatch: RegExpMatchArray | null;
   reqBody: any;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5518,15 +5518,14 @@ convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.0,
   dependencies:
     safe-buffer "~5.1.1"
 
-cookie-session@^2.0.0-alpha.1:
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/cookie-session/-/cookie-session-2.0.0-rc.1.tgz#66fa03f26e5873d681d70f14bff5e48a94c53d37"
-  integrity sha512-zg80EsLe7S1J4y0XxV7SZ8Fbi90ZZoampuX2bfYDOvJfc//98sSlZC41YDzTTjtVbeU1VlVdBbldXOOyi5xzEw==
+cookie-session@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/cookie-session/-/cookie-session-1.4.0.tgz#c325aea685ceb9c8e4fd00b0313a46d547747380"
+  integrity sha512-0hhwD+BUIwMXQraiZP/J7VP2YFzqo6g4WqZlWHtEHQ22t0MeZZrNBSCxC1zcaLAs8ApT3BzAKizx9gW/AP9vNA==
   dependencies:
     cookies "0.8.0"
-    debug "3.2.6"
+    debug "2.6.9"
     on-headers "~1.0.2"
-    safe-buffer "5.2.0"
 
 cookie-signature@1.0.6:
   version "1.0.6"
@@ -6058,17 +6057,17 @@ debug@3.1.0, debug@~3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@3.2.6, debug@^3.0.0, debug@^3.0.1, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
-  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  dependencies:
-    ms "^2.1.1"
-
 debug@4, debug@4.1.1, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
+debug@^3.0.0, debug@^3.0.1, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
 
@@ -16098,7 +16097,7 @@ safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@5.2.0, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
+safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
   integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==


### PR DESCRIPTION
## Description

Revert the incorrect throwing of an error within the local login flow.

This also downgrades `cookie-session` to the latest stable version.

## Motivation and Context

The error thrown for falsey `uuidMatch` was added in #560 to fix a type complaint. This commit fixes typing in the correct way and reverts adding the error.

I was running into `TypeError: this.socket.cork is not a function` errors on every request with no useful traces after making the `uuidMatch` fix. Downgrading `cookie-session` to a stable version solved these issues (and may also solve some of the account lockout problems some users encounter).

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
