### PR TITLE
fix(interaction-steps): handle case of empty campaign

### DIFF
--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
@@ -34,6 +34,8 @@ import {
   UpdateInteractionStepPayload
 } from "./resolvers";
 
+const DEFAULT_EMPTY_STEP_ID = "DEFAULT_EMPTY_STEP_ID";
+
 interface Values {
   interactionSteps: InteractionStepWithChildren;
 }
@@ -203,6 +205,12 @@ class CampaignInteractionStepsForm extends React.Component<InnerProps, State> {
     this.props.mutations.stageDeleteInteractionStep(id);
 
   handleFormChange = (changedStep: InteractionStepWithChildren) => {
+    if (changedStep.id === DEFAULT_EMPTY_STEP_ID) {
+      return this.props.mutations.stageAddInteractionStep({
+        ...changedStep,
+        id: generateId()
+      });
+    }
     const { answerOption, questionText, scriptOptions } = changedStep;
     this.props.mutations.stageUpdateInteractionStep(changedStep.id, {
       answerOption,
@@ -287,7 +295,7 @@ class CampaignInteractionStepsForm extends React.Component<InnerProps, State> {
       interactionSteps: []
     })
       ? {
-          id: "newId",
+          id: DEFAULT_EMPTY_STEP_ID,
           parentInteractionId: null,
           questionText: "",
           answerOption: "",


### PR DESCRIPTION
## Description

Add a new step when editing the default empty step in a brand new campaign.

## Motivation and Context

Previously, editing the default empty step of a new campaign would try to update an existing step. Because it was the default empty step being edited, this update would fail silently. This is addressed by adding an interaction step if none exists.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
