### PR TITLE
refactor: manage pagination result with apollo

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "hot-shots": "^6.3.0",
     "humps": "^1.1.0",
     "iconv-lite": "^0.5.1",
+    "immer": "^8.0.1",
     "isomorphic-fetch": "^2.2.1",
     "knex": "^0.21.1",
     "lodash": "^4.13.1",

--- a/src/components/InfiniteRelayList.tsx
+++ b/src/components/InfiniteRelayList.tsx
@@ -1,4 +1,5 @@
 import { FetchPolicy } from "apollo-client";
+import produce, { Draft } from "immer";
 import React from "react";
 import { Query } from "react-apollo";
 
@@ -12,12 +13,12 @@ export type CliffHanger<T> = (
 ) => React.ReactElement;
 
 export type UpdateQuery<TData, TVariables> = (
-  previousQueryResult: TData,
+  nextQueryResult: Draft<TData>,
   options: {
     fetchMoreResult?: TData;
     variables?: TVariables;
   }
-) => TData;
+) => void;
 
 interface InfiniteRelayListProps<TData, TNode, TVariables> {
   query: any;
@@ -69,7 +70,10 @@ const InfiniteRelayList = <TData, TNode, TVariables>(
               ...props.queryVars,
               ...props.nextQueryVars(relayPage.pageInfo.endCursor)
             },
-            updateQuery: props.updateQuery
+            updateQuery: (previousQueryResult, options) =>
+              produce(previousQueryResult, (nextResult) => {
+                props.updateQuery(nextResult, options);
+              })
           });
 
         return (

--- a/src/components/InfiniteRelayList.tsx
+++ b/src/components/InfiniteRelayList.tsx
@@ -1,120 +1,92 @@
 import { FetchPolicy } from "apollo-client";
-import isEqual from "lodash/isEqual";
 import React from "react";
+import { Query } from "react-apollo";
 
 import { emptyRelayPage, RelayPaginatedResponse } from "../api/pagination";
-import apolloClient from "../network/apollo-client-singleton";
 import ChildOnly from "./ChildOnly";
 import WhenSeen from "./WhenSeen";
 
-interface InfiniteRelayListProps<T> {
+export type CliffHanger<T> = (
+  hasMore: boolean,
+  last: RelayPaginatedResponse<T>
+) => React.ReactElement;
+
+export type UpdateQuery<TData, TVariables> = (
+  previousQueryResult: TData,
+  options: {
+    fetchMoreResult?: TData;
+    variables?: TVariables;
+  }
+) => TData;
+
+interface InfiniteRelayListProps<TData, TNode, TVariables> {
   query: any;
-  queryVars: Record<string, any>;
-  nextQueryVars(cursor: string | null): Record<string, any>;
-  renderNode: (node: T, idx: number) => React.ReactElement;
-  toRelay: (data: any) => RelayPaginatedResponse<T>;
-  keyFunc?: (node: T, idx: number) => any;
-  cliffHanger?: (
-    hasMore: boolean,
-    last: RelayPaginatedResponse<T>
-  ) => React.ReactElement;
+  queryVars: TVariables;
+  nextQueryVars(cursor: string | null): TVariables;
+  updateQuery: UpdateQuery<TData, TVariables>;
+  renderNode: (node: TNode, idx: number) => React.ReactElement;
+  toRelay: (data: TData) => RelayPaginatedResponse<TNode>;
+  keyFunc?: (node: TNode, idx: number) => any;
+  cliffHanger?: CliffHanger<TNode>;
   empty?: () => React.ReactElement;
   fetchPolicy?: FetchPolicy;
-  dbLastUpdatedAt?: Date;
 }
 
-interface InfiniteRelayListState<T> {
-  nodes: T[];
-  last: RelayPaginatedResponse<T>;
-  loading: boolean;
-  hasMore: boolean;
-}
+const DefaultCliffhanger: CliffHanger<any> = () => (
+  <div>
+    <span role="img" aria-label="end of list">
+      😳 End of list 😳
+    </span>
+  </div>
+);
 
-class InfiniteRelayList<T> extends React.Component<
-  InfiniteRelayListProps<T>,
-  InfiniteRelayListState<T>
-> {
-  state: InfiniteRelayListState<T> = {
-    nodes: [],
-    last: emptyRelayPage<T>(),
-    loading: false,
-    hasMore: false
-  };
+const DefaultEmpty = () => <div>No items found</div>;
 
-  async componentDidMount() {
-    await this.load();
-  }
+const InfiniteRelayList = <TData, TNode, TVariables>(
+  props: InfiniteRelayListProps<TData, TNode, TVariables>
+) => {
+  const Empty = props.empty || DefaultEmpty;
+  const cliffHanger = props.cliffHanger || DefaultCliffhanger;
 
-  componentDidUpdate(prevProps: InfiniteRelayListProps<T>) {
-    if (
-      prevProps.query !== this.props.query ||
-      !isEqual(prevProps.queryVars, this.props.queryVars) ||
-      !isEqual(prevProps.dbLastUpdatedAt, this.props.dbLastUpdatedAt)
-    ) {
-      this.load();
-    }
-  }
+  return (
+    <Query<TData, TVariables>
+      query={props.query}
+      variables={props.queryVars}
+      fetchPolicy={props.fetchPolicy || "network-only"}
+    >
+      {({ data, loading, fetchMore }): React.ReactNode => {
+        if (loading || !data) return <div />;
 
-  async query(
-    variables = this.props.queryVars
-  ): Promise<RelayPaginatedResponse<T>> {
-    const { data } = await apolloClient.query({
-      query: this.props.query,
-      variables,
-      fetchPolicy: this.props.fetchPolicy || "network-only"
-    });
-    return this.props.toRelay(data);
-  }
+        const relayPage = data ? props.toRelay(data) : emptyRelayPage<TNode>();
 
-  async load(more = false) {
-    if (more && !this.state.hasMore) return;
-    this.setState({ loading: true });
-    const last = await this.query(
-      more
-        ? {
-            ...this.props.queryVars,
-            ...this.props.nextQueryVars(this.state.last.pageInfo.endCursor)
-          }
-        : this.props.queryVars
-    );
-    this.setState((prev) => ({
-      nodes: (more ? prev.nodes : []).concat(
-        last.edges.map((edge) => edge.node)
-      ),
-      last,
-      loading: false,
-      hasMore: last.pageInfo.hasNextPage
-    }));
-  }
+        if (relayPage.edges.length === 0 && !loading) {
+          return <Empty />;
+        }
 
-  render() {
-    if (this.state.nodes.length === 0 && !this.state.loading) {
-      return (
-        <div>{(this.props.empty || (() => <div>no items found</div>))()}</div>
-      );
-    }
+        const onLoadMore = () =>
+          fetchMore({
+            variables: {
+              ...props.queryVars,
+              ...props.nextQueryVars(relayPage.pageInfo.endCursor)
+            },
+            updateQuery: props.updateQuery
+          });
 
-    return (
-      <div>
-        {this.state.nodes.map((item, idx) => (
-          <ChildOnly key={(this.props.keyFunc || ((_, i) => i))(item, idx)}>
-            {this.props.renderNode(item, idx)}
-          </ChildOnly>
-        ))}
-        <WhenSeen onSeenChange={(isSeen) => isSeen && this.load(true)}>
-          {(
-            this.props.cliffHanger ||
-            (() => (
-              <div>
-                <span role="img" aria-label="end of list">
-                  😳 end of list 😳
-                </span>
-              </div>
-            ))
-          )(this.state.hasMore, this.state.last)}
-        </WhenSeen>
-      </div>
-    );
-  }
-}
+        return (
+          <div>
+            {relayPage.edges.map(({ node }, idx) => (
+              <ChildOnly key={(props.keyFunc || ((_, i) => i))(node, idx)}>
+                {props.renderNode(node, idx)}
+              </ChildOnly>
+            ))}
+            <WhenSeen onSeenChange={(isSeen) => isSeen && onLoadMore()}>
+              {cliffHanger(relayPage.pageInfo.hasNextPage, relayPage)}
+            </WhenSeen>
+          </div>
+        );
+      }}
+    </Query>
+  );
+};
+
 export default InfiniteRelayList;

--- a/src/components/InfiniteRelayList.tsx
+++ b/src/components/InfiniteRelayList.tsx
@@ -83,7 +83,11 @@ const InfiniteRelayList = <TData, TNode, TVariables>(
                 {props.renderNode(node, idx)}
               </ChildOnly>
             ))}
-            <WhenSeen onSeenChange={(isSeen) => isSeen && onLoadMore()}>
+            <WhenSeen
+              onSeenChange={(isSeen) =>
+                isSeen && relayPage.pageInfo.hasNextPage && onLoadMore()
+              }
+            >
               {cliffHanger(relayPage.pageInfo.hasNextPage, relayPage)}
             </WhenSeen>
           </div>

--- a/src/components/WhenSeen.tsx
+++ b/src/components/WhenSeen.tsx
@@ -12,11 +12,11 @@ class WhenSeen extends React.Component<WhenSeenProps> {
   constructor(props: WhenSeenProps) {
     super(props);
     this.observer = new IntersectionObserver(([entry]) =>
-      props.onSeenChange(entry.isIntersecting)
+      this.props.onSeenChange(entry.isIntersecting)
     );
   }
 
-  onNewRef(newRef: Element | null) {
+  onNewRef = (newRef: Element | null) => {
     if (!isNull(newRef) && this.observer) {
       const oldRef = this.cliffhangerRef;
       if (oldRef !== newRef) {
@@ -25,12 +25,10 @@ class WhenSeen extends React.Component<WhenSeenProps> {
         this.cliffhangerRef = newRef;
       }
     }
-  }
+  };
 
   render() {
-    return (
-      <div ref={(newRef) => this.onNewRef(newRef)}>{this.props.children}</div>
-    );
+    return <div ref={this.onNewRef}>{this.props.children}</div>;
   }
 }
 

--- a/src/containers/AdminPeople/AdminPeople.tsx
+++ b/src/containers/AdminPeople/AdminPeople.tsx
@@ -148,7 +148,6 @@ interface AdminPeopleState {
     message: string;
     seen: boolean;
   };
-  lastMutated: Date;
 }
 
 class AdminPeople extends React.Component<
@@ -177,8 +176,7 @@ class AdminPeople extends React.Component<
     error: {
       message: "",
       seen: true
-    },
-    lastMutated: new Date()
+    }
   };
 
   handleConfirmSuperadmin = () => {
@@ -279,7 +277,6 @@ class AdminPeople extends React.Component<
       editAutoApprove: (autoApprove, userId) =>
         this.handleEditAutoApprove(autoApprove, userId),
       resetUserPassword: (userId) => this.handleResetPassword(userId),
-      wasUpdated: () => this.setState({ lastMutated: new Date() }),
       error: (message) => this.setState({ error: { message, seen: false } })
     };
   }
@@ -316,7 +313,6 @@ class AdminPeople extends React.Component<
           nameSearch={this.state.filter.nameSearch}
           onlyCampaignId={this.ctx().campaignFilter.onlyId}
           rowEventHandlers={this.rowEventHandlers()}
-          lastMutated={this.state.lastMutated}
         />
 
         <AddPersonButton
@@ -334,8 +330,7 @@ class AdminPeople extends React.Component<
           userId={this.state.userEdit.userId}
           afterEditing={() => {
             this.setState({
-              userEdit: { open: false, userId: "" },
-              lastMutated: new Date()
+              userEdit: { open: false, userId: "" }
             });
           }}
         />

--- a/src/containers/AdminPeople/AdminPeople.tsx
+++ b/src/containers/AdminPeople/AdminPeople.tsx
@@ -200,7 +200,6 @@ class AdminPeople extends React.Component<
         }
       });
     }
-    this.rowEventHandlers().wasUpdated(userId);
   };
 
   handleEditAutoApprove = async (
@@ -221,7 +220,6 @@ class AdminPeople extends React.Component<
         }
       });
     }
-    this.rowEventHandlers().wasUpdated(userId);
   };
 
   handleCloseSuperadminDialog = () => {

--- a/src/containers/AdminPeople/PeopleTable.tsx
+++ b/src/containers/AdminPeople/PeopleTable.tsx
@@ -1,5 +1,4 @@
 import gql from "graphql-tag";
-import cloneDeep from "lodash/cloneDeep";
 import PeopleIcon from "material-ui/svg-icons/social/people";
 import { Table, TableBody } from "material-ui/Table";
 import React from "react";
@@ -100,21 +99,18 @@ const PeopleTable: React.StatelessComponent<PeopleTableProps> = ({
             after: cursor,
             filter
           })}
-          updateQuery={(previousResult, { fetchMoreResult }) => {
+          updateQuery={(nextResultDraft, { fetchMoreResult }) => {
             if (
               !fetchMoreResult ||
               fetchMoreResult.organization.memberships.edges.length === 0
             )
-              return previousResult;
+              return;
 
-            const nextResult = cloneDeep(previousResult);
-            nextResult.organization.memberships.edges = [
-              ...nextResult.organization.memberships.edges,
-              ...fetchMoreResult.organization.memberships.edges
-            ];
-            nextResult.organization.memberships.pageInfo =
+            nextResultDraft.organization.memberships.edges.concat(
+              fetchMoreResult.organization.memberships.edges
+            );
+            nextResultDraft.organization.memberships.pageInfo =
               fetchMoreResult.organization.memberships.pageInfo;
-            return nextResult;
           }}
           toRelay={(data) => data.organization.memberships}
           renderNode={(membership: OrganizationMembership) => (

--- a/src/containers/AdminPeople/PeopleTable.tsx
+++ b/src/containers/AdminPeople/PeopleTable.tsx
@@ -100,15 +100,12 @@ const PeopleTable: React.StatelessComponent<PeopleTableProps> = ({
             filter
           })}
           updateQuery={(nextResultDraft, { fetchMoreResult }) => {
-            if (
-              !fetchMoreResult ||
-              fetchMoreResult.organization.memberships.edges.length === 0
-            )
-              return;
+            if (!fetchMoreResult) return;
 
-            nextResultDraft.organization.memberships.edges.concat(
-              fetchMoreResult.organization.memberships.edges
-            );
+            nextResultDraft.organization.memberships.edges = [
+              ...nextResultDraft.organization.memberships.edges,
+              ...fetchMoreResult.organization.memberships.edges
+            ];
             nextResultDraft.organization.memberships.pageInfo =
               fetchMoreResult.organization.memberships.pageInfo;
           }}

--- a/src/containers/AdminPeople/context.ts
+++ b/src/containers/AdminPeople/context.ts
@@ -37,6 +37,5 @@ export interface PeopleRowEventHandlers {
     userId: string
   ) => void;
   resetUserPassword: (userId: string) => void;
-  wasUpdated: (userId: string) => void;
   error: (errorMsg: string) => void;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11300,6 +11300,11 @@ immer@7.0.9:
   resolved "https://registry.yarnpkg.com/immer/-/immer-7.0.9.tgz#28e7552c21d39dd76feccd2b800b7bc86ee4a62e"
   integrity sha512-Vs/gxoM4DqNAYR7pugIxi0Xc8XAun/uy7AQu4fLLqaTBHxjOP9pJ266Q9MWA/ly4z6rAFZbvViOtihxUZ7O28A==
 
+immer@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
+  integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
+
 immutable@^3.7.4:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"


### PR DESCRIPTION
## Description

Use Apollo Client caching for pagination.

## Motivation and Context

Managing pagination state manually means components will not get updates from the Apollo Client cache (e.g. mutation result). This uses the `<Query>` component from Apollo Client to push pagination state management up to Apollo.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
