### PR TITLE
fix: fix role resolver

### DIFF
--- a/src/server/api/organization-membership.ts
+++ b/src/server/api/organization-membership.ts
@@ -6,6 +6,7 @@ interface IOrganizationMembership {
   user_id: number;
   organization_id: number;
   request_status: string;
+  role: string;
   user?: Record<string, unknown>;
   organization?: Record<string, unknown>;
 }
@@ -31,12 +32,8 @@ export const resolvers = {
         .reader("user")
         .where({ id: membership.user_id })
         .first("is_superadmin");
-      const { role } = await r
-        .reader("user_organization")
-        .where({ user_id: membership.user_id })
-        .first("role");
 
-      return is_superadmin ? UserRoleType.SUPERADMIN : role;
+      return is_superadmin ? UserRoleType.SUPERADMIN : membership.role;
     }
   }
 };


### PR DESCRIPTION
## Description

Use the membership record's `role`.

## Motivation and Context

The previously used query to get `role` wasn't scoped to the organization resulting in the wrong role being returned. We already have the organization-scoped `role`, however, as part of the `membership` -- the only reason we need a custom resolver for `role` is to check superadmin status.

## How Has This Been Tested?

This has been tested locally running against a production DB.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
