### PR TITLE
fix(deliverability-stats): ensure consistent null return type

### DIFF
--- a/src/server/api/lib/campaign.ts
+++ b/src/server/api/lib/campaign.ts
@@ -81,7 +81,8 @@ export const getDeliverabilityStats = async (campaignId: number) => {
     specificErrors: rows
       .filter((o) => o.send_status === "ERROR")
       .map((o) => ({
-        errorCode: o.error_codes ? o.error_codes[0] : null,
+        errorCode:
+          o.error_codes && o.error_codes.length > 0 ? o.error_codes[0] : null,
         count: o.count
       }))
   };

--- a/src/server/api/lib/campaign.ts
+++ b/src/server/api/lib/campaign.ts
@@ -53,7 +53,7 @@ export const getDeliverabilityStats = async (campaignId: number) => {
   const rows = await r.reader
     .raw(
       `
-        select count(*), send_status, error_codes
+        select count(*), send_status, coalesce(error_codes, '{}') as error_codes
         from message
         join campaign_contact on campaign_contact.id = message.campaign_contact_id
         where campaign_contact.campaign_id = ?


### PR DESCRIPTION
## Description

This ensures a) that `[]` and `null` error codes are grouped and b) that `null`, rather than `undefined`, is returned to the resolver.

## Motivation and Context

GraphQL does not coerce `undefined` -> `null` so we must ensure we're returning `null` to avoid this error:

```
GraphQL error: Resolve function for "DeliverabilityErrorStat.errorCode" returned undefined
```

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
