### PR TITLE
fix: handle mixed argument types

### DIFF
--- a/src/components/IncomingMessageList/SurveyColumn/ManageSurveyResponses.jsx
+++ b/src/components/IncomingMessageList/SurveyColumn/ManageSurveyResponses.jsx
@@ -88,7 +88,7 @@ class ManageSurveyResponses extends Component {
           questionResponses[iStepId] = value;
         }
       } catch (error) {
-        this.setState({ requestError: formatErrorMessage(error) });
+        this.setState({ requestError: formatErrorMessage(error.message) });
       } finally {
         this.setState({
           isMakingRequest: false,

--- a/src/containers/hoc/with-operations.jsx
+++ b/src/containers/hoc/with-operations.jsx
@@ -4,6 +4,7 @@ import { compose, graphql, withApollo } from "react-apollo";
 import { branch, renderComponent, withProps } from "recompose";
 
 import LoadingIndicator from "../../components/LoadingIndicator";
+import { replaceAll } from "../../lib/utils";
 
 /**
  * This HOC takes a list of GraphQL query names and adds a loading prop that is true if any of the
@@ -69,7 +70,10 @@ export const formatErrorMessage = (error) => {
       : Object.prototype.hasOwnProperty.call(error, "message")
       ? error.message
       : `${error}`;
-  return message.replaceAll("GraphQL Error:", "").trim();
+  return ["GraphQL Error:", "GraphQL error:"].reduce(
+    (acc, prefix) => replaceAll(acc, prefix, ""),
+    message
+  );
 };
 
 export const PrettyErrors = ({ errors }) => {

--- a/src/containers/hoc/with-operations.jsx
+++ b/src/containers/hoc/with-operations.jsx
@@ -63,7 +63,13 @@ export const withOperations = (options) => {
 
 // remove 'GraphQL Error:' from error messages, per client request
 export const formatErrorMessage = (error) => {
-  return error.message.replaceAll("GraphQL Error:", "").trim();
+  const message =
+    typeof error === "string"
+      ? error
+      : Object.prototype.hasOwnProperty.call(error, "message")
+      ? error.message
+      : `${error}`;
+  return message.replaceAll("GraphQL Error:", "").trim();
 };
 
 export const PrettyErrors = ({ errors }) => {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,3 +1,4 @@
+import escapeRegExp from "lodash/escapeRegExp";
 import isEqual from "lodash/isEqual";
 import isObject from "lodash/isObject";
 import transform from "lodash/transform";
@@ -43,3 +44,6 @@ export const asPercentWithTotal = (numerator, denominator) =>
       ? 0
       : ((numerator / denominator) * 100).toString().slice(0, 4)
   }%(${numerator})`;
+
+export const replaceAll = (str, find, replace) =>
+  str.replace(new RegExp(escapeRegExp(find), "g"), replace);

--- a/src/lib/utils.spec.ts
+++ b/src/lib/utils.spec.ts
@@ -1,0 +1,45 @@
+import { asPercentWithTotal, replaceAll, stringIsAValidUrl } from "./utils";
+
+describe("stringIsAValidUrl", () => {
+  test("recognizes valid URL", () => {
+    expect(stringIsAValidUrl("https://www.politicsrewired.com")).toBe(true);
+  });
+
+  test("recognizes valid URL with query string", () => {
+    expect(
+      stringIsAValidUrl("https://www.politicsrewired.com?foo=bar&bar=baz")
+    ).toBe(true);
+  });
+
+  test("rejects invalid URL without scheme", () => {
+    expect(stringIsAValidUrl("www.politicsrewired.com")).toBe(false);
+  });
+
+  test("rejects invalid URL", () => {
+    expect(stringIsAValidUrl("foo/bar")).toBe(false);
+  });
+});
+
+describe("replaceAll", () => {
+  test("replaces mulitple occurrences", () => {
+    expect(
+      replaceAll("buffalo buffalo buffalo buffalo buffalo", "buffalo", "squid")
+    ).toBe("squid squid squid squid squid");
+  });
+
+  test("escapes special regex characters", () => {
+    expect(replaceAll(`what about \\ characters?`, `\\`, `?`)).toBe(
+      "what about ? characters?"
+    );
+  });
+});
+
+describe("asPercentWithTotal", () => {
+  test("handles 0 denominator correctly", () => {
+    expect(asPercentWithTotal(10, 0)).toBe("0%(10)");
+  });
+
+  test("truncates decimal", () => {
+    expect(asPercentWithTotal(9, 11)).toBe("81.8%(9)");
+  });
+});

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -21,6 +21,7 @@ import { hasRole } from "../../lib/permissions";
 import { applyScript } from "../../lib/scripts";
 import { isNowBetween } from "../../lib/timezones";
 import { getSendBeforeUtc } from "../../lib/tz-helpers";
+import { replaceAll } from "../../lib/utils";
 import logger from "../../logger";
 import {
   assignTexters,
@@ -106,9 +107,6 @@ const { JOBS_SYNC } = config;
 
 const replaceCurlyApostrophes = (rawText) =>
   rawText.replace(/[\u2018\u2019]/g, "'");
-
-const replaceAll = (str, find, replace) =>
-  str.replace(new RegExp(escapeRegExp(find), "g"), replace);
 
 const replaceShortLinkDomains = async (organizationId, messageText) => {
   const domains = await r


### PR DESCRIPTION
## Description

Update `formatErrorMessage()` to handle mixed arguments gracefully.

## Motivation and Context

`formatErrorMessage()` gets passed `Error` and `string` type arguments in different places but previously only expected `Error` type. Passing a string would cause an `Uncaught TypeError: Cannot read property 'replaceAll' of undefined` error in the client rendering certain components unresponsive.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This has been tested locally and unit tests have been added.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
