### PR TITLE
fix(sendbuttonarrow): pin the send arrow to the top of the message field

### DIFF
--- a/src/components/SendButtonArrow.jsx
+++ b/src/components/SendButtonArrow.jsx
@@ -4,12 +4,14 @@ import NavigationArrowForward from "material-ui/svg-icons/navigation/arrow-forwa
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 
-// This is because the Toolbar from material-ui seems to only apply the correct margins if the
-// immediate child is a Button or other type it recognizes. Can get rid of this if we remove material-ui
+const INTERNAL_ARROW_PADDING = 11;
+
 const styles = StyleSheet.create({
   container: {
-    display: "inline-block",
-    marginLeft: 20
+    position: "absolute",
+    right: -INTERNAL_ARROW_PADDING,
+    top: -INTERNAL_ARROW_PADDING,
+    padding: 0
   },
   icon: {
     color: "rgb(83, 180, 119)",
@@ -17,16 +19,13 @@ const styles = StyleSheet.create({
     height: 40
   },
   arrowButton: {
-    "@media(minWidth: 450px)": {
+    "@media(min-width: 450px)": {
       display: "none !important"
     },
-    "@media(maxWidth: 450px)": {
+    "@media(max-width: 450px)": {
       display: "block !important"
     },
-    position: "absolute",
-    right: 2,
-    bottom: 125,
-    zIndex: 100
+    padding: 0 // Override the built-in IconButton padding.
   }
 });
 class SendButtonArrow extends Component {

--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -88,10 +88,11 @@ const styles = StyleSheet.create({
     marginBottom: "none"
   },
   messageField: {
-    padding: "0px 8px",
+    margin: "0px 8px",
     "@media(maxWidth: 450px)": {
       marginBottom: "8%"
-    }
+    },
+    position: "relative"
   }
 });
 


### PR DESCRIPTION
## Description

Before this change, the send arrow was positioned absolutely with respect to the entire screen, and it was "pinned" to the bottom right corner.

With this change, the send arrow is positioned absolutely with respect to the message field, and it is "pinned" to the top right corner.

This change also hides the send arrow when the screen width is greater than 450px. The existing CSS suggests this was the desired behavior, but it wasn't working as expected.

## Motivation and Context

While I was working on #438 / #829, I realized that adding the character count below the text field would require moving the arrow up by an arbitrary amount (the height of the new component). It felt off to have the `SendButtonArrow` component so dependent on its sibling components.

I also noticed #711, which suggests the incremental change of moving the send arrow out of the text field.

This change makes `SendButtonArrow` less dependent on its siblings (specifically the bottom action bar) and moves the arrow out of the text field, to the top right.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I tested this change in dev on Chrome and Safari with different screen widths.

## Screenshots:

![before](https://user-images.githubusercontent.com/8495791/104955078-93d3d800-5997-11eb-800e-5bc613d37896.png)
![after](https://user-images.githubusercontent.com/8495791/104955077-933b4180-5997-11eb-8958-50afe1476a30.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->
n/a

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
