### PR TITLE
feat: per organization message limits

### DIFF
--- a/migrations/20210112103258_monthly-org-message-limits.js
+++ b/migrations/20210112103258_monthly-org-message-limits.js
@@ -1,0 +1,37 @@
+exports.up = (knex) => {
+  return knex.schema.raw(`
+    alter table organization add column monthly_message_limit bigint;
+
+    create table monthly_organization_message_usages (
+      month integer,
+      organization_id integer references organization (id),
+      sent_message_count bigint,
+      primary key (organization_id, month)
+    );
+
+    create or replace function backfill_current_month_organization_message_usages() returns void as $$
+      insert into monthly_organization_message_usages (organization_id, month, sent_message_count)
+      select 
+        campaign.organization_id, 
+        extract('month' from now()) as month,
+        count(*) as sent_message_count
+      from message
+      join campaign_contact on campaign_contact.id = message.campaign_contact_id
+      join campaign on campaign.id = campaign_contact.campaign_id
+      where message.created_at > date_trunc('month', now())
+        and message.is_from_contact = false
+      group by 1, 2
+      on conflict (organization_id, month)
+      do update
+      set 
+        sent_message_count = monthly_organization_message_usages.sent_message_count
+    $$ language sql;
+  `);
+};
+
+exports.down = (knex) => {
+  return knex.schema.raw(`
+    alter table organization drop column monthly_message_limit;
+    drop table organizaton_usages;
+  `);
+};

--- a/src/components/AssignmentTexter.jsx
+++ b/src/components/AssignmentTexter.jsx
@@ -337,12 +337,12 @@ class AssignmentTexter extends React.Component {
       ) {
         // opt out or send message Error
         error.snackbarActionTitle = "A previous contact had been opted out";
-      } else {
+      } else if (e.message === undefined) {
         error.snackbarError = "Error: Please wait a few seconds and try again.";
       }
 
       error.snackbarError = `Error for contact ${contact_id}: ${error.snackbarError.replace(
-        "Error: GraphQL error:",
+        "GraphQL error:",
         ""
       )}`;
 

--- a/src/config.js
+++ b/src/config.js
@@ -369,6 +369,10 @@ const validators = {
     desc: "Email server user. Required for custom SMTP server usage.",
     default: undefined
   }),
+  ENABLE_MONTHLY_ORG_MESSAGE_LIMITS: bool({
+    desc: "Whether to enable monthly, per organization message limits",
+    default: false
+  }),
   ENCRYPTION_ALGORITHM: str({
     desc: "Encryption algorithm to use with crypto package.",
     choices: ["aes256"],

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -512,7 +512,7 @@ async function sendMessage(
     ? "and opt_out.organization_id = campaign.organization_id"
     : "";
 
-  let recordQuery = trx("campaign_contact")
+  const recordQuery = trx("campaign_contact")
     .join("campaign", "campaign_contact.campaign_id", "campaign.id")
     .where({ "campaign_contact.id": parseInt(campaignContactId, 10) })
     .whereRaw("campaign_contact.archived = false")
@@ -520,7 +520,7 @@ async function sendMessage(
     .leftJoin("assignment", "campaign_contact.assignment_id", "assignment.id");
 
   if (config.ENABLE_MONTHLY_ORG_MESSAGE_LIMITS) {
-    recordQuery = recordQuery
+    recordQuery
       .join("organization", "organization.id", "=", "campaign.organization_id")
       .leftJoin(
         "monthly_organization_message_usages",
@@ -529,7 +529,7 @@ async function sendMessage(
         "organization.id"
       )
       .whereRaw(
-        `monthly_organization_message_usages.month = extract('month' from now())`
+        `monthly_organization_message_usages.month = date_trunc('month', now())`
       );
   }
 

--- a/src/server/tasks/update-org-message-usage.ts
+++ b/src/server/tasks/update-org-message-usage.ts
@@ -1,0 +1,36 @@
+import { JobHelpers, Task } from "pg-compose";
+
+import { config } from "../../config";
+
+const updateOrgMessageUsage: Task = async (
+  payload: any,
+  helpers: JobHelpers
+) => {
+  if (config.ENABLE_MONTHLY_ORG_MESSAGE_LIMITS) {
+    await helpers.query(
+      `
+        insert into monthly_organization_message_usages (organization_id, month, sent_message_count)
+        select 
+          campaign.organization_id, 
+          extract('month' from now()) as month,
+          count(*) as sent_message_count
+        from message
+        join campaign_contact on campaign_contact.id = message.campaign_contact_id
+        join campaign on campaign.id = campaign_contact.campaign_id
+        where message.created_at > date_trunc('minute', $1) - interval '5 minutes'
+          and message.created_at <= date_trunc('minute', $1)
+          and message.is_from_contact = false
+        group by 1, 2
+        on conflict (organization_id, month)
+        do update
+        set 
+          sent_message_count = 
+            excluded.sent_message_count +
+            monthly_organization_message_usages.sent_message_count
+      `,
+      [payload.fireDate]
+    );
+  }
+};
+
+export default updateOrgMessageUsage;

--- a/src/server/tasks/update-org-message-usage.ts
+++ b/src/server/tasks/update-org-message-usage.ts
@@ -12,13 +12,13 @@ const updateOrgMessageUsage: Task = async (
         insert into monthly_organization_message_usages (organization_id, month, sent_message_count)
         select 
           campaign.organization_id, 
-          extract('month' from now()) as month,
+          date_trunc('month', now()) as month,
           count(*) as sent_message_count
         from message
         join campaign_contact on campaign_contact.id = message.campaign_contact_id
         join campaign on campaign.id = campaign_contact.campaign_id
-        where message.created_at > date_trunc('minute', $1) - interval '5 minutes'
-          and message.created_at <= date_trunc('minute', $1)
+        where message.created_at >= date_trunc('minute', $1) - interval '5 minutes'
+          and message.created_at < date_trunc('minute', $1)
           and message.is_from_contact = false
         group by 1, 2
         on conflict (organization_id, month)


### PR DESCRIPTION
## Description

Optionally restrict the amount of outbound messages an organization can send per month.

## Motivation and Context

User request for cost controls

## How Has This Been Tested?

I checked locally:
- [x] You can't send initials when you're over the limit
- [x] You can send initials when you're under the limit
- [x] You can send replies when you're over the limit
- [x] The backfill function is correct
- [x] The cronjob runs and produces the right behavior

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
