### PR TITLE
fix(timezones): map deprecated tzs to canonical tzs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -78,6 +78,13 @@ module.exports = {
     "@typescript-eslint/no-non-null-assertion": "off",
     "no-use-before-define": "off",
     "@typescript-eslint/no-use-before-define": "error",
+    "no-restricted-imports": [
+      "error",
+      {
+        name: "luxon",
+        message: "Please use src/lib/datetime instead."
+      }
+    ],
 
     // Rules to get linting to pass
     camelcase: ["off", { properties: "never" }],

--- a/dev-tools/associate-messages.js
+++ b/dev-tools/associate-messages.js
@@ -1,4 +1,5 @@
-import { DateTime } from "luxon";
+import { DateTime } from "../src/lib/datetime";
+
 const config = {
   client: "mysql",
   connection: process.env.DATABASE_URL,

--- a/migrations/20210111132048_update-timezones.js
+++ b/migrations/20210111132048_update-timezones.js
@@ -1,0 +1,39 @@
+const depractedTimezoneMap = {
+  "us/alaska": "America/Anchorage",
+  "us/aleutian": "America/Adak",
+  "us/arizona": "America/Phoenix",
+  "us/central": "America/Chicago",
+  "us/east-indiana": "America/Indiana/Indianapolis",
+  "us/eastern": "America/New_York",
+  "us/hawaii": "Pacific/Honolulu",
+  "us/indiana-starke": "America/Indiana/Knox",
+  "us/michigan": "America/Detroit",
+  "us/mountain": "America/Denver",
+  "us/pacific": "America/Los_Angeles",
+  "us/samoa": "Pacific/Pago_Pago"
+};
+
+exports.up = function up(knex) {
+  // Update campaign column default
+  return knex.schema
+    .raw(
+      `alter table only public.campaign alter column timezone set default 'America/New_York'`
+    )
+    .then(() =>
+      // Update existing deprecated values in campaign table
+      Promise.all(
+        Object.entries(depractedTimezoneMap).map(([deprecatedZone, ianaZone]) =>
+          knex("public.campaign")
+            .update({ timezone: ianaZone })
+            .whereRaw("lower(timezone) = ?", [deprecatedZone])
+        )
+      )
+    );
+  // Do not worry about campaign_contact.timezone because these are user-provided values
+};
+
+exports.down = function down(knex) {
+  return knex.schema.raw(
+    `alter table only public.campaign alter column timezone set default 'US/Eastern'`
+  );
+};

--- a/migrations/20210111132048_update-timezones.js
+++ b/migrations/20210111132048_update-timezones.js
@@ -1,4 +1,4 @@
-const depractedTimezoneMap = {
+const deprecatedTimezoneMap = {
   "us/alaska": "America/Anchorage",
   "us/aleutian": "America/Adak",
   "us/arizona": "America/Phoenix",
@@ -22,7 +22,9 @@ exports.up = function up(knex) {
     .then(() =>
       // Update existing deprecated values in campaign table
       Promise.all(
-        Object.entries(depractedTimezoneMap).map(([deprecatedZone, ianaZone]) =>
+        Object.entries(
+          deprecatedTimezoneMap
+        ).map(([deprecatedZone, ianaZone]) =>
           knex("public.campaign")
             .update({ timezone: ianaZone })
             .whereRaw("lower(timezone) = ?", [deprecatedZone])

--- a/src/components/AssignmentSummary.jsx
+++ b/src/components/AssignmentSummary.jsx
@@ -1,5 +1,4 @@
 import { css, StyleSheet } from "aphrodite";
-import { DateTime } from "luxon";
 import Badge from "material-ui/Badge";
 import { Card, CardActions, CardTitle } from "material-ui/Card";
 import Divider from "material-ui/Divider";
@@ -9,6 +8,7 @@ import React, { Component } from "react";
 import { withRouter } from "react-router-dom";
 
 import { dataTest } from "../lib/attributes";
+import { DateTime } from "../lib/datetime";
 
 const inlineStyles = {
   badge: {

--- a/src/components/ContactToolbar.jsx
+++ b/src/components/ContactToolbar.jsx
@@ -4,6 +4,8 @@ import { Toolbar, ToolbarGroup, ToolbarTitle } from "material-ui/Toolbar";
 import PropTypes from "prop-types";
 import React from "react";
 
+import { parseIanaZone } from "../lib/timezones";
+
 const inlineStyles = {
   toolbar: {
     backgroundColor: grey100
@@ -36,7 +38,7 @@ const ContactToolbar = function ContactToolbar(props) {
 
   const timezone = contactTimezone || campaign.timezone;
   const localTime = DateTime.local()
-    .setZone(timezone)
+    .setZone(parseIanaZone(timezone))
     .toLocaleString(DateTime.TIME_SIMPLE);
 
   const location = [city, state]

--- a/src/components/ContactToolbar.jsx
+++ b/src/components/ContactToolbar.jsx
@@ -1,10 +1,9 @@
-import { DateTime } from "luxon";
 import { grey100 } from "material-ui/styles/colors";
 import { Toolbar, ToolbarGroup, ToolbarTitle } from "material-ui/Toolbar";
 import PropTypes from "prop-types";
 import React from "react";
 
-import { parseIanaZone } from "../lib/timezones";
+import { DateTime } from "../lib/datetime";
 
 const inlineStyles = {
   toolbar: {
@@ -38,7 +37,7 @@ const ContactToolbar = function ContactToolbar(props) {
 
   const timezone = contactTimezone || campaign.timezone;
   const localTime = DateTime.local()
-    .setZone(parseIanaZone(timezone))
+    .setZone(timezone)
     .toLocaleString(DateTime.TIME_SIMPLE);
 
   const location = [city, state]

--- a/src/components/IncomingMessageList/MessageColumn/MessageList.tsx
+++ b/src/components/IncomingMessageList/MessageColumn/MessageList.tsx
@@ -1,10 +1,10 @@
 import { css, StyleSheet } from "aphrodite";
 import gql from "graphql-tag";
-import { DateTime } from "luxon";
 import React, { Component } from "react";
 
 import { Message } from "../../../api/message";
 import { loadData } from "../../../containers/hoc/with-operations";
+import { DateTime } from "../../../lib/datetime";
 import { QueryMap } from "../../../network/types";
 
 const styles: Record<string, React.CSSProperties> = StyleSheet.create({

--- a/src/components/MessageList.jsx
+++ b/src/components/MessageList.jsx
@@ -1,10 +1,11 @@
-import { DateTime } from "luxon";
 import Divider from "material-ui/Divider";
 import { List, ListItem } from "material-ui/List";
 import { red300 } from "material-ui/styles/colors";
 import ProhibitedIcon from "material-ui/svg-icons/av/not-interested";
 import PropTypes from "prop-types";
 import React from "react";
+
+import { DateTime } from "../lib/datetime";
 
 const styles = {
   optOut: {

--- a/src/components/forms/GSDateField.tsx
+++ b/src/components/forms/GSDateField.tsx
@@ -1,7 +1,7 @@
-import { DateTime } from "luxon";
 import { DatePicker, DatePickerProps } from "material-ui";
 import React from "react";
 
+import { DateTime } from "../../lib/datetime";
 import { ISODateString } from "../../lib/js-types";
 import { GSFormField, GSFormFieldProps } from "./GSFormField";
 

--- a/src/containers/AdminAssignmentRequest/AssignmentRequestTable.jsx
+++ b/src/containers/AdminAssignmentRequest/AssignmentRequestTable.jsx
@@ -1,4 +1,3 @@
-import { DateTime } from "luxon";
 import CircularProgress from "material-ui/CircularProgress";
 import FlatButton from "material-ui/FlatButton";
 import IconButton from "material-ui/IconButton";
@@ -17,6 +16,7 @@ import {
 import PropTypes from "prop-types";
 import React from "react";
 
+import { DateTime } from "../../lib/datetime";
 import theme from "../../styles/theme";
 
 export const RowWorkStatus = Object.freeze({

--- a/src/containers/AdminCampaignEdit/index.jsx
+++ b/src/containers/AdminCampaignEdit/index.jsx
@@ -1,7 +1,6 @@
 import gql from "graphql-tag";
 import isEqual from "lodash/isEqual";
 import pick from "lodash/pick";
-import { DateTime } from "luxon";
 import Avatar from "material-ui/Avatar";
 import { Card, CardActions, CardHeader, CardText } from "material-ui/Card";
 import CircularProgress from "material-ui/CircularProgress";
@@ -19,6 +18,7 @@ import { compose } from "react-apollo";
 
 import { withAuthzContext } from "../../components/AuthzProvider";
 import { camelCase, dataTest } from "../../lib/attributes";
+import { DateTime } from "../../lib/datetime";
 import theme from "../../styles/theme";
 import { loadData } from "../hoc/with-operations";
 import CampaignAutoassignModeForm from "./sections/CampaignAutoassignModeForm";

--- a/src/containers/AdminCampaignEdit/sections/CampaignBasicsForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignBasicsForm.tsx
@@ -1,7 +1,6 @@
 import { ApolloQueryResult } from "apollo-client";
 import gql from "graphql-tag";
 import isEmpty from "lodash/isEmpty";
-import { DateTime } from "luxon";
 import ColorPicker from "material-ui-color-picker";
 import RaisedButton from "material-ui/RaisedButton";
 import React from "react";
@@ -11,6 +10,7 @@ import * as yup from "yup";
 
 import GSForm from "../../../components/forms/GSForm";
 import { dataTest } from "../../../lib/attributes";
+import { DateTime } from "../../../lib/datetime";
 import { difference } from "../../../lib/utils";
 import { loadData } from "../../hoc/with-operations";
 import CampaignFormSectionHeading from "../components/CampaignFormSectionHeading";

--- a/src/containers/AdminCampaignEdit/sections/CampaignContactsForm/components/ExternalSystemsSource.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignContactsForm/components/ExternalSystemsSource.tsx
@@ -1,5 +1,4 @@
 import gql from "graphql-tag";
-import { DateTime } from "luxon";
 import Avatar from "material-ui/Avatar";
 import { Card, CardHeader, CardText } from "material-ui/Card";
 import DropDownMenu from "material-ui/DropDownMenu";
@@ -8,6 +7,7 @@ import { green500, grey500 } from "material-ui/styles/colors";
 import React from "react";
 
 import { ExternalSystem } from "../../../../../api/external-system";
+import { DateTime } from "../../../../../lib/datetime";
 import { loadData } from "../../../../hoc/with-operations";
 
 interface Props {

--- a/src/containers/AdminCampaignEdit/sections/CampaignOverlapManager.jsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignOverlapManager.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable max-classes-per-file,react/no-unused-state */
 import gql from "graphql-tag";
-import { DateTime } from "luxon";
 import DataTable from "material-ui-datatables";
 import CircularProgress from "material-ui/CircularProgress";
 import RaisedButton from "material-ui/RaisedButton";
@@ -9,6 +8,7 @@ import Toggle from "material-ui/Toggle";
 import React from "react";
 
 import LoadingIndicator from "../../../components/LoadingIndicator";
+import { DateTime } from "../../../lib/datetime";
 import { loadData } from "../../hoc/with-operations";
 
 const ROW_SIZE_OPTIONS = [25, 50, 100];

--- a/src/containers/AdminCampaignEdit/sections/CampaignTextingHoursForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignTextingHoursForm.tsx
@@ -11,6 +11,7 @@ import * as yup from "yup";
 
 import GSForm from "../../../components/forms/GSForm";
 import { dataSourceItem } from "../../../components/utils";
+import { parseIanaZone } from "../../../lib/timezones";
 import { difference } from "../../../lib/utils";
 import { loadData } from "../../hoc/with-operations";
 import CampaignFormSectionHeading from "../components/CampaignFormSectionHeading";
@@ -53,7 +54,7 @@ const timezones = [
 ];
 
 const timezoneChoices = timezones.map((timezone) =>
-  dataSourceItem(timezone, timezone)
+  dataSourceItem(timezone, parseIanaZone(timezone))
 );
 
 // Types

--- a/src/containers/AdminCampaignEdit/sections/CampaignTextingHoursForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignTextingHoursForm.tsx
@@ -1,7 +1,6 @@
 import { ApolloQueryResult } from "apollo-client";
 import gql from "graphql-tag";
 import isEmpty from "lodash/isEmpty";
-import { DateTime } from "luxon";
 import Autocomplete from "material-ui/AutoComplete";
 import RaisedButton from "material-ui/RaisedButton";
 import React from "react";
@@ -11,7 +10,7 @@ import * as yup from "yup";
 
 import GSForm from "../../../components/forms/GSForm";
 import { dataSourceItem } from "../../../components/utils";
-import { parseIanaZone } from "../../../lib/timezones";
+import { DateTime, parseIanaZone } from "../../../lib/datetime";
 import { difference } from "../../../lib/utils";
 import { loadData } from "../../hoc/with-operations";
 import CampaignFormSectionHeading from "../components/CampaignFormSectionHeading";

--- a/src/containers/AdminCampaignEdit/types.ts
+++ b/src/containers/AdminCampaignEdit/types.ts
@@ -8,8 +8,8 @@ export interface CampaignReadinessType {
   interactions: boolean;
 }
 
-export interface DataSourceItemType {
+export interface DataSourceItemType<T = string> {
   text: string;
-  rawValue: string;
+  rawValue: T;
   value: React.ReactNode;
 }

--- a/src/containers/AdminCampaignStats/index.jsx
+++ b/src/containers/AdminCampaignStats/index.jsx
@@ -1,6 +1,5 @@
 import { css, StyleSheet } from "aphrodite";
 import gql from "graphql-tag";
-import { DateTime } from "luxon";
 import RaisedButton from "material-ui/RaisedButton";
 import Snackbar from "material-ui/Snackbar";
 import { red600 } from "material-ui/styles/colors";
@@ -11,6 +10,7 @@ import { withRouter } from "react-router-dom";
 
 import { withAuthzContext } from "../../components/AuthzProvider";
 import { dataTest } from "../../lib/attributes";
+import { DateTime } from "../../lib/datetime";
 import theme from "../../styles/theme";
 import { loadData } from "../hoc/with-operations";
 import CampaignSurveyStats from "./CampaignSurveyStats";

--- a/src/containers/AdminExternalSystems.tsx
+++ b/src/containers/AdminExternalSystems.tsx
@@ -1,6 +1,5 @@
 import gql from "graphql-tag";
 import { History } from "history";
-import { DateTime } from "luxon";
 import Dialog from "material-ui/Dialog";
 import FlatButton from "material-ui/FlatButton";
 import FloatingActionButton from "material-ui/FloatingActionButton";
@@ -31,6 +30,7 @@ import {
   ExternalSystemType
 } from "../api/external-system";
 import { RelayPaginatedResponse } from "../api/pagination";
+import { DateTime } from "../lib/datetime";
 import { MutationMap, QueryMap } from "../network/types";
 import theme from "../styles/theme";
 import { loadData } from "./hoc/with-operations";

--- a/src/containers/AdminShortLinkDomains/ShortLinkDomainList.jsx
+++ b/src/containers/AdminShortLinkDomains/ShortLinkDomainList.jsx
@@ -1,4 +1,3 @@
-import { DateTime } from "luxon";
 import DataTables from "material-ui-datatables";
 import IconButton from "material-ui/IconButton";
 import { green500, red500 } from "material-ui/styles/colors";
@@ -10,6 +9,8 @@ import BlockIcon from "material-ui/svg-icons/content/block";
 import Toggle from "material-ui/Toggle";
 import PropTypes from "prop-types";
 import React, { Component } from "react";
+
+import { DateTime } from "../../lib/datetime";
 
 class ShortLinkDomainList extends Component {
   tableColumns = () => [

--- a/src/containers/CampaignList/CampaignList.jsx
+++ b/src/containers/CampaignList/CampaignList.jsx
@@ -1,4 +1,3 @@
-import { DateTime } from "luxon";
 import Chip from "material-ui/Chip";
 import IconButton from "material-ui/IconButton";
 import IconMenu from "material-ui/IconMenu";
@@ -16,6 +15,7 @@ import { withRouter } from "react-router-dom";
 
 import Empty from "../../components/Empty";
 import { dataTest } from "../../lib/attributes";
+import { DateTime } from "../../lib/datetime";
 import theme from "../../styles/theme";
 
 const inlineStyles = {

--- a/src/containers/Settings/components/General.jsx
+++ b/src/containers/Settings/components/General.jsx
@@ -1,6 +1,5 @@
 import { css, StyleSheet } from "aphrodite";
 import gql from "graphql-tag";
-import { DateTime } from "luxon";
 import { Card, CardActions, CardHeader, CardText } from "material-ui/Card";
 import Dialog from "material-ui/Dialog";
 import DropDownMenu from "material-ui/DropDownMenu";
@@ -17,6 +16,7 @@ import { RequestAutoApproveType } from "../../../api/organization-membership";
 import GSForm from "../../../components/forms/GSForm";
 import GSSubmitButton from "../../../components/forms/GSSubmitButton";
 import { snakeToTitleCase } from "../../../lib/attributes";
+import { DateTime } from "../../../lib/datetime";
 import { loadData } from "../../hoc/with-operations";
 
 const styles = StyleSheet.create({

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -8,6 +8,8 @@ interface Window {
   SPOKE_VERSION: string;
   MAX_MESSAGE_LENGTH: number;
   PASSPORT_STRATEGY: string;
+  TZ: string;
+  DST_REFERENCE_TIMEZONE: string;
 }
 
 // This was a workaround while we are transitioning from JS to TS - 2020-12-21

--- a/src/lib/datetime.ts
+++ b/src/lib/datetime.ts
@@ -1,0 +1,40 @@
+/* eslint-disable no-restricted-imports */
+import { DateTime as LuxonDateTime, Zone, ZoneOptions } from "luxon";
+
+export { Interval } from "luxon";
+
+// From: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+export const deprecatedTimezoneMap: Record<string, string> = {
+  "us/alaska": "America/Anchorage",
+  "us/aleutian": "America/Adak",
+  "us/arizona": "America/Phoenix",
+  "us/central": "America/Chicago",
+  "us/east-indiana": "America/Indiana/Indianapolis",
+  "us/eastern": "America/New_York",
+  "us/hawaii": "Pacific/Honolulu",
+  "us/indiana-starke": "America/Indiana/Knox",
+  "us/michigan": "America/Detroit",
+  "us/mountain": "America/Denver",
+  "us/pacific": "America/Los_Angeles",
+  "us/samoa": "Pacific/Pago_Pago"
+};
+
+export const parseIanaZone = (name: string) =>
+  deprecatedTimezoneMap[name.toLowerCase()] || name;
+
+export class DateTime extends LuxonDateTime {
+  /**
+   * Wrap luxon's default setZone() to guarantee support for deprecated, but still valid, IANA
+   * time zone names that Spoke uses.
+   * @param zone - name of IANA time zone
+   * @param options - luxon time zone options
+   */
+  setZone(zone: string | Zone, options?: ZoneOptions): DateTime {
+    if (typeof zone === "string") {
+      zone = parseIanaZone(zone);
+    }
+    return super.setZone(zone, options);
+  }
+}
+
+export default DateTime;

--- a/src/lib/timezones.js
+++ b/src/lib/timezones.js
@@ -1,23 +1,4 @@
-import { DateTime, Interval } from "luxon";
-
-// From: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-const depractedTimezoneMap = {
-  "us/alaska": "America/Anchorage",
-  "us/aleutian": "America/Adak",
-  "us/arizona": "America/Phoenix",
-  "us/central": "America/Chicago",
-  "us/east-indiana": "America/Indiana/Indianapolis",
-  "us/eastern": "America/New_York",
-  "us/hawaii": "Pacific/Honolulu",
-  "us/indiana-starke": "America/Indiana/Knox",
-  "us/michigan": "America/Detroit",
-  "us/mountain": "America/Denver",
-  "us/pacific": "America/Los_Angeles",
-  "us/samoa": "Pacific/Pago_Pago"
-};
-
-export const parseIanaZone = (name) =>
-  depractedTimezoneMap[name.toLowerCase()] || name;
+import { DateTime, Interval } from "./datetime";
 
 /**
  * Returns true if it is currently between the start and end hours in the specified timezone.
@@ -27,9 +8,7 @@ export const parseIanaZone = (name) =>
  * @param {number} endHour Interval ending hour in 24-hour format
  */
 export const isNowBetween = (timezone, starthour, endHour) => {
-  const campaignTime = DateTime.local()
-    .setZone(parseIanaZone(timezone))
-    .startOf("day");
+  const campaignTime = DateTime.local().setZone(timezone).startOf("day");
 
   return Interval.fromDateTimes(
     campaignTime.set({ hour: starthour }),

--- a/src/lib/timezones.js
+++ b/src/lib/timezones.js
@@ -1,5 +1,24 @@
 import { DateTime, Interval } from "luxon";
 
+// From: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+const depractedTimezoneMap = {
+  "us/alaska": "America/Anchorage",
+  "us/aleutian": "America/Adak",
+  "us/arizona": "America/Phoenix",
+  "us/central": "America/Chicago",
+  "us/east-indiana": "America/Indiana/Indianapolis",
+  "us/eastern": "America/New_York",
+  "us/hawaii": "Pacific/Honolulu",
+  "us/indiana-starke": "America/Indiana/Knox",
+  "us/michigan": "America/Detroit",
+  "us/mountain": "America/Denver",
+  "us/pacific": "America/Los_Angeles",
+  "us/samoa": "Pacific/Pago_Pago"
+};
+
+export const parseIanaZone = (name) =>
+  depractedTimezoneMap[name.toLowerCase()] || name;
+
 /**
  * Returns true if it is currently between the start and end hours in the specified timezone.
  *
@@ -8,7 +27,9 @@ import { DateTime, Interval } from "luxon";
  * @param {number} endHour Interval ending hour in 24-hour format
  */
 export const isNowBetween = (timezone, starthour, endHour) => {
-  const campaignTime = DateTime.local().setZone(timezone).startOf("day");
+  const campaignTime = DateTime.local()
+    .setZone(parseIanaZone(timezone))
+    .startOf("day");
 
   return Interval.fromDateTimes(
     campaignTime.set({ hour: starthour }),

--- a/src/lib/tz-helpers.ts
+++ b/src/lib/tz-helpers.ts
@@ -1,4 +1,4 @@
-import { DateTime } from "luxon";
+import { DateTime } from "./datetime";
 
 export const getProcessEnvTz: () => string = () =>
   typeof window === "undefined" ? (process.env.TZ as string) : window.TZ;

--- a/src/lib/tz-helpers.ts
+++ b/src/lib/tz-helpers.ts
@@ -1,11 +1,11 @@
 import { DateTime } from "luxon";
 
 export const getProcessEnvTz: () => string = () =>
-  typeof window === "undefined" ? process.env.TZ : window.TZ;
+  typeof window === "undefined" ? (process.env.TZ as string) : window.TZ;
 
 export const getProcessEnvDstReferenceTimezone: () => string = () =>
   typeof window === "undefined"
-    ? process.env.DST_REFERENCE_TIMEZONE
+    ? (process.env.DST_REFERENCE_TIMEZONE as string)
     : window.DST_REFERENCE_TIMEZONE;
 
 export const isValidTimezone: (tzstr: string) => boolean = (tzstr) =>

--- a/src/server/api/campaign-contact.js
+++ b/src/server/api/campaign-contact.js
@@ -1,5 +1,5 @@
 import { config } from "../../config";
-import { parseIanaZone } from "../../lib/timezones";
+import { parseIanaZone } from "../../lib/datetime";
 import logger from "../../logger";
 import { cacheableData, r } from "../models";
 import { errToObj } from "../utils";

--- a/src/server/api/campaign-contact.js
+++ b/src/server/api/campaign-contact.js
@@ -1,4 +1,5 @@
 import { config } from "../../config";
+import { parseIanaZone } from "../../lib/timezones";
 import logger from "../../logger";
 import { cacheableData, r } from "../models";
 import { errToObj } from "../utils";
@@ -249,7 +250,9 @@ export const resolvers = {
           "=",
           campaignContact.id
         );
-    }
+    },
+    timezone: (campaignContact) =>
+      campaignContact.timezone ? parseIanaZone(campaignContact.timezone) : null
   }
 };
 

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -1,7 +1,7 @@
 import { ExternalSyncReadinessState } from "../../api/campaign";
 import { emptyRelayPage } from "../../api/pagination";
 import { config } from "../../config";
-import { parseIanaZone } from "../../lib/timezones";
+import { parseIanaZone } from "../../lib/datetime";
 import { cacheOpts, memoizer } from "../memoredis";
 import { cacheableData, r } from "../models";
 import { currentEditors } from "../models/cacheable_queries";

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -1,6 +1,7 @@
 import { ExternalSyncReadinessState } from "../../api/campaign";
 import { emptyRelayPage } from "../../api/pagination";
 import { config } from "../../config";
+import { parseIanaZone } from "../../lib/timezones";
 import { cacheOpts, memoizer } from "../memoredis";
 import { cacheableData, r } from "../models";
 import { currentEditors } from "../models/cacheable_queries";
@@ -254,10 +255,10 @@ export const resolvers = {
       "textingHoursStart",
       "textingHoursEnd",
       "isAutoassignEnabled",
-      "timezone",
       "createdAt",
       "landlinesFiltered"
     ]),
+    timezone: (campaign) => parseIanaZone(campaign.timezone),
     readiness: (campaign) => campaign,
     repliesStaleAfter: (campaign) => campaign.replies_stale_after_minutes,
     useDynamicAssignment: (_) => false,

--- a/src/server/api/lib/twilio.js
+++ b/src/server/api/lib/twilio.js
@@ -1,8 +1,8 @@
 import _ from "lodash";
-import { DateTime } from "luxon";
 import Twilio from "twilio";
 
 import { config } from "../../../config";
+import { DateTime } from "../../../lib/datetime";
 import { getFormattedPhoneNumber } from "../../../lib/phone-format";
 import logger from "../../../logger";
 import { r } from "../../models";

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -5,7 +5,6 @@ import { GraphQLError } from "graphql/error";
 import _ from "lodash";
 import escapeRegExp from "lodash/escapeRegExp";
 import groupBy from "lodash/groupBy";
-import { DateTime } from "luxon";
 import request from "superagent";
 
 import { TextRequestType } from "../../api/organization";
@@ -13,9 +12,10 @@ import { RequestAutoApproveType } from "../../api/organization-membership";
 import { CampaignExportType } from "../../api/types";
 import { config } from "../../config";
 import { gzip, makeTree } from "../../lib";
+import { DateTime, parseIanaZone } from "../../lib/datetime";
 import { hasRole } from "../../lib/permissions";
 import { applyScript } from "../../lib/scripts";
-import { isNowBetween, parseIanaZone } from "../../lib/timezones";
+import { isNowBetween } from "../../lib/timezones";
 import logger from "../../logger";
 import {
   assignTexters,

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -15,7 +15,7 @@ import { config } from "../../config";
 import { gzip, makeTree } from "../../lib";
 import { hasRole } from "../../lib/permissions";
 import { applyScript } from "../../lib/scripts";
-import { isNowBetween } from "../../lib/timezones";
+import { isNowBetween, parseIanaZone } from "../../lib/timezones";
 import logger from "../../logger";
 import {
   assignTexters,
@@ -288,7 +288,7 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
     texting_hours_end: textingHoursEnd,
     is_autoassign_enabled: isAutoassignEnabled,
     replies_stale_after_minutes: repliesStaleAfter, // this is null to unset it - it must be null, not undefined
-    timezone,
+    timezone: parseIanaZone(timezone),
     external_system_id: externalSystemId
   };
 
@@ -617,7 +617,7 @@ async function sendMessage(
 
   const sendBefore = DateTime.utc()
     .set({ hour: endHour })
-    .setZone(timezone)
+    .setZone(parseIanaZone(timezone))
     .startOf("day")
     .toISO();
   const { contactNumber, text } = message;

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -617,7 +617,7 @@ async function sendMessage(
 
   const sendBefore = DateTime.utc()
     .set({ hour: endHour })
-    .setZone(parseIanaZone(timezone))
+    .setZone(timezone)
     .startOf("day")
     .toISO();
   const { contactNumber, text } = message;

--- a/src/server/tasks/export-campaign.ts
+++ b/src/server/tasks/export-campaign.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-cond-assign */
 import { format } from "fast-csv";
 import _ from "lodash";
-import { DateTime } from "luxon";
 
+import { DateTime } from "../../lib/datetime";
 import { getDownloadUrl, getUploadStream } from "../../workers/exports/upload";
 import {
   CampaignContactRecord,

--- a/src/server/tasks/export-for-van.ts
+++ b/src/server/tasks/export-for-van.ts
@@ -1,7 +1,7 @@
 import sortBy from "lodash/sortBy";
-import { DateTime } from "luxon";
 import Papa from "papaparse";
 
+import { DateTime } from "../../lib/datetime";
 import { uploadToCloud } from "../../workers/exports/upload";
 import { sendEmail } from "../mail";
 import { r } from "../models";

--- a/src/workers/cron/deliverability-report.ts
+++ b/src/workers/cron/deliverability-report.ts
@@ -1,8 +1,8 @@
 import knex from "knex";
 import _ from "lodash";
 import groupBy from "lodash/groupBy";
-import { DateTime, Interval } from "luxon";
 
+import { DateTime, Interval } from "../../lib/datetime";
 import { asUtc } from "../../lib/tz-helpers";
 import logger from "../../logger";
 import knexConfig from "../../server/knex";


### PR DESCRIPTION
## Description

Map deprecated IANA timezone names to canonical IANA timezone names as per https://en.wikipedia.org/wiki/List_of_tz_database_time_zones

## Motivation and Context

Luxon uses the `Intl` library under the hood rather than shipping its own timezone database. This
means we cannot rely on `Intl` being the same across systems/browsers. Specifically, we cannot rely
on `Intl` supporting deprecated IANA timezone names (e.g. "US/Eastern") even though they are
_technically_ valid.

Monkey patching `Intl` to add aliases would be the ideal solution, but I could not quickly find
anything on how to do that with Luxon. So instead I updated existing values and added defensive fixes.

See
- https://github.com/moment/luxon/issues/450
- https://bugs.chromium.org/p/chromium/issues/detail?id=364374

Closes #853

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
