### PR TITLE
chore: remove unused sortInteractionSteps function

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -22,7 +22,6 @@ export {
   findParent,
   getInteractionPath,
   getInteractionTree,
-  sortInteractionSteps,
   interactionStepForId,
   getTopMostParent,
   getChildren,

--- a/src/lib/interaction-step-helpers.js
+++ b/src/lib/interaction-step-helpers.js
@@ -81,19 +81,6 @@ export function getInteractionTree(allInteractionSteps, isModel) {
   return pathLengthHash;
 }
 
-export function sortInteractionSteps(interactionSteps) {
-  const pathTree = getInteractionTree(interactionSteps);
-  const orderedSteps = [];
-  Object.keys(pathTree).forEach((key) => {
-    const orderedBranch = pathTree[key].sort(
-      (a, b) =>
-        JSON.stringify(a.interactionStep) < JSON.stringify(b.interactionStep)
-    );
-    orderedBranch.forEach((ele) => orderedSteps.push(ele.interactionStep));
-  });
-  return orderedSteps;
-}
-
 export function getTopMostParent(interactionSteps, _isModel) {
   return interactionSteps.find((step) => step.parentInteractionId === null);
 }


### PR DESCRIPTION
## Description

This removes dead code.

## Motivation and Context

Removing dead code, especially utility functions with similar function other util functions, makes it easier to grok what's going on and removes the possibility of using the wrong/untested utility function elsewhere in the codebase.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
