### PR TITLE
fix: use structured logging for worker migrations

### DIFF
--- a/dev-tools/migrate-worker.js
+++ b/dev-tools/migrate-worker.js
@@ -1,5 +1,6 @@
 import { Pool } from "pg";
 import { runMigrations } from "pg-compose";
+import { Logger } from "graphile-worker";
 
 import { config } from "../src/config";
 import logger from "../src/logger";
@@ -13,9 +14,13 @@ const main = async () => {
   );
   const pool = new Pool({ connectionString });
 
+  const logFactory = (scope) => (level, message, meta) =>
+    logger.log({ level, message, ...meta, ...scope });
+  const graphileLogger = new Logger(logFactory);
+
   await runMigrations({
     pgPool: pool,
-    logger
+    logger: graphileLogger
   });
 
   await pool.end();

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "passport-local": "^1.0.0",
     "passport-local-authenticate": "^1.2.0",
     "pg": "^6.4.2",
-    "pg-compose": "^0.0.23",
+    "pg-compose": "^0.0.25",
     "pgc-ngp-van": "^0.0.12",
     "promise-retry": "^2.0.1",
     "prop-types": "^15.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15959,10 +15959,10 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-pg-compose@^0.0.23:
-  version "0.0.23"
-  resolved "https://registry.yarnpkg.com/pg-compose/-/pg-compose-0.0.23.tgz#8df34db24b229f35aa3dfdba75bf8488d2ecace9"
-  integrity sha512-H1bNwl2PoeLppxn9GpoO/rUvPNQhbiwIZX1WZNfQIIjAho/NQ85q+ibeh0gjIn2M0XquMoynHz0Jdi5RAE0dTQ==
+pg-compose@^0.0.25:
+  version "0.0.25"
+  resolved "https://registry.yarnpkg.com/pg-compose/-/pg-compose-0.0.25.tgz#c69db78cb5d1397b30a89a8202de93e417d9690e"
+  integrity sha512-WqwzU1CQ3MNeYAMwF6fcNP/D1TNkSdwfBh9ZcA1IypFu4OR0cdjOHJ/UHP50KfRlA5qxS/MdWv5eqNCcOZQmJw==
   dependencies:
     "@types/cryptr" "^4.0.1"
     chokidar "^3.3.1"


### PR DESCRIPTION
## Description

This updates pg-compose to 0.0.25 which uses the logger provided to pg-compose for migration errors rather than always using `console.error`. It also ensures that the correct logger type is passed to `runMigrations`.

## Motivation and Context

See politics-rewired/pg-compose#6

## How Has This Been Tested?

This has been tested locally to ensure that structured logging is used for a worker migration SQL error.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
