### PR TITLE
fix: use single source of truth for interaction steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@trt2/gsm-charset-utils": "^1.0.13",
     "@types/luxon": "^1.25.0",
     "aphrodite": "^0.4.1",
+    "apollo-cache": "^1.3.4",
     "apollo-cache-inmemory": "^1.6.5",
     "apollo-client": "^2.6.3",
     "apollo-link": "^1.2.13",

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/components/InteractionStepCard.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/components/InteractionStepCard.tsx
@@ -49,6 +49,7 @@ interface Props {
   availableActions: any[];
   hasBlockCopied: boolean;
   title?: string;
+  disabled?: boolean;
   onFormChange(e: any): void;
   onCopyBlock(interactionStep: InteractionStep): void;
   onRequestRootPaste(): void;
@@ -64,6 +65,7 @@ export const InteractionStepCard: React.SFC<Props> = (props) => {
     availableActions,
     hasBlockCopied,
     title = "Start",
+    disabled = false,
     onFormChange,
     onCopyBlock,
     onRequestRootPaste,
@@ -106,11 +108,18 @@ export const InteractionStepCard: React.SFC<Props> = (props) => {
           }
         />
         <CardActions>
-          <RaisedButton onClick={() => onCopyBlock(interactionStep)}>
+          <RaisedButton
+            disabled={disabled}
+            onClick={() => onCopyBlock(interactionStep)}
+          >
             Copy Block
           </RaisedButton>
           {hasBlockCopied && (
-            <RaisedButton label="+ Paste Block" onClick={onRequestRootPaste} />
+            <RaisedButton
+              label="+ Paste Block"
+              disabled={disabled}
+              onClick={onRequestRootPaste}
+            />
           )}
         </CardActions>
         <CardText>
@@ -128,8 +137,12 @@ export const InteractionStepCard: React.SFC<Props> = (props) => {
                   label="Answer"
                   fullWidth
                   hintText="Answer to the previous question"
+                  disabled={disabled}
                 />
-                <IconButton onClick={deleteStepFactory(stepId)}>
+                <IconButton
+                  disabled={disabled}
+                  onClick={deleteStepFactory(stepId)}
+                >
                   <DeleteIcon />
                 </IconButton>
               </div>
@@ -147,8 +160,12 @@ export const InteractionStepCard: React.SFC<Props> = (props) => {
                       label: action.display_name
                     }))
                   ]}
+                  disabled={disabled}
                 />
-                <IconButton tooltip="An action is something that is triggered by this answer being chosen, often in an outside system">
+                <IconButton
+                  tooltip="An action is something that is triggered by this answer being chosen, often in an outside system"
+                  disabled={disabled}
+                >
                   <HelpIconOutline />
                 </IconButton>
                 <div>
@@ -167,6 +184,7 @@ export const InteractionStepCard: React.SFC<Props> = (props) => {
               customFields={customFields}
               fullWidth
               multiLine
+              disabled={disabled}
             />
             <Form.Field
               {...dataTest("questionText")}
@@ -174,6 +192,7 @@ export const InteractionStepCard: React.SFC<Props> = (props) => {
               label="Question"
               fullWidth
               hintText="A question for texters to answer. E.g. Can this person attend the event?"
+              disabled={disabled}
             />
           </GSForm>
         </CardText>
@@ -184,16 +203,18 @@ export const InteractionStepCard: React.SFC<Props> = (props) => {
             key="add"
             {...dataTest("addResponse")}
             label="+ Add a response"
-            onClick={addStepFactory(stepId)}
             style={{ marginBottom: "10px" }}
+            disabled={disabled}
+            onClick={addStepFactory(stepId)}
           />
         )}
         {isAbleToAddResponse && hasBlockCopied && (
           <RaisedButton
             key="paste"
             label="+ Paste Block"
-            onClick={pasteBlockFactory(stepId)}
+            disabled={disabled}
             style={{ marginBottom: "10px" }}
+            onClick={pasteBlockFactory(stepId)}
           />
         )}
         {childSteps
@@ -206,6 +227,7 @@ export const InteractionStepCard: React.SFC<Props> = (props) => {
               customFields={customFields}
               availableActions={availableActions}
               hasBlockCopied={hasBlockCopied}
+              disabled={disabled}
               onFormChange={onFormChange}
               onCopyBlock={onCopyBlock}
               onRequestRootPaste={onRequestRootPaste}

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/components/InteractionStepCard.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/components/InteractionStepCard.tsx
@@ -87,7 +87,7 @@ export const InteractionStepCard: React.SFC<Props> = (props) => {
     availableActions &&
     availableActions.length > 0;
 
-  const stepHasScript = scriptOptions.length > 0;
+  const stepHasScript = scriptOptions && scriptOptions.length > 0;
   const stepHasQuestion = questionText;
   const stepCanHaveChildren = !parentInteractionId || answerOption;
   const isAbleToAddResponse =

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
@@ -338,6 +338,7 @@ class CampaignInteractionStepsForm extends React.Component<InnerProps, State> {
           customFields={customFields}
           availableActions={availableActions}
           hasBlockCopied={this.state.hasBlockCopied}
+          disabled={isWorking}
           onFormChange={this.handleFormChange}
           onCopyBlock={this.copyBlock}
           onRequestRootPaste={this.onRequestRootPaste}

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
@@ -1,6 +1,6 @@
 import { ApolloQueryResult } from "apollo-client/core/types";
 import gql from "graphql-tag";
-import cloneDeep from "lodash/cloneDeep";
+import produce from "immer";
 import isEqual from "lodash/isEqual";
 import { Dialog } from "material-ui";
 import FlatButton from "material-ui/FlatButton";
@@ -26,41 +26,37 @@ import {
   RequiredComponentProps
 } from "../../components/SectionWrapper";
 import InteractionStepCard from "./components/InteractionStepCard";
-
-/**
- * Returns `interactionSteps` with `stepId` and all its children marked as `isDeleted`.
- * @param {string} stepId The ID of the interaction step to mark as deleted.
- * @param {string[]} interactionSteps The list of interaction steps to work on.
- */
-const markDeleted = (stepId: string, interactionSteps: InteractionStep[]) => {
-  interactionSteps = interactionSteps.map((step) => {
-    const updates = step.id === stepId ? { isDeleted: true } : {};
-    return { ...step, ...updates };
-  });
-
-  const childSteps = interactionSteps.filter(
-    (step) => step.parentInteractionId === stepId
-  );
-  for (const childStep of childSteps) {
-    interactionSteps = markDeleted(childStep.id, interactionSteps);
-  }
-
-  return interactionSteps;
-};
+import {
+  AddInteractionStepPayload,
+  EditInteractionStepFragment,
+  generateId,
+  GET_CAMPAIGN_INTERACTIONS,
+  UpdateInteractionStepPayload
+} from "./resolvers";
 
 interface Values {
   interactionSteps: InteractionStepWithChildren;
 }
 
+interface InteractionStepWithLocalState extends InteractionStep {
+  isModified: boolean;
+}
+
 interface HocProps {
   mutations: {
     editCampaign(payload: Values): ApolloQueryResult<any>;
+    stageDeleteInteractionStep(iStepId: string): Promise<void>;
+    stageClearInteractionSteps(): Promise<void>;
+    stageAddInteractionStep(payload: AddInteractionStepPayload): Promise<void>;
+    stageUpdateInteractionStep(
+      iStepId: string,
+      payload: UpdateInteractionStepPayload
+    ): Promise<void>;
   };
   data: {
-    campaign: Pick<
-      Campaign,
-      "id" | "isStarted" | "interactionSteps" | "customFields"
-    >;
+    campaign: Pick<Campaign, "id" | "isStarted" | "customFields"> & {
+      interactionSteps: InteractionStepWithLocalState[];
+    };
   };
   availableActions: {
     availableActions: Action[];
@@ -72,7 +68,6 @@ interface InnerProps extends FullComponentProps, HocProps {}
 interface State {
   hasBlockCopied: boolean;
   confirmingRootPaste: boolean;
-  interactionSteps: InteractionStep[];
   isWorking: boolean;
 }
 
@@ -80,65 +75,72 @@ class CampaignInteractionStepsForm extends React.Component<InnerProps, State> {
   state: State = {
     isWorking: false,
     hasBlockCopied: false,
-    confirmingRootPaste: false,
-    interactionSteps: [
-      {
-        id: "newId",
-        parentInteractionId: null,
-        questionText: "",
-        answerOption: "",
-        scriptOptions: [""],
-        answerActions: "",
-        isDeleted: false,
-        createdAt: DateTime.local().toJSDate()
-      }
-    ]
+    confirmingRootPaste: false
   };
 
   componentDidMount() {
     this.updateClipboardHasBlock();
-
-    const { interactionSteps } = this.props.data.campaign;
-    if (interactionSteps.length > 0) {
-      this.setState({ interactionSteps: cloneDeep(interactionSteps) });
-    }
   }
 
-  pendingInteractionSteps = (options: { filterEmpty: boolean }) => {
-    const oldTree: InteractionStepWithChildren = makeTree(
-      this.props.data.campaign.interactionSteps
-    );
-
-    const emptyScriptSteps = this.state.interactionSteps.filter((step) => {
+  pendingInteractionSteps = (options: {
+    filterEmpty: boolean;
+    filterDeleted: boolean;
+    stripLocals: boolean;
+  }) => {
+    const hasEmptyScript = (step: InteractionStep) => {
       const hasNoOptions = step.scriptOptions.length === 0;
-      const hasEmptyScripts =
-        step.scriptOptions.filter((version) => version.trim() === "").length >
-        0;
-      return !step.isDeleted && (hasNoOptions || hasEmptyScripts);
-    });
+      const hasEmptyScriptOption =
+        step.scriptOptions.find((version) => version.trim() === "") !==
+        undefined;
+      return hasNoOptions || hasEmptyScriptOption;
+    };
 
-    const hasEmptyScripts = emptyScriptSteps.length > 0;
+    const {
+      campaign: { interactionSteps = [] } = {
+        campaign: { interactionSteps: [] }
+      }
+    } = this.props.data;
+    const liveInteractionSteps = interactionSteps
+      .filter(
+        (step) =>
+          (!options.filterDeleted || !step.isDeleted) &&
+          (!options.filterEmpty || !hasEmptyScript(step))
+      )
+      .map((step) => {
+        if (options.stripLocals) {
+          const { isModified: _, ...stripped } = step;
+          return stripped;
+        }
+        return step;
+      });
 
-    // Strip all empty script versions. "Save" should be disabled in this case, but just in case...
-    const interactionSteps = !options.filterEmpty
-      ? this.state.interactionSteps
-      : this.state.interactionSteps.map((step) => {
-          const scriptOptions = step.scriptOptions.filter(
-            (scriptOption) => scriptOption.trim() !== ""
-          );
-          return { ...step, scriptOptions };
-        });
-    const newTree: InteractionStepWithChildren = makeTree(interactionSteps);
+    const didChange =
+      interactionSteps.find(
+        (step) => step.isDeleted || step.isModified || step.id.includes("new")
+      ) !== undefined;
 
-    const didChange = !isEqual(oldTree, newTree);
+    const hasEmptyScripts =
+      liveInteractionSteps.find(hasEmptyScript) !== undefined;
 
-    return { interactionSteps: newTree, didChange, hasEmptyScripts };
+    return {
+      interactionSteps: liveInteractionSteps,
+      didChange,
+      hasEmptyScripts
+    };
   };
 
   handleSave = async () => {
-    const { interactionSteps, didChange } = this.pendingInteractionSteps({
-      filterEmpty: true
+    const { didChange } = this.pendingInteractionSteps({
+      filterEmpty: true,
+      filterDeleted: false,
+      stripLocals: true
     });
+
+    const interactionSteps = makeTree(
+      this.props.data.campaign.interactionSteps.map(
+        ({ isModified: _, ...step }) => step
+      )
+    );
 
     if (!didChange) return;
 
@@ -156,28 +158,8 @@ class CampaignInteractionStepsForm extends React.Component<InnerProps, State> {
   };
 
   createAddStepHandler = (parentInteractionId: string) => () => {
-    const randId = this.generateId();
-
-    const newStep: InteractionStep = {
-      id: randId,
-      parentInteractionId,
-      questionText: "",
-      scriptOptions: [""],
-      answerOption: "",
-      answerActions: "",
-      isDeleted: false,
-      createdAt: DateTime.local().toJSDate()
-    };
-
-    this.setState({
-      interactionSteps: [...this.state.interactionSteps, newStep]
-    });
+    this.props.mutations.stageAddInteractionStep({ parentInteractionId });
   };
-
-  generateId = () =>
-    `new${Math.random()
-      .toString(36)
-      .replace(/[^a-zA-Z1-9]+/g, "")}`;
 
   onRequestRootPaste = () => {
     this.setState({ confirmingRootPaste: true });
@@ -195,7 +177,7 @@ class CampaignInteractionStepsForm extends React.Component<InnerProps, State> {
       const newBlocks: InteractionStep[] = JSON.parse(text);
 
       newBlocks.forEach((interactionStep) => {
-        idMap[interactionStep.id] = this.generateId();
+        idMap[interactionStep.id] = generateId();
       });
 
       const mappedBlocks: InteractionStep[] = newBlocks.map(
@@ -211,42 +193,49 @@ class CampaignInteractionStepsForm extends React.Component<InnerProps, State> {
         }
       );
 
-      this.setState({
-        interactionSteps:
-          parentInteractionId === null
-            ? mappedBlocks
-            : this.state.interactionSteps.concat(mappedBlocks)
-      });
+      if (parentInteractionId === null) {
+        this.props.mutations.stageClearInteractionSteps();
+      }
+
+      mappedBlocks.forEach((newStep) =>
+        this.props.mutations.stageAddInteractionStep(newStep)
+      );
     });
   };
 
-  createDeleteStepHandler = (id: string) => () => {
-    const interactionSteps = markDeleted(id, this.state.interactionSteps);
-    this.setState({ interactionSteps });
-  };
+  createDeleteStepHandler = (id: string) => () =>
+    this.props.mutations.stageDeleteInteractionStep(id);
 
   handleFormChange = (changedStep: InteractionStepWithChildren) => {
-    const updatedEvent = { ...changedStep, interactionSteps: undefined };
-    const interactionSteps = this.state.interactionSteps.map((step) =>
-      step.id === updatedEvent.id ? updatedEvent : step
-    );
-    this.setState({ interactionSteps });
+    const { answerOption, questionText, scriptOptions } = changedStep;
+    this.props.mutations.stageUpdateInteractionStep(changedStep.id, {
+      answerOption,
+      questionText,
+      scriptOptions
+    });
   };
 
-  copyBlock = (interactionStep: InteractionStep) => {
+  copyBlock = (interactionStep: InteractionStepWithChildren) => {
     const interactionStepsInBlock = new Set([interactionStep.id]);
     const {
       parentInteractionId: _id,
+      interactionSteps: _interactionSteps,
       ...orphanedInteractionStep
     } = interactionStep;
     const block = [orphanedInteractionStep];
 
     let interactionStepsAdded = 1;
 
+    const { interactionSteps } = this.pendingInteractionSteps({
+      filterEmpty: false,
+      filterDeleted: true,
+      stripLocals: true
+    });
+
     while (interactionStepsAdded !== 0) {
       interactionStepsAdded = 0;
 
-      for (const is of this.state.interactionSteps) {
+      for (const is of interactionSteps) {
         if (
           !interactionStepsInBlock.has(is.id) &&
           is.parentInteractionId &&
@@ -280,9 +269,7 @@ class CampaignInteractionStepsForm extends React.Component<InnerProps, State> {
     const {
       isNew,
       saveLabel,
-      data: {
-        campaign: { customFields }
-      },
+      data: { campaign: { customFields } = { customFields: [] } },
       availableActions: { availableActions }
     } = this.props;
 
@@ -290,10 +277,31 @@ class CampaignInteractionStepsForm extends React.Component<InnerProps, State> {
       interactionSteps,
       didChange: hasPendingChanges,
       hasEmptyScripts
-    } = this.pendingInteractionSteps({ filterEmpty: false });
+    } = this.pendingInteractionSteps({
+      filterEmpty: false,
+      filterDeleted: true,
+      stripLocals: true
+    });
     const isSaveDisabled =
       isWorking || hasEmptyScripts || (!isNew && !hasPendingChanges);
     const finalSaveLabel = isWorking ? "Working..." : saveLabel;
+
+    const tree = makeTree(interactionSteps);
+    const finalFree: InteractionStepWithChildren = isEqual(tree, {
+      interactionSteps: []
+    })
+      ? {
+          id: "newId",
+          parentInteractionId: null,
+          questionText: "",
+          answerOption: "",
+          scriptOptions: [""],
+          answerActions: "",
+          interactionSteps: [],
+          isDeleted: false,
+          createdAt: DateTime.local().toISO()
+        }
+      : tree;
 
     return (
       <div
@@ -326,7 +334,7 @@ class CampaignInteractionStepsForm extends React.Component<InnerProps, State> {
           subtitle="You can add scripts and questions and your texters can indicate responses from your contacts. For example, you might want to collect RSVPs to an event or find out whether to follow up about a different volunteer activity."
         />
         <InteractionStepCard
-          interactionStep={interactionSteps}
+          interactionStep={finalFree}
           customFields={customFields}
           availableActions={availableActions}
           hasBlockCopied={this.state.hasBlockCopied}
@@ -356,24 +364,7 @@ class CampaignInteractionStepsForm extends React.Component<InnerProps, State> {
 
 const queries: QueryMap<FullComponentProps> = {
   data: {
-    query: gql`
-      query getCampaignInteractions($campaignId: String!) {
-        campaign(id: $campaignId) {
-          id
-          isStarted
-          interactionSteps {
-            id
-            questionText
-            scriptOptions
-            answerOption
-            answerActions
-            parentInteractionId
-            isDeleted
-          }
-          customFields
-        }
-      }
-    `,
+    query: GET_CAMPAIGN_INTERACTIONS,
     options: (ownProps) => ({
       variables: {
         campaignId: ownProps.campaignId
@@ -409,13 +400,7 @@ const mutations: MutationMap<FullComponentProps> = {
         editCampaign(id: $campaignId, campaign: $payload) {
           id
           interactionSteps {
-            id
-            questionText
-            scriptOptions
-            answerOption
-            answerActions
-            parentInteractionId
-            isDeleted
+            ...EditInteractionStep
           }
           isStarted
           customFields
@@ -425,11 +410,84 @@ const mutations: MutationMap<FullComponentProps> = {
           }
         }
       }
+      ${EditInteractionStepFragment}
     `,
     variables: {
       campaignId: ownProps.campaignId,
       payload
+    },
+    update: (store, { data: { editCampaign } }) => {
+      const variables = { campaignId: ownProps.campaignId };
+      const old = store.readQuery({
+        query: GET_CAMPAIGN_INTERACTIONS,
+        variables
+      });
+      const data = produce(old, (draft: any) => {
+        draft.campaign.interactionSteps = editCampaign.interactionSteps;
+      });
+      store.writeQuery({ query: GET_CAMPAIGN_INTERACTIONS, variables, data });
     }
+  }),
+  stageDeleteInteractionStep: (_ownProps) => (iStepId: string) => ({
+    mutation: gql`
+      mutation StageDeleteInteractionStep($iStepId: String!) {
+        stageDeleteInteractionStep(iStepId: $iStepId) @client
+      }
+    `,
+    variables: { iStepId }
+  }),
+  stageClearInteractionSteps: ({ campaignId }) => () => ({
+    mutation: gql`
+      mutation StageClearInteractionSteps($campaignId: String!) {
+        stageClearInteractionSteps(campaignId: $campaignId) @client
+      }
+    `,
+    variables: { campaignId }
+  }),
+  stageAddInteractionStep: ({ campaignId }) => (
+    payload: AddInteractionStepPayload
+  ) => ({
+    mutation: gql`
+      mutation StageAddInteractionStep(
+        $campaignId: String!
+        $id: String
+        $parentInteractionId: String
+        $questionText: String
+        $scriptOptions: [String]
+        $answerOption: String
+      ) {
+        stageAddInteractionStep(
+          campaignId: $campaignId
+          id: $id
+          parentInteractionId: $parentInteractionId
+          questionText: $questionText
+          scriptOptions: $scriptOptions
+          answerOption: $answerOption
+        ) @client
+      }
+    `,
+    variables: { campaignId, ...payload }
+  }),
+  stageUpdateInteractionStep: (_ownProps) => (
+    iStepId: string,
+    payload: UpdateInteractionStepPayload
+  ) => ({
+    mutation: gql`
+      mutation StageUpdateInteractionStep(
+        $iStepId: String!
+        $questionText: String
+        $scriptOptions: [String]
+        $answerOption: String
+      ) {
+        stageUpdateInteractionStep(
+          iStepId: $iStepId
+          questionText: $questionText
+          scriptOptions: $scriptOptions
+          answerOption: $answerOption
+        ) @client
+      }
+    `,
+    variables: { iStepId, ...payload }
   })
 };
 

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
@@ -95,11 +95,7 @@ class CampaignInteractionStepsForm extends React.Component<InnerProps, State> {
       return hasNoOptions || hasEmptyScriptOption;
     };
 
-    const {
-      campaign: { interactionSteps = [] } = {
-        campaign: { interactionSteps: [] }
-      }
-    } = this.props.data;
+    const interactionSteps = this.props.data?.campaign?.interactionSteps ?? [];
     const liveInteractionSteps = interactionSteps
       .filter(
         (step) =>

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/resolvers.ts
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/resolvers.ts
@@ -1,0 +1,192 @@
+import { Resolver, Resolvers } from "apollo-client";
+import gql from "graphql-tag";
+import produce from "immer";
+
+import { InteractionStep } from "../../../../api/interaction-step";
+import { DateTime } from "../../../../lib/datetime";
+import { LocalResolverContext } from "../../../../network/types";
+
+export const generateId = () =>
+  `new${Math.random()
+    .toString(36)
+    .replace(/[^a-zA-Z1-9]+/g, "")}`;
+
+export const EditInteractionStepFragment = gql`
+  fragment EditInteractionStep on InteractionStep {
+    id
+    questionText
+    scriptOptions
+    answerOption
+    answerActions
+    parentInteractionId
+    isDeleted
+    isModified @client
+  }
+`;
+
+export const GET_CAMPAIGN_INTERACTIONS = gql`
+  query GetEditCampaignInteractions($campaignId: String!) {
+    campaign(id: $campaignId) {
+      id
+      isStarted
+      interactionSteps {
+        ...EditInteractionStep
+      }
+      customFields
+    }
+  }
+  ${EditInteractionStepFragment}
+`;
+
+export interface StageDeleteInteractionStepVars {
+  iStepId: string;
+}
+
+export const stageDeleteInteractionStep: Resolver = (
+  _root,
+  variables: StageDeleteInteractionStepVars,
+  { client, getCacheKey }: LocalResolverContext
+) => {
+  const id = getCacheKey({
+    __typename: "InteractionStep",
+    id: variables.iStepId
+  });
+  const fragment = gql`
+    fragment pendingDeleteInteractionStep on InteractionStep {
+      isDeleted
+    }
+  `;
+
+  const iStep = client.readFragment({ fragment, id });
+  const data = { ...iStep, isDeleted: true };
+  client.writeData({ id, data });
+  return null;
+};
+
+export const stageClearInteractionSteps: Resolver = (
+  _root,
+  { campaignId }: { campaignId: string },
+  { client }: LocalResolverContext
+) => {
+  const variables = { campaignId };
+  const cachedResult = client.readQuery({
+    query: GET_CAMPAIGN_INTERACTIONS,
+    variables
+  });
+  const data = produce(cachedResult, (draft: any) => {
+    draft.campaign.interactionSteps = [];
+  });
+  client.writeQuery({
+    query: GET_CAMPAIGN_INTERACTIONS,
+    variables,
+    data
+  });
+  return null;
+};
+
+export type AddInteractionStepPayload = Partial<
+  Pick<
+    InteractionStep,
+    | "id"
+    | "parentInteractionId"
+    | "answerOption"
+    | "answerActions"
+    | "questionText"
+    | "scriptOptions"
+  >
+>;
+
+export interface StageAddInteractionStepVars extends AddInteractionStepPayload {
+  campaignId: string;
+}
+
+export const stageAddInteractionStep: Resolver = (
+  _root,
+  { campaignId, ...payload }: StageAddInteractionStepVars,
+  { client }: LocalResolverContext
+) => {
+  const variables = { campaignId };
+  const cachedResult = client.readQuery({
+    query: GET_CAMPAIGN_INTERACTIONS,
+    variables
+  });
+  const data = produce(cachedResult, (draft: any) => {
+    draft.campaign.interactionSteps.push({
+      __typename: "InteractionStep",
+      id: payload.id ?? generateId(),
+      parentInteractionId: payload.parentInteractionId ?? null,
+      questionText: payload.questionText ?? "",
+      scriptOptions: payload.scriptOptions ?? [""],
+      answerOption: payload.answerOption ?? "",
+      answerActions: payload.answerOption ?? "",
+      isDeleted: false,
+      isModified: true,
+      createdAt: DateTime.local().toISO()
+    });
+  });
+  client.writeQuery({
+    query: GET_CAMPAIGN_INTERACTIONS,
+    variables,
+    data
+  });
+  return null;
+};
+
+export type UpdateInteractionStepPayload = Partial<
+  Pick<InteractionStep, "answerOption" | "questionText" | "scriptOptions">
+>;
+
+export interface StageUpdateInteractionStepVars
+  extends UpdateInteractionStepPayload {
+  iStepId: string;
+}
+
+export const stageUpdateInteractionStep: Resolver = (
+  _root,
+  { iStepId, ...payload }: StageUpdateInteractionStepVars,
+  { client, getCacheKey }: LocalResolverContext
+) => {
+  const id = getCacheKey({ __typename: "InteractionStep", id: iStepId });
+  const fragment = gql`
+    fragment editableIStep on InteractionStep {
+      questionText
+      scriptOptions
+      answerOption
+    }
+  `;
+  const iStep = client.readFragment({ fragment, id });
+  const data = { ...iStep, ...payload, isModified: true };
+  client.writeData({ id, data });
+  return null;
+};
+
+export const isModified: Resolver = (
+  { id: iStepId },
+  _variables,
+  { client, getCacheKey }: LocalResolverContext
+) => {
+  const id = getCacheKey({ __typename: "InteractionStep", id: iStepId });
+  const fragment = gql`
+    fragment editableIStep on InteractionStep {
+      questionText
+      scriptOptions
+      answerOption
+    }
+  `;
+  const iStep = client.readFragment({ fragment, id });
+  return iStep?.isModified ?? false;
+};
+
+const resolvers: Resolvers = {
+  Mutation: {
+    stageDeleteInteractionStep,
+    stageClearInteractionSteps,
+    stageAddInteractionStep,
+    stageUpdateInteractionStep
+  },
+  InteractionStep: {
+    isModified
+  }
+};
+
+export default resolvers;

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/resolvers.ts
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/resolvers.ts
@@ -167,14 +167,17 @@ export const isModified: Resolver = (
 ) => {
   const id = getCacheKey({ __typename: "InteractionStep", id: iStepId });
   const fragment = gql`
-    fragment editableIStep on InteractionStep {
-      questionText
-      scriptOptions
-      answerOption
+    fragment modifiableStep on InteractionStep {
+      isModified
     }
   `;
-  const iStep = client.readFragment({ fragment, id });
-  return iStep?.isModified ?? false;
+  try {
+    const iStep = client.readFragment({ fragment, id });
+    return iStep?.isModified ?? false;
+  } catch {
+    // readFragment throws an error if `isModified` cannot be found (e.g. the starting condition)
+    return false;
+  }
 };
 
 const resolvers: Resolvers = {

--- a/src/network/apollo-client-singleton.ts
+++ b/src/network/apollo-client-singleton.ts
@@ -12,6 +12,7 @@ import _fetch from "isomorphic-fetch"; // TODO - remove?
 import omitDeep from "omit-deep-lodash";
 
 import { eventBus, EventTypes } from "../client/events";
+import iStepLocalResolvers from "../containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/resolvers";
 import unions from "./unions.json";
 
 const uploadLink = createUploadLink({
@@ -87,7 +88,8 @@ const ApolloClientSingleton = new ApolloClient({
   link,
   cache,
   connectToDevTools: true,
-  queryDeduplication: true
+  queryDeduplication: true,
+  resolvers: [iStepLocalResolvers]
 });
 
 export default ApolloClientSingleton;

--- a/src/network/types.ts
+++ b/src/network/types.ts
@@ -1,4 +1,5 @@
-import { MutationOptions } from "apollo-client";
+import { ApolloCache } from "apollo-cache";
+import { ApolloClient, MutationOptions } from "apollo-client";
 import { OperationOption } from "react-apollo";
 
 export interface QueryMap<OuterProps> {
@@ -11,4 +12,10 @@ export type MutationCreator<OuterProps> = (
 
 export interface MutationMap<OuterProps> {
   [key: string]: MutationCreator<OuterProps>;
+}
+
+export interface LocalResolverContext<TCacheShape extends unknown = any> {
+  client: ApolloClient<TCacheShape>;
+  cache: ApolloCache<TCacheShape>;
+  getCacheKey: (obj: { __typename: string; id: string | number }) => any;
 }


### PR DESCRIPTION
## Description

This makes the Apollo cache the definitive source of truth for editing interaction steps.

## Motivation and Context

Splitting state between the Apollo cache and React component state creates opportunities for DB state and client UI to diverge. Making Apollo the definitive source of truth ensures that all database updates from both queries mutations are reflected in the UI and removed the possibility for React component state to hold onto invalid stale values.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
