### PR TITLE
fix(interaction-steps): fix edit script

### DIFF
--- a/src/components/forms/GSScriptOptionsField.jsx
+++ b/src/components/forms/GSScriptOptionsField.jsx
@@ -41,7 +41,7 @@ class GSScriptOptionsField extends GSFormField {
   };
 
   createDeleteHandler = (scriptVersion) => () => {
-    const { value: scriptVersions } = this.props;
+    const scriptVersions = [...this.props.value];
     const targetIndex = scriptVersions.indexOf(scriptVersion);
     scriptVersions.splice(targetIndex, 1);
     this.props.onChange(scriptVersions);
@@ -55,7 +55,7 @@ class GSScriptOptionsField extends GSFormField {
 
   // save script if no link warning is needed
   handleSaveScript = () => {
-    const { value: scriptVersions } = this.props;
+    const scriptVersions = [...this.props.value];
     const { scriptTarget, scriptDraft } = this.state;
     const targetIndex = scriptVersions.indexOf(scriptTarget);
     scriptVersions[targetIndex] = scriptDraft.trim();
@@ -65,7 +65,7 @@ class GSScriptOptionsField extends GSFormField {
   };
 
   handleAddScriptVersion = () => {
-    const { value: scriptVersions } = this.props;
+    const scriptVersions = [...this.props.value];
     scriptVersions.push("");
     this.props.onChange(scriptVersions);
   };

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
@@ -420,7 +420,12 @@ const mutations: MutationMap<FullComponentProps> = {
         variables
       });
       const data = produce(old, (draft: any) => {
-        draft.campaign.interactionSteps = editCampaign.interactionSteps;
+        draft.campaign.interactionSteps = editCampaign.interactionSteps.map(
+          (step: InteractionStepWithLocalState) => ({
+            ...step,
+            isModified: false
+          })
+        );
       });
       store.writeQuery({ query: GET_CAMPAIGN_INTERACTIONS, variables, data });
     }


### PR DESCRIPTION
## Description

Fix error thrown while saving interaction steps.

## Motivation and Context

`<GSScriptOptionsField>` was  mutating props causing this error under some conditions, namely read-only values being passed as props:

```
Uncaught TypeError: Cannot assign to read only property '0' of object '[object Array]'
    at GSScriptOptionsField.handleSaveScript (GSScriptOptionsField.jsx:61)
```

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
