### PR TITLE
fix: fix regression in canned response resolver

### DIFF
--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -315,18 +315,14 @@ export const resolvers = {
 
       return getInteractionSteps({ campaignId: campaign.id });
     },
-    cannedResponses: async (campaign, _, { user }) => {
+    cannedResponses: async (campaign, { userId: userIdArg }) => {
       const getCannedResponses = memoizer.memoize(
-        async ({ campaignId, userId }) => {
-          return cacheableData.cannedResponse.query({
-            userId: userId || "",
-            campaignId
-          });
-        },
+        ({ campaignId, userId }) =>
+          cacheableData.cannedResponse.query({ campaignId, userId }),
         cacheOpts.CampaignCannedResponses
       );
 
-      return getCannedResponses({ campaignId: campaign.id, userId: user.id });
+      return getCannedResponses({ campaignId: campaign.id, userId: userIdArg });
     },
     contacts: async (campaign) =>
       r


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Use optional `userId` argument from GraphQL for canned response query.

## Motivation and Context

This fixes a regression from #726 (typescript eslint). A shadowed variable name error was incorrectly fixed by using the session user's ID instead of the GraphQL query argument.

GraphQL query signature looks like:

```gql
type Campaign {
    cannedResponses(userId: String): [CannedResponse]
}
```

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
