### PR TITLE
fix(worker): fix lock on semaphore and add early return

### DIFF
--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -4,6 +4,7 @@ import { loadYaml, PgComposeWorker, run } from "pg-compose";
 import url from "url";
 
 import { config } from "../config";
+import { sleep } from "../lib";
 import logger from "../logger";
 import {
   exportCampaign,
@@ -148,9 +149,7 @@ export const getWorker = async (attempt = 0): Promise<PgComposeWorker> => {
 
   // Someone beat us to the punch of initializing the runner
   if (attempt >= 20) throw new Error("getWorker() took too long to resolve");
-  await new Promise<void>((resolve, _reject) =>
-    setTimeout(() => resolve(), 100)
-  );
+  await sleep(100);
   return getWorker(attempt + 1);
 };
 


### PR DESCRIPTION
## Description

The semaphore is now checked before acquiring. An early return is also added for better performance (no yaml parsing) on subsequent worker fetches.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previously, the worker could be instantiated twice if two `getWorker()` calls both grabbed the semaphore before the other's `await run()` finished.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
