### PR TITLE
fix(admincampaignedit): fix use of lodash/pick in checkSectionSaved

### DIFF
--- a/src/containers/AdminCampaignEdit/index.jsx
+++ b/src/containers/AdminCampaignEdit/index.jsx
@@ -331,7 +331,7 @@ class AdminCampaignEdit extends React.Component {
     const [formVals, propVals] = [
       this.state.campaignFormValues,
       this.props.campaignData.campaign
-    ].map(pick(section.keys));
+    ].map((vals) => pick(vals, section.keys));
     return isEqual(formVals, propVals);
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR addresses an error that prevented admins from creating or editing campaigns; attempting to
do led to an infinite spinner and a console error: `Uncaught TypeError: #<Object> is not a function
at Array.map (<anonymous>) at AdminCampaig nEdit.checkSectionSaved (index.jsx:331)`. `pick` was
being called without the object it's meant to "pick" from.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #851

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
1. Start the dev server from master.
2. Navigate to the "Campaigns" tab in admin mode.
3. Try to create a new campaign or try to edit an existing campaign.
4. Instead of seeing an infinite screen, see the usual campaign editing page!

OS: macOS Catalina
Browser: Chrome
Version: 87.0.4280.88

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->
n/a

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
