### PR TITLE
fix: make makeTree() deterministic

### DIFF
--- a/src/api/interaction-step.ts
+++ b/src/api/interaction-step.ts
@@ -11,7 +11,7 @@ export interface InteractionStep {
   isDeleted: boolean;
   answerActions: string;
   questionResponse?: QuestionResponse;
-  createdAt: Date;
+  createdAt: string;
 }
 
 export interface InteractionStepWithChildren extends InteractionStep {

--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -283,7 +283,10 @@ export class AssignmentTexterContact extends React.Component {
   getStartingMessageText = () => {
     const { contact, campaign } = this.props;
     if (contact.messageStatus === "needsMessage") {
-      const { scriptOptions } = getTopMostParent(campaign.interactionSteps);
+      const { scriptOptions } = getTopMostParent(
+        campaign.interactionSteps,
+        false
+      );
       const randomScript = sample(scriptOptions);
       const scriptVersionHash = md5(randomScript);
       return [scriptVersionHash, this.getMessageTextFromScript(randomScript)];

--- a/src/lib/interaction-step-helpers.js
+++ b/src/lib/interaction-step-helpers.js
@@ -102,9 +102,11 @@ export function sortInteractionSteps(interactionSteps) {
   return orderedSteps;
 }
 
-export function getTopMostParent(interactionSteps, _isModel) {
-  return sortedSteps(interactionSteps).find(
-    (step) => step.parentInteractionId === null
+export function getTopMostParent(interactionSteps, isModel) {
+  return sortedSteps(interactionSteps).find((step) =>
+    isModel
+      ? step.parent_interaction_id === null
+      : step.parentInteractionId === null
   );
 }
 
@@ -116,7 +118,7 @@ export function makeTree(interactionSteps, id = null, indexed = null) {
       fromPairs
     )(interactionSteps);
 
-  const root = id ? indexedById[id] : getTopMostParent(interactionSteps);
+  const root = id ? indexedById[id] : getTopMostParent(interactionSteps, false);
 
   return {
     ...root,

--- a/src/lib/interaction-step-helpers.js
+++ b/src/lib/interaction-step-helpers.js
@@ -13,7 +13,7 @@ export const sortByCreatedAt = (is) => {
 };
 
 // Sort by newest first
-export const sortedSteps = flow(sortBy(sortByCreatedAt), reverse);
+export const sortByNewest = flow(sortBy(sortByCreatedAt), reverse);
 
 export function findParent(interactionStep, allInteractionSteps, isModel) {
   let parent = null;
@@ -103,7 +103,7 @@ export function sortInteractionSteps(interactionSteps) {
 }
 
 export function getTopMostParent(interactionSteps, isModel) {
-  return sortedSteps(interactionSteps).find((step) =>
+  return sortByNewest(interactionSteps).find((step) =>
     isModel
       ? step.parent_interaction_id === null
       : step.parentInteractionId === null
@@ -124,7 +124,7 @@ export function makeTree(interactionSteps, id = null, indexed = null) {
     ...root,
     interactionSteps: flow(
       filter((is) => is.parentInteractionId === root.id),
-      sortedSteps,
+      sortByNewest,
       map((c) => makeTree(interactionSteps, c.id, indexedById))
     )(interactionSteps)
   };

--- a/src/lib/interaction-step-helpers.spec.ts
+++ b/src/lib/interaction-step-helpers.spec.ts
@@ -153,4 +153,44 @@ describe("makeTree", () => {
       ]
     });
   });
+
+  test("handles building a tree when given multiple root interaction steps", () => {
+    const rootStepA: InteractionStep = {
+      ...baseEmptyStep,
+      id: "1",
+      parentInteractionId: null,
+      createdAt: "2021-01-26T00:00:01Z"
+    };
+    const childStepAA: InteractionStep = {
+      ...baseEmptyStep,
+      id: "2",
+      parentInteractionId: "1",
+      createdAt: "2021-01-26T00:00:02Z"
+    };
+    const rootStepB: InteractionStep = {
+      ...baseEmptyStep,
+      id: "3",
+      parentInteractionId: null,
+      createdAt: "2021-01-26T00:00:03Z"
+    };
+    const childStepBA: InteractionStep = {
+      ...baseEmptyStep,
+      id: "4",
+      parentInteractionId: "3",
+      createdAt: "2021-01-26T00:00:04Z"
+    };
+
+    const steps: InteractionStep[] = [
+      rootStepA,
+      childStepAA,
+      rootStepB,
+      childStepBA
+    ];
+    const tree = makeTree(steps);
+
+    expect(tree).toEqual({
+      ...rootStepB,
+      interactionSteps: [{ ...childStepBA, interactionSteps: [] }]
+    });
+  });
 });

--- a/src/lib/interaction-step-helpers.spec.ts
+++ b/src/lib/interaction-step-helpers.spec.ts
@@ -1,0 +1,156 @@
+import { InteractionStep } from "../api/interaction-step";
+import { makeTree } from "./interaction-step-helpers";
+
+const baseEmptyStep = {
+  questionText: "",
+  answerActions: "",
+  scriptOptions: [""],
+  isDeleted: false,
+  answerOption: "",
+  createdAt: "2021-01-26T00:00:00Z"
+};
+
+describe("makeTree", () => {
+  test("handles empty interaction steps argument", () => {
+    const steps: InteractionStep[] = [];
+    const tree = makeTree(steps);
+    expect(tree).toEqual({ interactionSteps: [] });
+  });
+
+  test("handles building a basic tree", () => {
+    const rootStep: InteractionStep = {
+      ...baseEmptyStep,
+      id: "1",
+      parentInteractionId: null,
+      createdAt: "2021-01-26T00:00:01Z"
+    };
+    const childStepA: InteractionStep = {
+      ...baseEmptyStep,
+      id: "2",
+      parentInteractionId: "1",
+      createdAt: "2021-01-26T00:00:02Z"
+    };
+    const childStepB: InteractionStep = {
+      ...baseEmptyStep,
+      id: "3",
+      parentInteractionId: "1",
+      createdAt: "2021-01-26T00:00:03Z"
+    };
+    const childStepAA: InteractionStep = {
+      ...baseEmptyStep,
+      id: "4",
+      parentInteractionId: "2",
+      createdAt: "2021-01-26T00:00:04Z"
+    };
+    const steps: InteractionStep[] = [
+      rootStep,
+      childStepA,
+      childStepB,
+      childStepAA
+    ];
+
+    const tree = makeTree(steps);
+
+    expect(tree).toEqual({
+      ...rootStep,
+      interactionSteps: [
+        { ...childStepB, interactionSteps: [] },
+        {
+          ...childStepA,
+          interactionSteps: [{ ...childStepAA, interactionSteps: [] }]
+        }
+      ]
+    });
+  });
+
+  test("handles building a tree with deleted steps", () => {
+    const rootStep: InteractionStep = {
+      ...baseEmptyStep,
+      id: "1",
+      parentInteractionId: null,
+      createdAt: "2021-01-26T00:00:01Z"
+    };
+    const childStepA: InteractionStep = {
+      ...baseEmptyStep,
+      id: "2",
+      parentInteractionId: "1",
+      createdAt: "2021-01-26T00:00:02Z"
+    };
+    const childStepB: InteractionStep = {
+      ...baseEmptyStep,
+      id: "3",
+      parentInteractionId: "1",
+      isDeleted: true,
+      createdAt: "2021-01-26T00:00:03Z"
+    };
+    const childStepAA: InteractionStep = {
+      ...baseEmptyStep,
+      id: "4",
+      parentInteractionId: "2",
+      createdAt: "2021-01-26T00:00:04Z"
+    };
+    const steps: InteractionStep[] = [
+      rootStep,
+      childStepA,
+      childStepB,
+      childStepAA
+    ];
+
+    const tree = makeTree(steps);
+
+    expect(tree).toEqual({
+      ...rootStep,
+      interactionSteps: [
+        { ...childStepB, interactionSteps: [] },
+        {
+          ...childStepA,
+          interactionSteps: [{ ...childStepAA, interactionSteps: [] }]
+        }
+      ]
+    });
+  });
+
+  test("handles building a tree when input array is unsorted", () => {
+    const rootStep: InteractionStep = {
+      ...baseEmptyStep,
+      id: "1",
+      parentInteractionId: null,
+      createdAt: "2021-01-26T00:00:01Z"
+    };
+    const childStepA: InteractionStep = {
+      ...baseEmptyStep,
+      id: "2",
+      parentInteractionId: "1",
+      createdAt: "2021-01-26T00:00:02Z"
+    };
+    const childStepB: InteractionStep = {
+      ...baseEmptyStep,
+      id: "3",
+      parentInteractionId: "1",
+      createdAt: "2021-01-26T00:00:03Z"
+    };
+    const childStepC: InteractionStep = {
+      ...baseEmptyStep,
+      id: "4",
+      parentInteractionId: "1",
+      createdAt: "2021-01-26T00:00:04Z"
+    };
+    const steps: InteractionStep[] = [
+      rootStep,
+      childStepA,
+      childStepC,
+      childStepB
+    ];
+
+    const tree = makeTree(steps);
+
+    expect(tree).toEqual({
+      ...rootStep,
+      interactionSteps: [
+        { ...childStepC, interactionSteps: [] },
+        { ...childStepB, interactionSteps: [] },
+        { ...childStepA, interactionSteps: [] }
+      ]
+    });
+  });
+});

--- a/src/server/routes/campaign-preview.js
+++ b/src/server/routes/campaign-preview.js
@@ -2,6 +2,7 @@ import express from "express";
 import h from "h";
 import { sortBy } from "lodash";
 
+import { getTopMostParent } from "../../lib/interaction-step-helpers";
 import { symmetricDecrypt } from "../api/lib/crypto";
 import { r } from "../models";
 
@@ -93,9 +94,7 @@ const makeCampaignPreviewHtml = async (campaignId) => {
     .reader("canned_response")
     .where({ campaign_id: campaignId });
 
-  const rootInteractionStep = interactionSteps.find(
-    (is) => !is.parent_interaction_id
-  );
+  const rootInteractionStep = getTopMostParent(interactionSteps, true);
 
   const toc = getInteractionStepsWithParentId(
     rootInteractionStep.id,


### PR DESCRIPTION
## Description

This makes it so that `makeTree()` returns a deterministic tree in the face of multiple root interaction steps based on the most recent root interaction step.

## Motivation and Context

Non-deterministic Postgres result ordering is part the interaction step saving bug. Different loads of a page may show different trees when multiple root interaction steps exist.

## How Has This Been Tested?

This has been tested locally and unit tests have been added.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
