### PR TITLE
fix(user): unique email addresses with migration

### DIFF
--- a/migrations/20210104095122_unique_user_email_addresses.js
+++ b/migrations/20210104095122_unique_user_email_addresses.js
@@ -1,0 +1,83 @@
+exports.up = function (knex) {
+  return knex.schema.raw(`
+    create extension if not exists citext;
+    alter table public.user alter column email type citext;
+
+    with 
+      duplicated_users as (
+        select email
+        from public.user
+        group by 1
+        having count(*) > 1
+      ),
+      user_assignment as (
+        select 
+          public.user.id as user_id,
+          email,
+          max(assignment.created_at) as most_recent_assignment
+        from public.user
+        join assignment on assignment.user_id = public.user.id
+        where email in ( select email from duplicated_users )
+        group by 1, 2
+      ),
+      keep_discard_user_pairs as (
+        select duplicated_users.email, keep.user_id as keep_user_id, array_agg(discard.user_id) as discard_user_ids
+        from duplicated_users
+        join user_assignment as keep 
+          on keep.user_id = (
+            select user_id
+            from user_assignment 
+            where user_assignment.email = duplicated_users.email
+            order by most_recent_assignment desc
+            limit 1
+          )
+        join user_assignment as discard 
+          on discard.user_id <> keep.user_id
+          and discard.email = duplicated_users.email
+        group by 1, 2
+      ),
+      lockout_old as (
+        update public.user u
+        set auth0_id = 'lockedout|deprecation',
+            email = split_part(u.email, '@', 1) || '+deprecatedasduplicate' || split_part(u.email, '@', 2)
+        from keep_discard_user_pairs
+        where u.id = ANY(keep_discard_user_pairs.discard_user_ids)
+        returning 1
+      ),
+      merged_org_memberships as (
+        insert into user_organization (user_id, organization_id, role)
+        select keep_user_id as user_id, organization_id, role
+        from keep_discard_user_pairs
+        join user_organization on user_organization.user_id = ANY(keep_discard_user_pairs.discard_user_ids)
+        on conflict (user_id, organization_id)
+        do update
+        set role = (
+          case 
+            when excluded.updated_at > user_organization.updated_at then excluded.role
+            else user_organization.role
+          end
+        )
+        returning 1
+      ),
+      reassignments as (
+        update assignment
+        set user_id = keep_discard_user_pairs.keep_user_id
+        from keep_discard_user_pairs
+        where assignment.user_id = ANY(keep_discard_user_pairs.discard_user_ids)
+        returning 1
+      )
+      select 
+        ( select count(*) from lockout_old ) as lockout_count,
+        ( select count(*) from merged_org_memberships ) as merged_org_memberships_count,
+        ( select count(*) from reassignments ) as reassignments_count;
+
+    alter table public.user add constraint email_unique unique (email);
+  `);
+};
+
+exports.down = function (knex) {
+  return knex.schema.raw(`
+    alter table public.user drop constraint email_unique;
+    alter table public.user alter column email type text;
+  `);
+};

--- a/migrations/20210104095122_unique_user_email_addresses.js
+++ b/migrations/20210104095122_unique_user_email_addresses.js
@@ -14,9 +14,12 @@ exports.up = function (knex) {
         select 
           public.user.id as user_id,
           email,
-          max(assignment.created_at) as most_recent_assignment
+          coalesce(
+            max(assignment.created_at),
+            public.user.updated_at
+          ) as most_recent_assignment
         from public.user
-        join assignment on assignment.user_id = public.user.id
+        left join assignment on assignment.user_id = public.user.id
         where email in ( select email from duplicated_users )
         group by 1, 2
       ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Changes user.email to citext and includes some data migration to make the constraint true. For details on the migration, see the comment in the issue: https://github.com/politics-rewired/Spoke/issues/782

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See https://github.com/politics-rewired/Spoke/issues/782

## How Has This Been Tested?

I've tested that the migration is syntactically correct and up/downable and doesn't mess up a clean database locally.

The accuracy of the data modification has been tested on a client's production database with rollbacks.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
