### PR TITLE
fix: remove mutation of props in CampaignTeamsForm

### DIFF
--- a/src/containers/AdminCampaignEdit/index.jsx
+++ b/src/containers/AdminCampaignEdit/index.jsx
@@ -1,4 +1,5 @@
 import gql from "graphql-tag";
+import { pick } from "lodash";
 import isEqual from "lodash/isEqual";
 import Avatar from "material-ui/Avatar";
 import { Card, CardActions, CardHeader, CardText } from "material-ui/Card";
@@ -323,20 +324,15 @@ class AdminCampaignEdit extends React.Component {
     // * Determines greyness of section button
     // * Determine if section is marked done (in green) along with checkSectionCompleted()
     // * Must be false for a section to save!!
-    // Only Contacts section implements checkSaved()
     if (Object.prototype.hasOwnProperty.call(section, "checkSaved")) {
       return section.checkSaved();
     }
-    const sectionState = {};
-    const sectionProps = {};
-    section.keys.forEach((key) => {
-      sectionState[key] = this.state.campaignFormValues[key];
-      sectionProps[key] = this.props.campaignData.campaign[key];
-    });
-    if (JSON.stringify(sectionState) !== JSON.stringify(sectionProps)) {
-      return false;
-    }
-    return true;
+
+    const [formVals, propVals] = [
+      this.state.campaignFormValues,
+      this.props.campaignData.campaign
+    ].map(pick(section.keys));
+    return isEqual(formVals, propVals);
   };
 
   checkSectionCompleted = (section) => {

--- a/src/containers/AdminCampaignEdit/sections/CampaignTeamsForm.jsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignTeamsForm.jsx
@@ -1,3 +1,4 @@
+import { differenceBy } from "lodash";
 import ChipInput from "material-ui-chip-input";
 import RaisedButton from "material-ui/RaisedButton";
 import Toggle from "material-ui/Toggle";
@@ -28,29 +29,19 @@ class CampaignTeamsForm extends React.Component {
     this.props.onChange({ isAssignmentLimitedToTeams });
   };
 
-  addTeam = (team) => {
-    const { teams } = this.props.formValues;
-
-    const teanAlreadySelected =
-      teams.filter((existingTeam) => existingTeam.id === team.id).length > 0;
-
-    if (!teanAlreadySelected) {
-      teams.push(team);
-    }
-
-    this.props.onChange({ teams });
-  };
-
   // Prevent user-defined teams
   handleBeforeRequestAdd = ({ id: tagId, title }) =>
     !Number.isNaN(tagId) && tagId !== title;
 
-  handleAddTeam = ({ id: teamId }) => {
+  handleAddTeam = ({ id: selectedTeamId }) => {
     const { orgTeams } = this.props;
-
-    const team = orgTeams.find((orgTeam) => orgTeam.id === teamId);
-
-    this.addTeam(team);
+    const { teams: currentTeams } = this.props.formValues;
+    const addableTeams = differenceBy(orgTeams, currentTeams, "id");
+    this.props.onChange({
+      teams: currentTeams.concat(
+        addableTeams.filter((team) => team.id === selectedTeamId)
+      )
+    });
   };
 
   handleRemoveTeam = (deleteTeamId) => {


### PR DESCRIPTION
previous code was imperatively mutating the teams array passed in as props

## Description
AdminCampaignEdit relies on comparison between props and server response to enable or disable the save button. When editing a campaign's teams, only toggling the non-teams-array related value (the flag for restricting texters to team) is the only way to allow this condition to be true, as the teams array (pulled from server response and passed as props) was being mutated on user input, so it was always in sync (regardless of database changes).

## Motivation and Context
this should fix this issue: https://github.com/politics-rewired/Spoke/issues/820

## How Has This Been Tested?
only tried locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
