### PR TITLE
feat(van): sync opt-outs

### DIFF
--- a/migrations/20201216105636_van_sync_opt_out_configuration.js
+++ b/migrations/20201216105636_van_sync_opt_out_configuration.js
@@ -1,0 +1,27 @@
+exports.up = function up(knex) {
+  return knex.schema.raw(`
+    -- Opt Out Sync Configurations
+    create table public.external_sync_opt_out_configuration (
+      id uuid not null default uuid_generate_v1mc(),
+      system_id uuid not null references public.external_system(id),
+      external_result_code_id uuid not null references public.external_result_code(id),
+      created_at timestamptz not null default now(),
+      updated_at timestamptz not null default now(),
+
+      primary key (id),
+      unique (system_id)
+    );
+
+    create trigger _500_external_sync_opt_out_configuration_updated_at
+      before update
+      on public.external_sync_opt_out_configuration
+      for each row
+      execute procedure universal_updated_at();
+  `);
+};
+
+exports.down = function down(knex) {
+  return knex.schema.raw(`
+    drop table public.external_sync_opt_out_configuration;
+  `);
+};

--- a/src/api/external-system.ts
+++ b/src/api/external-system.ts
@@ -2,6 +2,7 @@ import { ExternalActivistCode } from "./external-activist-code";
 import { ExternalList } from "./external-list";
 import { ExternalResultCode } from "./external-result-code";
 import { ExternalSurveyQuestion } from "./external-survey-question";
+import { ExternalResultCodeTarget } from "./external-sync-config";
 import { RelayPaginatedResponse } from "./pagination";
 
 export enum ExternalSystemType {
@@ -22,6 +23,7 @@ export interface ExternalSystem {
   surveyQuestions: RelayPaginatedResponse<ExternalSurveyQuestion>;
   activistCodes: RelayPaginatedResponse<ExternalActivistCode>;
   resultCodes: RelayPaginatedResponse<ExternalResultCode>;
+  optOutSyncConfig: ExternalResultCodeTarget | null;
 }
 
 export interface ExternalSystemInput {
@@ -71,6 +73,7 @@ export const schema = `
     surveyQuestions(filter: ExternalSurveyQuestionFilter, after: Cursor, first: Int): ExternalSurveyQuestionPage!
     activistCodes(filter: ExternalActivistCodeFilter, after: Cursor, first: Int): ExternalActivistCodePage!
     resultCodes(after: Cursor, first: Int): ExternalResultCodePage!
+    optOutSyncConfig: ExternalResultCodeTarget
   }
 
   type ExternalSystemEdge {

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -346,6 +346,7 @@ const rootSchema = `
     createQuestionResponseSyncTarget(input: QuestionResponseSyncTargetInput!): ExternalSyncConfigTarget!
     deleteQuestionResponseSyncTarget(targetId: String!): String!
     syncCampaignToSystem(input: SyncCampaignToSystemInput!): Boolean!
+    editExternalOptOutSyncConfig(systemId: String!, targetId: String): ExternalSystem!
   }
 
   schema {

--- a/src/containers/AdminExternalSystemDetail/components/OptOutConfigurationCard.tsx
+++ b/src/containers/AdminExternalSystemDetail/components/OptOutConfigurationCard.tsx
@@ -1,0 +1,197 @@
+import { ApolloQueryResult } from "apollo-client";
+import gql from "graphql-tag";
+import { Card, CardHeader, CardText } from "material-ui/Card";
+import CircularProgress from "material-ui/CircularProgress";
+import Dialog from "material-ui/Dialog";
+import FlatButton from "material-ui/FlatButton";
+import MenuItem from "material-ui/MenuItem";
+import SelectField from "material-ui/SelectField";
+import React from "react";
+
+import { ExternalSystem } from "../../../api/external-system";
+import { sleep } from "../../../lib/utils";
+import { MutationMap, QueryMap } from "../../../network/types";
+import { loadData } from "../../hoc/with-operations";
+
+interface Props {
+  systemId: string;
+  mutations: {
+    editSyncConfig(targetId: string | null): Promise<ApolloQueryResult<any>>;
+  };
+  syncConfig: {
+    externalSystem: Pick<ExternalSystem, "id" | "optOutSyncConfig">;
+  };
+  resultCodes: { externalSystem: Pick<ExternalSystem, "id" | "resultCodes"> };
+}
+
+interface State {
+  isWorking: boolean;
+  error?: string;
+}
+
+class OptOutConfigurationCard extends React.Component<Props, State> {
+  state: State = {
+    isWorking: false,
+    error: undefined
+  };
+
+  handleChangeResultCode = async (
+    e: React.SyntheticEvent<unknown>,
+    index: number,
+    targetId: string | null
+  ) => {
+    this.setState({ isWorking: true });
+
+    try {
+      // Ensure loading indicator is shown at least long enough for the user to see
+      await Promise.all([
+        sleep(400),
+        this.props.mutations.editSyncConfig(targetId).then((response) => {
+          if (response.errors) throw response.errors;
+        })
+      ]);
+    } catch (err) {
+      this.setState({ error: err.message });
+    } finally {
+      this.setState({ isWorking: false });
+    }
+  };
+
+  handleDismissError = () => this.setState({ error: undefined });
+
+  render() {
+    const { error, isWorking } = this.state;
+    const {
+      syncConfig: {
+        externalSystem: { optOutSyncConfig }
+      },
+      resultCodes: {
+        externalSystem: { resultCodes }
+      }
+    } = this.props;
+
+    return (
+      <Card>
+        <CardHeader title="Opt Out Sync Configuration" />
+        <CardText>
+          Map Spoke Opt Outs to the result code selected below. If no result
+          code is selected, opt outs will not be synced.
+          <div style={{ display: "flex", alignItems: "center" }}>
+            <SelectField
+              floatingLabelText="Result Code"
+              value={optOutSyncConfig?.resultCode.id}
+              fullWidth
+              disabled={isWorking}
+              onChange={this.handleChangeResultCode}
+            >
+              <MenuItem value={null} primaryText="" />
+              {resultCodes.edges.map(({ node }) => (
+                <MenuItem
+                  key={node.id}
+                  value={node.id}
+                  primaryText={node.name}
+                />
+              ))}
+            </SelectField>
+            <CircularProgress
+              style={{
+                visibility: isWorking ? "visible" : "hidden",
+                marginLeft: "10px"
+              }}
+            />
+          </div>
+        </CardText>
+        <Dialog
+          title="Error Saving Opt Out Sync Configuration"
+          actions={[
+            <FlatButton
+              key="close"
+              label="Close"
+              primary
+              onClick={this.handleDismissError}
+            />
+          ]}
+          modal={false}
+          open={error !== undefined}
+          onRequestClose={this.handleDismissError}
+        >
+          {error}
+        </Dialog>
+      </Card>
+    );
+  }
+}
+
+const queries: QueryMap<Props> = {
+  syncConfig: {
+    query: gql`
+      query getOptOutSyncConfig($systemId: String!) {
+        externalSystem(systemId: $systemId) {
+          id
+          optOutSyncConfig {
+            id
+            resultCode {
+              id
+              name
+            }
+          }
+        }
+      }
+    `,
+    options: ({ systemId }) => ({
+      variables: { systemId }
+    })
+  },
+  resultCodes: {
+    query: gql`
+      query getExternalResultCodes($systemId: String!) {
+        externalSystem(systemId: $systemId) {
+          id
+          resultCodes {
+            edges {
+              node {
+                id
+                name
+              }
+            }
+          }
+        }
+      }
+    `,
+    options: ({ systemId }) => ({
+      variables: { systemId }
+    })
+  }
+};
+
+const mutations: MutationMap<Props> = {
+  editSyncConfig: (ownProps) => (targetId: string | null) => ({
+    mutation: gql`
+      mutation editExternalOptOutSyncConfig(
+        $systemId: String!
+        $targetId: String
+      ) {
+        editExternalOptOutSyncConfig(systemId: $systemId, targetId: $targetId) {
+          id
+          optOutSyncConfig {
+            id
+            resultCode {
+              id
+              name
+            }
+          }
+        }
+      }
+    `,
+    variables: {
+      systemId: ownProps.systemId,
+      targetId
+    },
+    refetchQueries: ["getExternalSystems"]
+  })
+};
+
+export default loadData({
+  mutations,
+  queries
+})(OptOutConfigurationCard);

--- a/src/containers/AdminExternalSystemDetail/index.tsx
+++ b/src/containers/AdminExternalSystemDetail/index.tsx
@@ -10,6 +10,7 @@ import { withRouter } from "react-router-dom";
 import { ExternalSystem } from "../../api/external-system";
 import { QueryMap } from "../../network/types";
 import { loadData } from "../hoc/with-operations";
+import OptOutConfigurationCard from "./components/OptOutConfigurationCard";
 
 interface Props {
   match: any;
@@ -50,6 +51,8 @@ export const AdminExternalSystemsDetail: React.SFC<Props> = (props) => {
           </dl>
         </CardText>
       </Card>
+      <br />
+      <OptOutConfigurationCard systemId={externalSystem.id} />
     </div>
   );
 };

--- a/src/server/api/external-system.ts
+++ b/src/server/api/external-system.ts
@@ -75,6 +75,12 @@ export const resolvers = {
         .reader("external_result_code")
         .where({ system_id: system.id });
       return formatPage(query, { after, first, primaryColumn: "created_at" });
-    }
+    },
+    optOutSyncConfig: (system: ExternalSystem) =>
+      r
+        .reader("public.external_sync_opt_out_configuration")
+        .where({ system_id: system.id })
+        .first()
+        .then((result) => result || null)
   }
 };

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -3443,6 +3443,37 @@ const rootMutations = {
       ]);
 
       return true;
+    },
+    editExternalOptOutSyncConfig: async (
+      _root,
+      { systemId, targetId },
+      { user }
+    ) => {
+      const externalSystem = await r
+        .knex("external_system")
+        .where({ id: systemId })
+        .first();
+
+      await accessRequired(user, externalSystem.organization_id, "ADMIN");
+
+      if (targetId) {
+        await r.knex.raw(
+          `
+            insert into external_sync_opt_out_configuration (system_id, external_result_code_id)
+            values (?, ?)
+            on conflict (system_id) do update
+              set external_result_code_id = EXCLUDED.external_result_code_id
+          `,
+          [externalSystem.id, targetId]
+        );
+      } else {
+        await r
+          .knex("external_sync_opt_out_configuration")
+          .where({ system_id: externalSystem.id })
+          .del();
+      }
+
+      return externalSystem;
     }
   }
 };


### PR DESCRIPTION
## Description

Allows configuring a per-integration sync mapping for Spoke opt outs.

## Motivation and Context

Closes #797 

## How Has This Been Tested?

This has been tested locally with a variety of combinations of opt out, messaged status, and question response mappings by looking at the payload to be sent to VAN.

## Screenshots (if appropriate):

<table border="1"><tr><td>

![Menubar_and_Spoke](https://user-images.githubusercontent.com/2145526/102394342-9e214180-3fa7-11eb-87de-69cd3586f224.png)

</td></tr></table>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

The VAN sync documentation will need to be updated to include this configuration step.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
