### PR TITLE
test: test persistInteractionStepTree

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "material-ui-color-picker": "^1.0.1",
     "material-ui-datatables": "^0.18.2",
     "md5": "^2.2.1",
-    "memoredis": "^1.1.0",
+    "memoredis": "^1.1.1",
     "mysql": "^2.17.1",
     "nexmo": "^1.0.0-beta-7",
     "node-cron": "^2.0.3",

--- a/src/server/api/lib/interaction-steps.spec.ts
+++ b/src/server/api/lib/interaction-steps.spec.ts
@@ -1,6 +1,23 @@
 import { Pool, PoolClient } from "pg";
 
+import {
+  createCompleteCampaign,
+  createInteractionStep
+} from "../../../../__test__/testbed-preparation/core";
+import { InteractionStepWithChildren } from "../../../api/interaction-step";
 import { config } from "../../../config";
+import { InteractionStepRecord } from "../types";
+import { persistInteractionStepTree } from "./interaction-steps";
+
+const emptyStep = {
+  questionText: "",
+  answerOption: "",
+  scriptOptions: [""],
+  answerActions: "'",
+  interactionSteps: [],
+  isDeleted: false,
+  createdAt: "2021-01-27T00:00:00Z"
+};
 
 describe("persistInteractionStepTree", () => {
   let pool: Pool;
@@ -16,9 +33,85 @@ describe("persistInteractionStepTree", () => {
     if (pool) await pool.end();
   });
 
-  test("removes deleted interaction steps");
+  test("adds new interaction steps", async () => {
+    const { campaign } = await createCompleteCampaign(client, {});
+    const rootStep: InteractionStepWithChildren = {
+      ...emptyStep,
+      id: "new1",
+      parentInteractionId: null
+    };
 
-  test("adds new interaction steps");
+    await persistInteractionStepTree(campaign.id, rootStep, {
+      is_started: campaign.is_started
+    });
 
-  test("updates modified interaction steps");
+    const {
+      rows: [rootStepRecord]
+    } = await client.query<InteractionStepRecord>(
+      `select * from interaction_step where campaign_id = $1`,
+      [campaign.id]
+    );
+
+    expect(rootStepRecord).toHaveProperty("id");
+    expect(rootStepRecord.is_deleted).toBe(false);
+    expect(rootStepRecord.parent_interaction_id).toBeNull();
+  });
+
+  test("removes deleted interaction steps", async () => {
+    const { campaign } = await createCompleteCampaign(client, {});
+    const rootStep = await createInteractionStep(client, {
+      campaignId: campaign.id
+    });
+
+    const stepToDelete: InteractionStepWithChildren = {
+      ...emptyStep,
+      id: `${rootStep.id}`,
+      parentInteractionId: `${rootStep.parent_interaction_id}`,
+      isDeleted: true
+    };
+
+    await persistInteractionStepTree(campaign.id, stepToDelete, {
+      is_started: campaign.is_started
+    });
+
+    const {
+      rows: [deletedStep]
+    } = await client.query<InteractionStepRecord>(
+      `select * from interaction_step where id = $1`,
+      [rootStep.id]
+    );
+
+    expect(deletedStep).toHaveProperty("is_deleted");
+    expect(deletedStep.is_deleted).toBe(true);
+  });
+
+  test("updates modified interaction steps", async () => {
+    const { campaign } = await createCompleteCampaign(client, {});
+    const rootStep = await createInteractionStep(client, {
+      campaignId: campaign.id
+    });
+
+    const NEW_QUESTION = "Did it update?";
+
+    const stepToUpdate: InteractionStepWithChildren = {
+      ...emptyStep,
+      id: `${rootStep.id}`,
+      parentInteractionId: `${rootStep.parent_interaction_id}`,
+      questionText: NEW_QUESTION
+    };
+
+    await persistInteractionStepTree(campaign.id, stepToUpdate, {
+      is_started: campaign.is_started
+    });
+
+    const {
+      rows: [deletedStep]
+    } = await client.query<InteractionStepRecord>(
+      `select * from interaction_step where id = $1`,
+      [rootStep.id]
+    );
+
+    expect(deletedStep.question).toEqual(NEW_QUESTION);
+    expect(deletedStep.is_deleted).toBe(false);
+  });
 });

--- a/src/server/api/lib/interaction-steps.spec.ts
+++ b/src/server/api/lib/interaction-steps.spec.ts
@@ -1,0 +1,24 @@
+import { Pool, PoolClient } from "pg";
+
+import { config } from "../../../config";
+
+describe("persistInteractionStepTree", () => {
+  let pool: Pool;
+  let client: PoolClient;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: config.TEST_DATABASE_URL });
+    client = await pool.connect();
+  });
+
+  afterAll(async () => {
+    if (client) client.release();
+    if (pool) await pool.end();
+  });
+
+  test("removes deleted interaction steps");
+
+  test("adds new interaction steps");
+
+  test("updates modified interaction steps");
+});

--- a/src/server/api/lib/interaction-steps.ts
+++ b/src/server/api/lib/interaction-steps.ts
@@ -1,0 +1,93 @@
+/* eslint-disable import/prefer-default-export */
+import Knex from "knex";
+
+import { InteractionStepWithChildren } from "../../../api/interaction-step";
+import { cacheOpts, memoizer } from "../../memoredis";
+import { r } from "../../models";
+import { CampaignRecord } from "../types";
+
+export const persistInteractionStepTree = async (
+  campaignId: number,
+  rootInteractionStep: InteractionStepWithChildren,
+  origCampaignRecord: Pick<CampaignRecord, "is_started">,
+  knexTrx?: Knex,
+  temporaryIdMap: Record<string, string> = {}
+) => {
+  // Perform updates in a transaction if one is not present
+  if (!knexTrx) {
+    return r.knex.transaction(async (trx) => {
+      await persistInteractionStepTree(
+        campaignId,
+        rootInteractionStep,
+        origCampaignRecord,
+        trx,
+        temporaryIdMap
+      );
+    });
+  }
+
+  // Update the parent interaction step ID if this step has a reference to a temporary ID
+  // and the parent has since been inserted
+  const { parentInteractionId } = rootInteractionStep;
+  if (parentInteractionId && temporaryIdMap[parentInteractionId]) {
+    rootInteractionStep.parentInteractionId =
+      temporaryIdMap[parentInteractionId];
+  }
+
+  if (rootInteractionStep.id.indexOf("new") !== -1) {
+    // Insert new interaction steps
+    const [newId] = await knexTrx("interaction_step")
+      .insert({
+        parent_interaction_id: rootInteractionStep.parentInteractionId || null,
+        question: rootInteractionStep.questionText,
+        script_options: rootInteractionStep.scriptOptions,
+        answer_option: rootInteractionStep.answerOption,
+        answer_actions: rootInteractionStep.answerActions,
+        campaign_id: campaignId,
+        is_deleted: false
+      })
+      .returning("id");
+
+    if (rootInteractionStep.parentInteractionId) {
+      memoizer.invalidate(cacheOpts.InteractionStepChildren.key, {
+        interactionStepId: rootInteractionStep.parentInteractionId
+      });
+    }
+
+    // Update the mapping of temporary IDs
+    temporaryIdMap[rootInteractionStep.id] = newId;
+  } else if (!origCampaignRecord.is_started && rootInteractionStep.isDeleted) {
+    // Hard delete interaction steps if the campaign hasn't started
+    await knexTrx("interaction_step")
+      .where({ id: rootInteractionStep.id })
+      .delete();
+  } else {
+    // Update the interaction step record
+    await knexTrx("interaction_step")
+      .where({ id: rootInteractionStep.id })
+      .update({
+        question: rootInteractionStep.questionText,
+        script_options: rootInteractionStep.scriptOptions,
+        answer_option: rootInteractionStep.answerOption,
+        answer_actions: rootInteractionStep.answerActions,
+        is_deleted: rootInteractionStep.isDeleted
+      });
+
+    memoizer.invalidate(cacheOpts.InteractionStepSingleton.key, {
+      interactionStepId: rootInteractionStep.id
+    });
+  }
+
+  // Persist child interaction steps
+  await Promise.all(
+    rootInteractionStep.interactionSteps.map(async (childStep) => {
+      await persistInteractionStepTree(
+        campaignId,
+        childStep,
+        origCampaignRecord,
+        knexTrx,
+        temporaryIdMap
+      );
+    })
+  );
+};

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -76,6 +76,7 @@ import { resolvers as interactionStepResolvers } from "./interaction-step";
 import { resolvers as inviteResolvers } from "./invite";
 import { notifyAssignmentCreated, notifyOnTagConversation } from "./lib/alerts";
 import { processContactsFile } from "./lib/edit-campaign";
+import { persistInteractionStepTree } from "./lib/interaction-steps";
 import {
   getContactMessagingService,
   saveNewIncomingMessage
@@ -171,91 +172,6 @@ const replaceShortLinkDomains = async (organizationId, messageText) => {
   };
   const finalMessageText = domains.reduce(replacerReducer, messageText);
   return finalMessageText;
-};
-
-const persistInteractionStepTree = async (
-  campaignId,
-  rootInteractionStep,
-  origCampaignRecord,
-  knexTrx,
-  temporaryIdMap = {}
-) => {
-  // Perform updates in a transaction if one is not present
-  if (!knexTrx) {
-    return r.knex.transaction(async (trx) => {
-      await persistInteractionStepTree(
-        campaignId,
-        rootInteractionStep,
-        origCampaignRecord,
-        trx,
-        temporaryIdMap
-      );
-    });
-  }
-
-  // Update the parent interaction step ID if this step has a reference to a temporary ID
-  // and the parent has since been inserted
-  if (temporaryIdMap[rootInteractionStep.parentInteractionId]) {
-    rootInteractionStep.parentInteractionId =
-      temporaryIdMap[rootInteractionStep.parentInteractionId];
-  }
-
-  if (rootInteractionStep.id.indexOf("new") !== -1) {
-    // Insert new interaction steps
-    const [newId] = await knexTrx("interaction_step")
-      .insert({
-        parent_interaction_id: rootInteractionStep.parentInteractionId || null,
-        question: rootInteractionStep.questionText,
-        script_options: rootInteractionStep.scriptOptions,
-        answer_option: rootInteractionStep.answerOption,
-        answer_actions: rootInteractionStep.answerActions,
-        campaign_id: campaignId,
-        is_deleted: false
-      })
-      .returning("id");
-
-    if (rootInteractionStep.parentInteractionId) {
-      memoizer.invalidate(cacheOpts.InteractionStepChildren.key, {
-        interactionStepId: rootInteractionStep.parentInteractionId
-      });
-    }
-
-    // Update the mapping of temporary IDs
-    temporaryIdMap[rootInteractionStep.id] = newId;
-  } else if (!origCampaignRecord.is_started && rootInteractionStep.isDeleted) {
-    // Hard delete interaction steps if the campaign hasn't started
-    await knexTrx("interaction_step")
-      .where({ id: rootInteractionStep.id })
-      .delete();
-  } else {
-    // Update the interaction step record
-    await knexTrx("interaction_step")
-      .where({ id: rootInteractionStep.id })
-      .update({
-        question: rootInteractionStep.questionText,
-        script_options: rootInteractionStep.scriptOptions,
-        answer_option: rootInteractionStep.answerOption,
-        answer_actions: rootInteractionStep.answerActions,
-        is_deleted: rootInteractionStep.isDeleted
-      });
-
-    memoizer.invalidate(cacheOpts.InteractionStepSingleton.key, {
-      interactionStepId: rootInteractionStep.id
-    });
-  }
-
-  // Persist child interaction steps
-  await Promise.all(
-    rootInteractionStep.interactionSteps.map(async (childStep) => {
-      await persistInteractionStepTree(
-        campaignId,
-        childStep,
-        origCampaignRecord,
-        knexTrx,
-        temporaryIdMap
-      );
-    })
-  );
 };
 
 async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {

--- a/src/server/memoredis.ts
+++ b/src/server/memoredis.ts
@@ -20,7 +20,7 @@ const ONE_HOUR = ONE_MINUTE * 60;
 const ONE_DAY = ONE_HOUR * 24;
 const ONE_WEEK = ONE_DAY * 7;
 
-const cacheOpts = {
+const cacheOptsPlain: Record<string, [string, number]> = {
   GetUser: ["get-user", ONE_HOUR],
   GetUserOrganization: ["get-user-organization", ONE_HOUR],
   CampaignHasUnassignedContacts: [
@@ -61,11 +61,11 @@ const cacheOpts = {
   MyCurrentAssignmentTargets: ["my-current-assignment-targets", ONE_SECOND * 5]
 };
 
-Object.keys(cacheOpts).forEach((name) => {
-  cacheOpts[name] = {
-    key: cacheOpts[name][0],
-    ttl: cacheOpts[name][1]
-  };
-});
+const cacheOpts = Object.fromEntries(
+  Object.entries(cacheOptsPlain).map(([name, [key, ttl]]) => [
+    name,
+    { key, ttl }
+  ])
+);
 
 export { memoizer, cacheOpts };

--- a/yarn.lock
+++ b/yarn.lock
@@ -14344,10 +14344,10 @@ memoize-one@^5.0.0:
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
   integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
 
-memoredis@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/memoredis/-/memoredis-1.1.0.tgz#fd14b1632af8d135845d5e05ffd786463589f582"
-  integrity sha512-cg6JV/0rIAH/eJlxlmg2noHSsx7bM/qFC5xVANKxBaF5PW1gxdjR6YKJli17e2W2UNBVk90AH5taJ9us0HuBEw==
+memoredis@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/memoredis/-/memoredis-1.1.1.tgz#4cb6c1059f3532a61f2e430210494e20a9d1268d"
+  integrity sha512-7siPiPBjiBrmUo5q7FADfhH/ZIMcBPh3ugK3RJWQR8PSXx+8v5rGcAST5uENrCdjIfLDrOCmMjbFoQUZyWl5WA==
   dependencies:
     json-date-parser "^1.0.1"
     json-stable-stringify "^1.0.1"


### PR DESCRIPTION
## Description

This adds unit tests for persistInteractionStepTree

## Motivation and Context

Ruling out server-side problems with the current interaction step saving bug.

## How Has This Been Tested?

The relocation of `persistInteractionStepTree()` has been tested locally. `persistInteractionStepTree()` is now tested with unit tests.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
