### PR TITLE
fix: add defensive fix for null/undefined zone name

### DIFF
--- a/src/lib/datetime.ts
+++ b/src/lib/datetime.ts
@@ -20,7 +20,7 @@ export const deprecatedTimezoneMap: Record<string, string> = {
 };
 
 export const parseIanaZone = (name: string) =>
-  deprecatedTimezoneMap[name.toLowerCase()] || name;
+  name ? deprecatedTimezoneMap[name.toLowerCase()] : name;
 
 export class DateTime extends LuxonDateTime {
   /**


### PR DESCRIPTION

## Description

Add a defensive fix for `null`/`undefined` time zone names passed to `parseIanaZone()`.

## Motivation and Context

This resolves issue opened by user flagging an error with the `editCampaign` mutation.

The project is not typed enough to rely on TS to catch places where null/undefined is passed to
parseIanaZone() despite the required `string` argument.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
