### PR TITLE
chore: remove deprecated touch-tap plugin

### DIFF
--- a/__test__/AssignmentSummary.test.js
+++ b/__test__/AssignmentSummary.test.js
@@ -4,7 +4,6 @@
 import React from 'react'
 import { mount } from 'enzyme'
 import { StyleSheetTestUtils } from 'aphrodite'
-import injectTapEventPlugin from 'react-tap-event-plugin'
 import each from 'jest-each'
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
 import { CardActions, CardTitle } from 'material-ui/Card'
@@ -64,7 +63,6 @@ describe('AssignmentSummary text', function t() {
 })
 
 describe('AssignmentSummary actions inUSA and NOT AllowSendAll', () => {
-  injectTapEventPlugin()  // prevents warning
   function create(unmessaged, unreplied, badTimezone, past, skipped, isDynamic) {
     window.NOT_IN_USA = 0
     window.ALLOW_SEND_ALL = false

--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
     "react-portal": "^4.2.1",
     "react-router-dom": "^5.1.2",
     "react-select": "^2.0.0",
-    "react-tap-event-plugin": "^2.0.0",
     "recompose": "^0.24.0",
     "redis": "^2.8.0",
     "redis-promisify": "^0.1.2",

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -6,7 +6,6 @@ import { StyleSheet } from "aphrodite";
 import React from "react";
 import ReactDOM from "react-dom";
 import Form from "react-formal";
-import injectTapEventPlugin from "react-tap-event-plugin";
 
 import GSDateField from "../components/forms/GSDateField";
 import GSPasswordField from "../components/forms/GSPasswordField";
@@ -34,8 +33,5 @@ Form.addInputTypes({
   select: GSSelectField,
   password: GSPasswordField
 });
-
-// Needed for MaterialUI
-injectTapEventPlugin();
 
 ReactDOM.render(<App />, document.getElementById("mount"));

--- a/src/components/AssignmentTexter.jsx
+++ b/src/components/AssignmentTexter.jsx
@@ -259,14 +259,14 @@ class AssignmentTexter extends React.Component {
       />,
       <IconButton
         key="previous"
-        onTouchTap={this.handleNavigatePrevious}
+        onClick={this.handleNavigatePrevious}
         disabled={!this.hasPrevious()}
       >
         <NavigateBeforeIcon />
       </IconButton>,
       <IconButton
         key="next"
-        onTouchTap={this.handleNavigateNext}
+        onClick={this.handleNavigateNext}
         disabled={!this.hasNext()}
       >
         <NavigateNextIcon />

--- a/src/components/BulkSendButton.jsx
+++ b/src/components/BulkSendButton.jsx
@@ -30,7 +30,7 @@ export default class BulkSendButton extends Component {
     return (
       <div className={css(styles.container)}>
         <RaisedButton
-          onTouchTap={this.sendMessages}
+          onClick={this.sendMessages}
           label={
             this.state.isSending
               ? "Sending..."

--- a/src/components/Chip.jsx
+++ b/src/components/Chip.jsx
@@ -33,16 +33,16 @@ function Chip({
   text,
   iconRightClass,
   onIconRightTouchTap,
-  onTouchTap,
+  onClick,
   style = {}
 }) {
   return (
-    <div style={extend({}, styles.chip, style)} onTouchTap={onTouchTap}>
+    <div style={extend({}, styles.chip, style)} onClick={onClick}>
       {text}
       {iconRightClass
         ? React.createElement(iconRightClass, {
             style: styles.icon,
-            onTouchTap: onIconRightTouchTap
+            onClick: onIconRightTouchTap
           })
         : ""}
     </div>
@@ -53,7 +53,7 @@ Chip.propTypes = {
   text: PropTypes.node,
   iconRightClass: PropTypes.string,
   onIconRightTouchTap: PropTypes.func,
-  onTouchTap: PropTypes.func,
+  onClick: PropTypes.func,
   style: PropTypes.object
 };
 

--- a/src/components/ConfirmButton.jsx
+++ b/src/components/ConfirmButton.jsx
@@ -44,7 +44,7 @@ export default class ConfirmButton extends Component {
     return (
       <div className={css(styles.container)}>
         <RaisedButton
-          onTouchTap={this.toggleConfirmationDialog}
+          onClick={this.toggleConfirmationDialog}
           label={this.props.label}
         />
         <Dialog

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -46,7 +46,7 @@ const Navigation = function Navigation(props) {
                 {...dataTest(camelCase(`nav ${section.path}`))}
                 key={section.name}
                 primaryText={section.name}
-                onTouchTap={() => props.history.push(section.url)}
+                onClick={() => props.history.push(section.url)}
                 rightAvatar={
                   section.badge && (
                     <Avatar backgroundColor="#FFAA00" size={30}>

--- a/src/components/ScriptEditor.jsx
+++ b/src/components/ScriptEditor.jsx
@@ -197,7 +197,7 @@ class ScriptEditor extends React.Component {
             key={field}
             style={styles.scriptFieldButton}
             text={delimit(field)}
-            onTouchTap={() => this.addCustomField(field)}
+            onClick={() => this.addCustomField(field)}
           />
         ))}
       </div>

--- a/src/components/ScriptList.jsx
+++ b/src/components/ScriptList.jsx
@@ -75,12 +75,12 @@ class ScriptList extends React.Component {
     //     targetOrigin={{horizontal: 'left', vertical: 'bottom'}}
     //   >
     //     <MenuItem primaryText={duplicateCampaignResponses && !script.isUserCreated ? "Duplicate and edit" : "Edit"}
-    //       onTouchTap={() => this.handleEditScript(script)}
+    //       onClick={() => this.handleEditScript(script)}
     //     />
     //     {
     //       script.isUserCreated ? (
     //         <MenuItem primaryText="Delete"
-    //           onTouchTap={() => this.handleDeleteScript(script.id)}
+    //           onClick={() => this.handleDeleteScript(script.id)}
     //         />
     //       ) : ''
     //     }
@@ -91,7 +91,7 @@ class ScriptList extends React.Component {
     const listItems = scripts.map((script) => (
       <ListItem
         value={script.text}
-        onTouchTap={() => onSelectCannedResponse(script)}
+        onClick={() => onSelectCannedResponse(script)}
         key={script.id}
         primaryText={script.title}
         secondaryText={script.text}
@@ -115,7 +115,7 @@ class ScriptList extends React.Component {
           <FlatButton
             label="Add new canned response"
             icon={<CreateIcon />}
-            onTouchTap={this.handleOpenDialog}
+            onClick={this.handleOpenDialog}
           />
         ) : (
           ""
@@ -128,7 +128,7 @@ class ScriptList extends React.Component {
               <FlatButton
                 key="cancel"
                 label="Cancel"
-                onTouchTap={this.handleCloseDialog}
+                onClick={this.handleCloseDialog}
               />,
               <Form.Button
                 key="save"

--- a/src/components/SendButton.jsx
+++ b/src/components/SendButton.jsx
@@ -42,7 +42,7 @@ class SendButton extends Component {
       <div className={css(styles.container)}>
         <RaisedButton
           {...dataTest("send")}
-          onTouchTap={this.handleTouchTap}
+          onClick={this.handleTouchTap}
           disabled={this.props.disabled}
           label={this.clickStepLabels()[this.state.clickStepIndex]}
           primary

--- a/src/components/forms/GSScriptField.jsx
+++ b/src/components/forms/GSScriptField.jsx
@@ -91,13 +91,13 @@ class GSScriptField extends GSFormField {
             key="cancel"
             {...dataTest("scriptCancel")}
             label="Cancel"
-            onTouchTap={this.handleCancelDialog}
+            onClick={this.handleCancelDialog}
           />,
           <RaisedButton
             key="done"
             {...dataTest("scriptDone")}
             label="Done"
-            onTouchTap={this.wrapSaveScript}
+            onClick={this.wrapSaveScript}
             primary
           />
         ]}

--- a/src/components/forms/GSScriptOptionsField.jsx
+++ b/src/components/forms/GSScriptOptionsField.jsx
@@ -113,13 +113,13 @@ class GSScriptOptionsField extends GSFormField {
         key="cancel"
         {...dataTest("scriptCancel")}
         label="Cancel"
-        onTouchTap={this.handleCancelDialog}
+        onClick={this.handleCancelDialog}
       />,
       <RaisedButton
         key="done"
         {...dataTest("scriptDone")}
         label="Done"
-        onTouchTap={this.wrapSaveScript}
+        onClick={this.wrapSaveScript}
         primary
         disabled={isDuplicate}
       />

--- a/src/containers/AdminCampaignEdit/index.jsx
+++ b/src/containers/AdminCampaignEdit/index.jsx
@@ -726,7 +726,7 @@ class AdminCampaignEdit extends React.Component {
           {this.props.campaignData.campaign.isArchived ? (
             <RaisedButton
               label="Unarchive"
-              onTouchTap={() =>
+              onClick={() =>
                 this.props.mutations.unarchiveCampaign(
                   this.props.campaignData.campaign.id
                 )
@@ -735,7 +735,7 @@ class AdminCampaignEdit extends React.Component {
           ) : (
             <RaisedButton
               label="Archive"
-              onTouchTap={() =>
+              onClick={() =>
                 this.props.mutations.archiveCampaign(
                   this.props.campaignData.campaign.id
                 )
@@ -747,7 +747,7 @@ class AdminCampaignEdit extends React.Component {
             primary
             label="Start This Campaign!"
             disabled={!isCompleted}
-            onTouchTap={async () => {
+            onClick={async () => {
               this.setState({
                 startingCampaign: true
               });
@@ -892,7 +892,7 @@ class AdminCampaignEdit extends React.Component {
                   <RaisedButton
                     label="Discard Job"
                     icon={<CancelIcon />}
-                    onTouchTap={() => this.handleDeleteJob(jobId)}
+                    onClick={() => this.handleDeleteJob(jobId)}
                   />
                 </CardActions>
               ) : null}

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm.jsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm.jsx
@@ -279,7 +279,7 @@ class CampaignInteractionStepsForm extends React.Component {
             {this.state.hasBlockCopied && (
               <RaisedButton
                 label="+ Paste Block"
-                onTouchTap={this.onRequestRootPaste}
+                onClick={this.onRequestRootPaste}
               />
             )}
           </CardActions>
@@ -300,9 +300,7 @@ class CampaignInteractionStepsForm extends React.Component {
                     hintText="Answer to the previous question"
                   />
                   <IconButton
-                    onTouchTap={this.createDeleteStepHandler(
-                      interactionStep.id
-                    )}
+                    onClick={this.createDeleteStepHandler(interactionStep.id)}
                   >
                     <DeleteIcon />
                   </IconButton>
@@ -360,7 +358,7 @@ class CampaignInteractionStepsForm extends React.Component {
                 key="add"
                 {...dataTest("addResponse")}
                 label="+ Add a response"
-                onTouchTap={this.createAddStepHandler(interactionStep.id)}
+                onClick={this.createAddStepHandler(interactionStep.id)}
                 style={{ marginBottom: "10px" }}
               />
             ].concat(
@@ -369,9 +367,7 @@ class CampaignInteractionStepsForm extends React.Component {
                     <RaisedButton
                       key="paste"
                       label="+ Paste Block"
-                      onTouchTap={this.createPasteBlockHandler(
-                        interactionStep.id
-                      )}
+                      onClick={this.createPasteBlockHandler(interactionStep.id)}
                       style={{ marginBottom: "10px" }}
                     />
                   ]

--- a/src/containers/AdminCampaignEdit/sections/CampaignTextersForm.jsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignTextersForm.jsx
@@ -451,7 +451,7 @@ export default class CampaignTextersForm extends React.Component {
           )}
           <div className={css(styles.removeButton)}>
             <IconButton
-              onTouchTap={async () => {
+              onClick={async () => {
                 const currentFormValues = this.formValues();
                 const newFormValues = {
                   ...currentFormValues
@@ -533,12 +533,12 @@ export default class CampaignTextersForm extends React.Component {
               <RaisedButton
                 {...dataTest("addAll")}
                 label="Add All"
-                onTouchTap={() => this.addAllTexters()}
+                onClick={() => this.addAllTexters()}
               />
               <RaisedButton
                 {...dataTest("addAll")}
                 label="Remove Empty"
-                onTouchTap={() => this.removeEmptyTexters()}
+                onClick={() => this.removeEmptyTexters()}
               />
             </div>
           </div>

--- a/src/containers/AdminCampaignList.jsx
+++ b/src/containers/AdminCampaignList.jsx
@@ -241,7 +241,7 @@ class AdminCampaignList extends React.Component {
           <FloatingActionButton
             {...dataTest("addCampaign")}
             style={theme.components.floatingButton}
-            onTouchTap={this.handleClickNewButton}
+            onClick={this.handleClickNewButton}
           >
             <ContentAdd />
           </FloatingActionButton>

--- a/src/containers/AdminCampaignStats/index.jsx
+++ b/src/containers/AdminCampaignStats/index.jsx
@@ -209,7 +209,7 @@ class AdminCampaignStats extends React.Component {
                         campaign.isArchived ? (
                           <RaisedButton
                             key="unarchive"
-                            onTouchTap={() =>
+                            onClick={() =>
                               this.props.mutations.unarchiveCampaign()
                             }
                             label="Unarchive"
@@ -218,7 +218,7 @@ class AdminCampaignStats extends React.Component {
                         !campaign.isArchived ? (
                           <RaisedButton
                             key="archive"
-                            onTouchTap={() =>
+                            onClick={() =>
                               this.props.mutations.archiveCampaign()
                             }
                             label="Archive"
@@ -228,7 +228,7 @@ class AdminCampaignStats extends React.Component {
                         <RaisedButton
                           key="open-script-preview"
                           label="Open Script Preview"
-                          onTouchTap={() => {
+                          onClick={() => {
                             window.open(
                               `/preview/${campaign.previewUrl}`,
                               "_blank"
@@ -241,7 +241,7 @@ class AdminCampaignStats extends React.Component {
                           {...dataTest("copyCampaign")}
                           label="Copy Campaign"
                           disabled={this.state.copyingCampaign}
-                          onTouchTap={() => {
+                          onClick={() => {
                             this.setState({ copyingCampaign: true });
 
                             this.props.mutations

--- a/src/containers/AdminNavigation.jsx
+++ b/src/containers/AdminNavigation.jsx
@@ -26,7 +26,7 @@ class AdminNavigation extends React.Component {
           <ListItem
             {...dataTest("navSwitchToTexter")}
             primaryText="Switch to texter"
-            onTouchTap={() =>
+            onClick={() =>
               this.props.history.push(`/app/${organizationId}/todos`)
             }
           />

--- a/src/containers/AdminPersonList.jsx
+++ b/src/containers/AdminPersonList.jsx
@@ -238,7 +238,7 @@ class AdminPersonList extends React.Component {
                 <FlatButton
                   {...dataTest("editPerson")}
                   label="Edit"
-                  onTouchTap={() => {
+                  onClick={() => {
                     this.editUser(person.id);
                   }}
                 />
@@ -248,7 +248,7 @@ class AdminPersonList extends React.Component {
                   <FlatButton
                     label="Reset Password"
                     disabled={currentUser.id === person.id}
-                    onTouchTap={() => {
+                    onClick={() => {
                       this.resetPassword(person.id);
                     }}
                   />
@@ -272,7 +272,7 @@ class AdminPersonList extends React.Component {
         <FloatingActionButton
           {...dataTest("addPerson")}
           style={theme.components.floatingButton}
-          onTouchTap={this.handleOpen}
+          onClick={this.handleOpen}
         >
           <ContentAdd />
         </FloatingActionButton>
@@ -304,7 +304,7 @@ class AdminPersonList extends React.Component {
                   {...dataTest("inviteOk")}
                   label="OK"
                   primary
-                  onTouchTap={this.handleClose}
+                  onClick={this.handleClose}
                 />
               ]}
               modal={false}
@@ -323,7 +323,7 @@ class AdminPersonList extends React.Component {
                   {...dataTest("passResetOK")}
                   label="OK"
                   primary
-                  onTouchTap={this.handleClose}
+                  onClick={this.handleClose}
                 />
               ]}
               modal={false}

--- a/src/containers/AssignmentTexterContact/ContactActionDialog.jsx
+++ b/src/containers/AssignmentTexterContact/ContactActionDialog.jsx
@@ -88,7 +88,7 @@ class ContactActionDialog extends Component {
               <FlatButton
                 style={inlineStyles.dialogButton}
                 label="Cancel"
-                onTouchTap={handleCloseDialog}
+                onClick={handleCloseDialog}
               />
               <Form.Button
                 type="submit"

--- a/src/containers/AssignmentTexterContact/TopFixedSection.jsx
+++ b/src/containers/AssignmentTexterContact/TopFixedSection.jsx
@@ -14,7 +14,7 @@ const TopFixedSection = (props) => {
       contactSettings={contactSettings}
       rightToolbarIcon={
         <IconButton
-          onTouchTap={onExitTexter}
+          onClick={onExitTexter}
           tooltip="Return Home"
           tooltipPosition="bottom-center"
         >

--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -572,14 +572,14 @@ export class AssignmentTexterContact extends React.Component {
     if (messageStatus === "closed") {
       button = (
         <RaisedButton
-          onTouchTap={() => this.handleEditMessageStatus("needsResponse")}
+          onClick={() => this.handleEditMessageStatus("needsResponse")}
           label="Reopen"
         />
       );
     } else if (messageStatus === "needsResponse") {
       button = (
         <RaisedButton
-          onTouchTap={this.handleClickCloseContactButton}
+          onClick={this.handleClickCloseContactButton}
           label="Skip Reply"
         />
       );
@@ -653,12 +653,12 @@ export class AssignmentTexterContact extends React.Component {
             {...dataTest("optOut")}
             secondary
             label="Opt out"
-            onTouchTap={this.handleOpenOptOutDialog}
+            onClick={this.handleOpenOptOutDialog}
             tooltip="Opt out this contact"
           />
           <RaisedButton
             label="Canned replies"
-            onTouchTap={this.handleOpenPopover}
+            onClick={this.handleOpenPopover}
             disabled={!isCannedResponseEnabled}
           />
           {this.renderNeedsResponseToggleButton(contact)}
@@ -698,14 +698,14 @@ export class AssignmentTexterContact extends React.Component {
               {this.renderNeedsResponseToggleButton(contact)}
               <RaisedButton
                 label="Canned responses"
-                onTouchTap={this.handleOpenPopover}
+                onClick={this.handleOpenPopover}
                 disabled={!isCannedResponseEnabled}
               />
               <RaisedButton
                 {...dataTest("optOut")}
                 secondary
                 label="Opt out"
-                onTouchTap={this.handleOpenOptOutDialog}
+                onClick={this.handleOpenOptOutDialog}
               />
               <RaisedButton
                 label="Manage Tags"

--- a/src/containers/AssignmentTexterSurveyDropdown.jsx
+++ b/src/containers/AssignmentTexterSurveyDropdown.jsx
@@ -64,7 +64,7 @@ class AssignmentTexterSurveyDropdown extends Component {
         key="clear"
         value="clearResponse"
         primaryText="Clear response"
-        // onTouchTap={(event) => this.handleAnswerDelete(event, step.id)}
+        // onClick={(event) => this.handleAnswerDelete(event, step.id)}
       />
     );
 

--- a/src/containers/UserEdit.jsx
+++ b/src/containers/UserEdit.jsx
@@ -295,7 +295,7 @@ class UserEdit extends React.Component {
             {canChangePassword && (
               <div className={css(styles.container)}>
                 <RaisedButton
-                  onTouchTap={this.handleClick}
+                  onClick={this.handleClick}
                   label="Change password"
                   variant="outlined"
                 />
@@ -336,7 +336,7 @@ class UserEdit extends React.Component {
             onBackdropClick={this.handleClose}
             onEscapeKeyDown={this.handleClose}
           >
-            <RaisedButton onTouchTap={this.handleClose} label="OK" primary />
+            <RaisedButton onClick={this.handleClose} label="OK" primary />
           </Dialog>
         </div>
 

--- a/src/containers/UserMenu.jsx
+++ b/src/containers/UserMenu.jsx
@@ -136,7 +136,7 @@ class UserMenu extends Component {
       <div>
         <IconButton
           {...dataTest("userMenuButton")}
-          onTouchTap={this.handleTouchTap}
+          onClick={this.handleTouchTap}
           iconStyle={{ fontSize: "18px" }}
         >
           {this.renderAvatar(currentUser, avatarSize)}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7791,7 +7791,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.6, fbjs@^0.8.9:
+fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -15129,13 +15129,6 @@ react-select@^2.0.0:
     raf "^3.4.0"
     react-input-autosize "^2.2.1"
     react-transition-group "^2.2.1"
-
-react-tap-event-plugin@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/react-tap-event-plugin/-/react-tap-event-plugin-2.0.1.tgz#316beb3bc6556e29ec869a7293e89c826a9074d2"
-  integrity sha1-MWvrO8ZVbinshppyk+icgmqQdNI=
-  dependencies:
-    fbjs "^0.8.6"
 
 react-test-renderer@15:
   version "15.6.2"


### PR DESCRIPTION
## Description

This removed the deprecated `react-tap-event-plugin` plugin.

## Motivation and Context

Closes #417

## How Has This Been Tested?

This has been loosely tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
