### PR TITLE
refactor(send-message): add general handle conversation

### DIFF
--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -305,6 +305,14 @@ const rootSchema = `
     editCampaignContactMessageStatus(messageStatus: String!, campaignContactId:String!): CampaignContact,
     deleteQuestionResponses(interactionStepIds:[String], campaignContactId:String!): CampaignContact,
     updateQuestionResponses(questionResponses:[QuestionResponseInput], campaignContactId:String!): CampaignContact,
+    handleConversation(
+      campaignContactId: String!, 
+      message:MessageInput,
+      questionResponses: [QuestionResponseInput],
+      interactionStepIdsForDeletedQuestionResponses: [String],
+      optOut: ContactActionInput,
+      closeConversation: Boolean
+    ): CampaignContact,
     startCampaign(id:String!): Campaign,
     archiveCampaign(id:String!): Campaign,
     unarchiveCampaign(id:String!): Campaign,

--- a/src/server/models/cacheable_queries/opt-out.js
+++ b/src/server/models/cacheable_queries/opt-out.js
@@ -81,7 +81,10 @@ export const optOutCache = {
       .limit(1);
     return dbResult.length > 0;
   },
-  save: async ({ cell, organizationId, assignmentId, reason }) => {
+  save: async (
+    trx = r.knex,
+    { cell, organizationId, assignmentId, reason }
+  ) => {
     const updateQueryParams = { "campaign_contact.cell": cell };
     if (!sharingOptOuts) {
       updateQueryParams["campaign.organization_id"] = organizationId;
@@ -96,7 +99,7 @@ export const optOutCache = {
     }
     // database
     try {
-      await r.knex("opt_out").insert({
+      await trx("opt_out").insert({
         assignment_id: assignmentId,
         organization_id: organizationId,
         reason_code: reason,
@@ -113,7 +116,8 @@ export const optOutCache = {
       .leftJoin("campaign", "campaign_contact.campaign_id", "campaign.id")
       .where(updateQueryParams)
       .pluck("campaign_contact.id");
-    await r.knex("campaign_contact").whereIn("id", contactIds).update({
+
+    await trx("campaign_contact").whereIn("id", contactIds).update({
       is_opted_out: true
     });
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is a defensive fix to address issues likely responsible for https://github.com/politics-rewired/Spoke/issues/780 where some of `sendMessage`, `updateQuestionResponse`, etc. succeed and some do not.

It moves these operations to one mutation and runs them in a single transaction on the server.

<!--- Describe your changes in detail -->

## Motivation and Context

See https://github.com/politics-rewired/Spoke/issues/780.

## How Has This Been Tested?

I've tested each code pathway locally - send a message while updating a question response, while deleting a question response, while opting out a contact, and all of the above while skipping a reply as well.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
