### PR TITLE
fix: add getSendBeforeUtc util to fix sendBefore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,10 @@ jobs:
           name: Lint codebase
           command: yarn lint && yarn format
 
+      - run:
+          name: Unit tests
+          command: yarn jest src/**/*
+
   build_image:
     docker:
       - image: circleci/node:12.20.0

--- a/jest.config.js
+++ b/jest.config.js
@@ -23,10 +23,12 @@ module.exports = {
     SESSION_SECRET: "it is JUST a test! -- it better be!",
     TEST_ENVIRONMENT: "1"
   },
-  moduleFileExtensions: ["js", "jsx"],
-  transform: {
-    ".*.js": "<rootDir>/node_modules/babel-jest"
-  },
+  testMatch: [
+    "**/__tests__/**/*.js?(x),**/?(*.)(spec|test).js?(x)",
+    "**/?(*.)+(spec|test).[jt]s?(x)"
+  ],
+  moduleFileExtensions: ["js", "jsx", "ts", "tsx"],
+  transform: { "\\.[jt]sx?$": "babel-jest" },
   moduleDirectories: ["node_modules"],
   moduleNameMapper: {
     "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":

--- a/src/lib/tz-helpers.spec.ts
+++ b/src/lib/tz-helpers.spec.ts
@@ -1,0 +1,25 @@
+import { DateTime } from "./datetime";
+import { getSendBeforeUtc } from "./tz-helpers";
+
+describe("getSendBefore", () => {
+  test("gets correct sendBefore for midday Eastern", () => {
+    const middayUsEastern = DateTime.fromISO("2020-01-20T12:00:00-05:00");
+    expect(getSendBeforeUtc("America/New_York", 21, middayUsEastern)).toBe(
+      "2020-01-21T02:00:00.000Z"
+    );
+  });
+
+  test("gets correct sendBefore for afterhours Eastern", () => {
+    const afterHoursEastern = DateTime.fromISO("2020-01-20T22:00:00-05:00");
+    expect(getSendBeforeUtc("America/New_York", 21, afterHoursEastern)).toBe(
+      "2020-01-21T02:00:00.000Z"
+    );
+  });
+
+  test("gets correct sendBefore for afterhours UTC", () => {
+    const afterHoursUtc = DateTime.fromISO("2020-01-21T03:00:00Z");
+    expect(getSendBeforeUtc("America/New_York", 21, afterHoursUtc)).toBe(
+      "2020-01-21T02:00:00.000Z"
+    );
+  });
+});

--- a/src/lib/tz-helpers.ts
+++ b/src/lib/tz-helpers.ts
@@ -13,3 +13,15 @@ export const isValidTimezone: (tzstr: string) => boolean = (tzstr) =>
 
 export const asUtc: (dt: Date) => DateTime = (dt) =>
   DateTime.fromJSDate(dt, { zone: "utc" });
+
+export const getSendBeforeUtc = (
+  zone: string,
+  endHour: number,
+  now?: DateTime
+) =>
+  (now ?? DateTime.local())
+    .setZone(zone)
+    .startOf("day")
+    .set({ hour: endHour })
+    .setZone("utc")
+    .toISO();

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -20,6 +20,7 @@ import { DateTime, parseIanaZone } from "../../lib/datetime";
 import { hasRole } from "../../lib/permissions";
 import { applyScript } from "../../lib/scripts";
 import { isNowBetween } from "../../lib/timezones";
+import { getSendBeforeUtc } from "../../lib/tz-helpers";
 import logger from "../../logger";
 import {
   assignTexters,
@@ -653,11 +654,7 @@ async function sendMessage(
     throw new GraphQLError("Outside permitted texting time for this recipient");
   }
 
-  const sendBefore = DateTime.utc()
-    .set({ hour: endHour })
-    .setZone(timezone)
-    .startOf("day")
-    .toISO();
+  const sendBefore = getSendBeforeUtc(timezone, endHour, DateTime.local());
   const { contactNumber, text } = message;
 
   if (text.length > (config.MAX_MESSAGE_LENGTH || 99999)) {


### PR DESCRIPTION
## Description

Add a testable utility function for generating the `sendBefore` value for a campaign's messages.

## Motivation and Context

The previous generation method was producing values in the past.

Switchboard also drops the timezone data so converting to UTC must be the final step.

## How Has This Been Tested?

This has been tested with included unit tests.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
