### PR TITLE
fix(people): pass membership id to membership mutation

### DIFF
--- a/src/containers/AdminPeople/AdminPeople.tsx
+++ b/src/containers/AdminPeople/AdminPeople.tsx
@@ -142,7 +142,7 @@ interface AdminPeopleState {
   };
   confirmSuperadmin: {
     open: boolean;
-    superadminId: string;
+    superadminMembershipId: string;
   };
   error: {
     message: string;
@@ -172,7 +172,7 @@ class AdminPeople extends React.Component<
     },
     confirmSuperadmin: {
       open: false,
-      superadminId: ""
+      superadminMembershipId: ""
     },
     error: {
       message: "",
@@ -182,15 +182,21 @@ class AdminPeople extends React.Component<
   };
 
   handleConfirmSuperadmin = () => {
-    const { superadminId } = this.state.confirmSuperadmin;
-    this.handleEditRole(UserRoleType.SUPERADMIN, superadminId);
+    const { superadminMembershipId } = this.state.confirmSuperadmin;
+    this.handleEditMembershipRole(
+      UserRoleType.SUPERADMIN,
+      superadminMembershipId
+    );
     this.handleCloseSuperadminDialog();
   };
 
-  handleEditRole = async (role: UserRoleType, userId: string) => {
+  handleEditMembershipRole = async (
+    role: UserRoleType,
+    membershipId: string
+  ) => {
     const { editOrganizationMembership } = this.props.mutations;
     try {
-      const response = await editOrganizationMembership(userId, {
+      const response = await editOrganizationMembership(membershipId, {
         role
       });
       if (response.errors) throw response.errors;
@@ -202,16 +208,16 @@ class AdminPeople extends React.Component<
         }
       });
     }
-    this.rowEventHandlers().wasUpdated(userId);
+    this.rowEventHandlers().wasUpdated(membershipId);
   };
 
   handleEditAutoApprove = async (
     autoApprove: RequestAutoApproveType,
-    userId: string
+    membershipId: string
   ) => {
     const { editOrganizationMembership } = this.props.mutations;
     try {
-      const response = await editOrganizationMembership(userId, {
+      const response = await editOrganizationMembership(membershipId, {
         autoApprove
       });
       if (response.errors) throw response.errors;
@@ -223,16 +229,18 @@ class AdminPeople extends React.Component<
         }
       });
     }
-    this.rowEventHandlers().wasUpdated(userId);
+    this.rowEventHandlers().wasUpdated(membershipId);
   };
 
   handleCloseSuperadminDialog = () => {
-    this.setState({ confirmSuperadmin: { open: false, superadminId: "" } });
+    this.setState({
+      confirmSuperadmin: { open: false, superadminMembershipId: "" }
+    });
   };
 
-  startConfirmSuperadmin = (superadminId: string) =>
+  startConfirmSuperadmin = (superadminMembershipId: string) =>
     this.setState(() => ({
-      confirmSuperadmin: { superadminId, open: true }
+      confirmSuperadmin: { superadminMembershipId, open: true }
     }));
 
   handleResetPassword = async (userId: string) => {
@@ -269,11 +277,11 @@ class AdminPeople extends React.Component<
         this.setState((prev) => ({
           userEdit: { ...prev.userEdit, userId, open: true }
         })),
-      editRole: (role, userId) => {
+      editMembershipRole: (role, membershipId) => {
         if (role === UserRoleType.SUPERADMIN) {
-          this.startConfirmSuperadmin(userId);
+          this.startConfirmSuperadmin(membershipId);
         } else {
-          this.handleEditRole(role, userId);
+          this.handleEditMembershipRole(role, membershipId);
         }
       },
       editAutoApprove: (autoApprove, userId) =>
@@ -426,7 +434,6 @@ const mutations: MutationMap<AdminPeopleExtendedProps> = {
       autoApprove,
       role
     }: {
-      membershipId: string;
       autoApprove?: RequestAutoApproveType;
       role?: UserRoleType;
     }

--- a/src/containers/AdminPeople/PeopleRow.tsx
+++ b/src/containers/AdminPeople/PeopleRow.tsx
@@ -150,7 +150,9 @@ const PeopleRow: React.StatelessComponent<PeopleRowExtendedProps> = ({
       <TableRowColumn>
         <RoleSelect
           context={context}
-          onSelect={(role) => handlers.editRole(role, row.user.id)}
+          onSelect={(role) =>
+            handlers.editMembershipRole(role, row.membership.id)
+          }
         />
       </TableRowColumn>
 
@@ -158,7 +160,7 @@ const PeopleRow: React.StatelessComponent<PeopleRowExtendedProps> = ({
         <AutoApproveSelect
           context={context}
           onChange={(autoApprove) =>
-            handlers.editAutoApprove(autoApprove, row.user.id)
+            handlers.editAutoApprove(autoApprove, row.membership.id)
           }
         />
       </TableRowColumn>

--- a/src/containers/AdminPeople/context.ts
+++ b/src/containers/AdminPeople/context.ts
@@ -31,10 +31,10 @@ export interface AdminPeopleContext {
 
 export interface PeopleRowEventHandlers {
   startEdit: (userId: string) => void;
-  editRole: (role: UserRoleType, userId: string) => void;
+  editMembershipRole: (role: UserRoleType, membershipId: string) => void;
   editAutoApprove: (
     autoApprove: RequestAutoApproveType,
-    userId: string
+    membershipId: string
   ) => void;
   resetUserPassword: (userId: string) => void;
   wasUpdated: (userId: string) => void;


### PR DESCRIPTION
## Description

Pass membership ID instead of user ID to `editOrganizationMembership` mutation.

## Motivation and Context

The `editOrganizationMembership` mutation expects the ID of an `OrganizationMembership` (`user_orgranization` table) instance.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
