### PR TITLE
fix: fix email notifications on campaign start

### DIFF
--- a/src/server/notifications.js
+++ b/src/server/notifications.js
@@ -83,7 +83,7 @@ export const sendUserNotification = async (notification) => {
     const assignments = await r
       .reader("assignment")
       .where({ campaign_id: notification.campaignId })
-      .pluck(["user_id", "campaign_id"]);
+      .select(["user_id", "campaign_id"]);
 
     const count = assignments.length;
     for (let i = 0; i < count; i += 1) {


### PR DESCRIPTION
## Description

Restore email notifications on campaign start.

## Motivation and Context

A user reported that starting a campaign did not trigger email notifications. Inspection of that clients settings showed that emails _should_ have been going out for campaign start events. Looking at logs I found:

```json
{
	"content": {
		"service": "spoke",
		"message": "GraphQL error: Undefined binding(s) detected when compiling FIRST query: select * from \"campaign\" where \"id\" = ? limit ?",
		"attributes": {
			"path": [
				"startCampaign"
			],
			"extensions": {
				"code": "INTERNAL_SERVER_ERROR"
			},
			"level": "error",
			"locations": [
				{
					"line": 2,
					"column": 3
				}
			]
		}
	}
}
```

Turns out that Knex's `pluck()` only works for a single column (makes sense) and returns `false` otherwise, rather than throwing an error (does not make sense). This meant that the query to get assignments was returning an array of `false` causing the error above in a subsequent query referencing `assignment.campaign_id` (`false.campaign_id`).

## How Has This Been Tested?

The error was reproduced locally and has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
