### PR TITLE
fix: update refs usage

### DIFF
--- a/src/components/ScriptEditor.jsx
+++ b/src/components/ScriptEditor.jsx
@@ -154,7 +154,11 @@ class ScriptEditor extends React.Component {
     ]);
   };
 
-  focus = () => this.refs.editor.focus();
+  focus = () => {
+    if (this.editorRef) {
+      this.editorRef.focus();
+    }
+  };
 
   addCustomField = (field) => {
     const textToInsert = delimit(field);
@@ -203,7 +207,9 @@ class ScriptEditor extends React.Component {
             name={name}
             editorState={this.state.editorState}
             onChange={this.onEditorChange}
-            ref="editor"
+            ref={(el) => {
+              this.editorRef = el;
+            }}
             spellCheck
           />
         </div>

--- a/src/components/forms/GSForm.jsx
+++ b/src/components/forms/GSForm.jsx
@@ -53,7 +53,13 @@ export default class GSForm extends React.Component {
   }
 
   submit = () => {
-    this.refs.form.submit();
+    if (this.formRef) {
+      this.formRef.submit();
+    }
+  };
+
+  handleFormRefChange = (ref) => {
+    this.formRef = ref;
   };
 
   handleSubmitForm = async (formValues) => {
@@ -145,7 +151,7 @@ export default class GSForm extends React.Component {
       this.props.value || this.state.model || this.props.defaultValue;
     return (
       <Form
-        ref="form"
+        ref={this.handleFormRefChange}
         value={value}
         {...this.props}
         onChange={this.handleOnFormChange}

--- a/src/components/forms/GSScriptField.jsx
+++ b/src/components/forms/GSScriptField.jsx
@@ -36,7 +36,9 @@ class GSScriptField extends GSFormField {
       {
         open: true
       },
-      () => this.refs.dialogScriptInput.focus()
+      () => {
+        if (this.scriptInputRef) this.scriptInputRef.focus();
+      }
     );
   };
 
@@ -106,7 +108,9 @@ class GSScriptField extends GSFormField {
         onRequestClose={this.handleCancelDialog}
       >
         <ScriptEditor
-          ref="dialogScriptInput"
+          ref={(el) => {
+            this.scriptInputRef = el;
+          }}
           name={name}
           scriptText={this.state.script}
           scriptFields={scriptFields}

--- a/src/components/forms/GSScriptOptionsField.jsx
+++ b/src/components/forms/GSScriptOptionsField.jsx
@@ -36,7 +36,9 @@ class GSScriptOptionsField extends GSFormField {
 
     this.setState(
       { scriptTarget: scriptVersion, scriptDraft: scriptVersion },
-      () => this.refs.dialogScriptInput.focus()
+      () => {
+        if (this.inputRef) this.inputRef.focus();
+      }
     );
   };
 
@@ -134,7 +136,9 @@ class GSScriptOptionsField extends GSFormField {
         onRequestClose={this.handleCancelDialog}
       >
         <ScriptEditor
-          ref="dialogScriptInput"
+          ref={(ref) => {
+            this.inputRef = ref;
+          }}
           name={name}
           scriptText={scriptDraft}
           scriptFields={scriptFields}

--- a/src/components/forms/GSTextField.jsx
+++ b/src/components/forms/GSTextField.jsx
@@ -5,12 +5,16 @@ import React from "react";
 import GSFormField from "./GSFormField";
 
 export default class GSTextField extends GSFormField {
+  handleNewRef = (el) => {
+    this.textFieldRef = el;
+  };
+
   render() {
     const { value } = this.props;
     const safeProps = omit(this.props, "errors");
     return (
       <TextField
-        ref="textField"
+        ref={this.handleNewRef}
         floatingLabelText={this.floatingLabelText()}
         floatingLabelStyle={{
           zIndex: 0

--- a/src/containers/AdminCampaignList.jsx
+++ b/src/containers/AdminCampaignList.jsx
@@ -89,10 +89,10 @@ class AdminCampaignList extends React.Component {
   };
 
   releaseAllReplies = () => {
-    const ageInHours = this.refs.numberOfHoursToRelease.input.value;
-    const releaseOnRestricted = this.refs.releaseOnRestricted.state.switched;
-    const limitToCurrentlyTextableContacts = this.refs
-      .limitToCurrentlyTextableContacts.state.switched;
+    const ageInHours = this.numberOfHoursToReleaseRef.input.value;
+    const releaseOnRestricted = this.releaseOnRestrictedRef.state.switched;
+    const limitToCurrentlyTextableContacts = this
+      .limitToCurrentlyTextableContactsRef.state.switched;
 
     this.setState({ releasingInProgress: true });
 
@@ -204,7 +204,9 @@ class AdminCampaignList extends React.Component {
                 <TextField
                   type="number"
                   floatingLabelText="Number of Hours"
-                  ref="numberOfHoursToRelease"
+                  ref={(el) => {
+                    this.numberOfHoursToReleaseRef = el;
+                  }}
                   defaultValue={1}
                 />
                 <br />
@@ -212,14 +214,24 @@ class AdminCampaignList extends React.Component {
                 Should we release replies on campaigns that are restricted to
                 teams? If unchecked, replies on campaigns restricted to team
                 members will stay assigned to their current texter.
-                <Toggle ref="releaseOnRestricted" defaultToggled={false} />
+                <Toggle
+                  ref={(el) => {
+                    this.releaseOnRestrictedRef = el;
+                  }}
+                  defaultToggled={false}
+                />
                 <br />
                 <br />
                 Release contacts only if it is within texting hours in the
                 contact's timezone? If unchecked, replies will be released for
                 contacts that may not be textable until later today or until
                 tomorrow.
-                <Toggle ref="limitToCurrentlyTextableContacts" defaultToggled />
+                <Toggle
+                  ref={(el) => {
+                    this.limitToCurrentlyTextableContactsRef = el;
+                  }}
+                  defaultToggled
+                />
               </div>
             ) : (
               <div />

--- a/src/containers/AssignmentTexterContact/ContactActionDialog.jsx
+++ b/src/containers/AssignmentTexterContact/ContactActionDialog.jsx
@@ -10,6 +10,8 @@ import * as yup from "yup";
 import GSForm from "../../components/forms/GSForm";
 import GSSubmitButton from "../../components/forms/GSSubmitButton";
 
+const FIELD_NAME = "messageText";
+
 const styles = StyleSheet.create({
   contactActionCard: {
     "@media(max-width: 320px)": {
@@ -43,8 +45,11 @@ class ContactActionDialog extends Component {
 
   getContactActionTextFieldRef = () => {
     // Intercept enter key at the deepest underlying DOM <textarea> leaf
-    return this.refs.contactActionText.refs.input.refs.textField.input.refs
-      .input;
+    if (this.contactActionTextRef) {
+      return this.contactActionTextRef.querySelectorAll(
+        `textarea[name="${FIELD_NAME}"]`
+      )[0];
+    }
   };
 
   // Allow <shift> + <enter> to add newlines rather than submitting
@@ -77,13 +82,13 @@ class ContactActionDialog extends Component {
             value={{ messageText }}
             onSubmit={onSubmit}
           >
-            <Form.Field
-              ref="contactActionText"
-              name="messageText"
-              fullWidth
-              autoFocus
-              multiLine
-            />
+            <div
+              ref={(el) => {
+                this.contactActionTextRef = el;
+              }}
+            >
+              <Form.Field name={FIELD_NAME} fullWidth autoFocus multiLine />
+            </div>
             <div className={css(styles.dialogActions)}>
               <FlatButton
                 style={inlineStyles.dialogButton}

--- a/src/containers/AssignmentTexterContact/MessageTextField.jsx
+++ b/src/containers/AssignmentTexterContact/MessageTextField.jsx
@@ -2,6 +2,8 @@ import { css, StyleSheet } from "aphrodite";
 import React, { Component } from "react";
 import Form from "react-formal";
 
+const FIELD_NAME = "messageText";
+
 const styles = StyleSheet.create({
   textField: {
     "@media(max-width: 350px)": {
@@ -23,7 +25,11 @@ class MessageTextField extends Component {
 
   getMessageFieldRef = () => {
     // Intercept enter key at the deepest underlying DOM <textarea> leaf
-    return this.refs.messageText.refs.input.refs.textField.input.refs.input;
+    if (this.messageTextRef !== undefined) {
+      return this.messageTextRef.querySelectorAll(
+        `textarea[name="${FIELD_NAME}"]`
+      )[0];
+    }
   };
 
   // Allow <shift> + <enter> to add newlines rather than submitting
@@ -37,16 +43,21 @@ class MessageTextField extends Component {
 
   render() {
     return (
-      <Form.Field
-        ref="messageText"
-        className={css(styles.textField)}
-        name="messageText"
-        label="Your message"
-        multiLine
-        fullWidth
-        rowsMax={6}
-        {...this.props}
-      />
+      <div
+        ref={(el) => {
+          this.messageTextRef = el;
+        }}
+      >
+        <Form.Field
+          className={css(styles.textField)}
+          name={FIELD_NAME}
+          label="Your message"
+          multiLine
+          fullWidth
+          rowsMax={6}
+          {...this.props}
+        />
+      </div>
     );
   }
 }

--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -191,7 +191,7 @@ export class AssignmentTexterContact extends React.Component {
       }, 1500);
     }
 
-    const scroller = this.refs.messageScrollContainer;
+    const scroller = this.messageScrollContainerRef;
     if (scroller) {
       scroller.scrollTo(0, scroller.scrollHeight);
     }
@@ -533,7 +533,7 @@ export class AssignmentTexterContact extends React.Component {
   };
 
   handleClickSendMessageButton = () => {
-    this.refs.form.submit();
+    this.formRef.submit();
     if (this.props.contact.messageStatus === "needsMessage") {
       this.setState({ justSentNew: true });
     }
@@ -793,7 +793,9 @@ export class AssignmentTexterContact extends React.Component {
           <div>
             <div className={css(styles.messageField)}>
               <GSForm
-                ref="form"
+                ref={(el) => {
+                  this.formRef = el;
+                }}
                 schema={this.messageSchema}
                 value={{ messageText }}
                 onSubmit={
@@ -861,7 +863,9 @@ export class AssignmentTexterContact extends React.Component {
           <div className={css(styles.dynamicFlexSection)}>
             {contact.messages.length > 0 ? (
               <div
-                ref="messageScrollContainer"
+                ref={(el) => {
+                  this.messageScrollContainerRef = el;
+                }}
                 className={css(styles.verticalScrollingSection)}
                 {...dataTest("messageList")}
               >


### PR DESCRIPTION
## Description

Replace string refs with callback refs.

## Motivation and Context

[String refs are deprecated](https://reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs).

## How Has This Been Tested?

This has been tested locally. Specifically:

- releaseAllReplies modal
- message textfield

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
