### PR TITLE
fix: pass props directly when HOC contexts are not available

### DIFF
--- a/src/components/CannedResponseMenu.jsx
+++ b/src/components/CannedResponseMenu.jsx
@@ -2,6 +2,7 @@ import { List } from "material-ui/List";
 import Popover from "material-ui/Popover";
 import type from "prop-types";
 import React from "react";
+import { withApollo } from "react-apollo";
 
 import ScriptList from "./ScriptList";
 
@@ -20,10 +21,11 @@ class CannedResponseMenu extends React.Component {
   };
 
   renderCannedResponses({ scripts, subheader, showAddScriptButton }) {
-    const { customFields, campaignId, texterId } = this.props;
+    const { customFields, campaignId, texterId, client } = this.props;
 
     return (
       <ScriptList
+        client={client}
         texterId={texterId}
         campaignId={campaignId}
         scripts={scripts}
@@ -72,6 +74,7 @@ class CannedResponseMenu extends React.Component {
 }
 
 CannedResponseMenu.propTypes = {
+  client: type.object.isRequired,
   scripts: type.array,
   onSelectCannedResponse: type.func,
   onRequestClose: type.func,
@@ -84,4 +87,4 @@ CannedResponseMenu.propTypes = {
   campaignCannedResponses: type.array
 };
 
-export default CannedResponseMenu;
+export default withApollo(CannedResponseMenu);

--- a/src/containers/UserMenu/components/OrganizationItem.tsx
+++ b/src/containers/UserMenu/components/OrganizationItem.tsx
@@ -1,0 +1,83 @@
+import ApolloClient from "apollo-client";
+import gql from "graphql-tag";
+import MenuItem from "material-ui/MenuItem";
+import React from "react";
+import { RouterProps } from "react-router-dom";
+
+import { Organization } from "../../../api/organization";
+import { UserRoleType } from "../../../api/organization-membership";
+import { User } from "../../../api/user";
+import { hasRole } from "../../../lib/permissions";
+
+// Accept history as passed prop because we cannot use withRouter within UserMenu's Popover
+// (Popover content exists outside of <BrowserRouter> context)
+interface Props extends Pick<RouterProps, "history"> {
+  organization: Pick<Organization, "id" | "name">;
+  client: ApolloClient<unknown>;
+}
+
+interface State {
+  loading: boolean;
+  roles?: UserRoleType[];
+}
+
+class OrganizationItemInner extends React.Component<Props, State> {
+  state: State = {
+    loading: true,
+    roles: undefined
+  };
+
+  componentDidMount() {
+    // Perform this query manually because we cannot use withOperations within
+    // UserMenu's Popover (Popover exists outside of <ApolloProvider> context)
+    this.props.client
+      .query<{
+        currentUser: Pick<User, "id" | "roles">;
+      }>({
+        query: gql`
+          query getCurrentUserRoles($organizationId: String!) {
+            currentUser {
+              id
+              roles(organizationId: $organizationId)
+            }
+          }
+        `,
+        variables: {
+          organizationId: this.props.organization.id
+        }
+      })
+      .then((res) => {
+        const { roles } = res.data.currentUser;
+        const newState: State = { loading: false, roles };
+        this.setState(newState);
+      });
+  }
+
+  render() {
+    const { organization, history } = this.props;
+    const { loading, roles } = this.state;
+    const path =
+      !loading &&
+      roles !== undefined &&
+      hasRole(UserRoleType.SUPERVOLUNTEER, roles)
+        ? `/admin/${organization.id}`
+        : `/app/${organization.id}`;
+
+    // Use `any` because of mismatch between @types/react versions
+    const handleClick = (event: any) => {
+      event.preventDefault();
+      history.push(path);
+    };
+
+    return (
+      <MenuItem
+        primaryText={organization.name}
+        value={path}
+        disabled={loading}
+        onClick={handleClick}
+      />
+    );
+  }
+}
+
+export default OrganizationItemInner;


### PR DESCRIPTION
## Description

Pass Apollo `client` and React Router `history` to components that exist outside of the React DOM tree.

## Motivation and Context

Material UI v0's `<Popover>` component renders its children outside of the application's React DOM tree. This means the `<Popover>` children are not children of a context providers (e.g. `<ApolloProvider>`, `<BrowserRouter>`), a breaking issue in future versions of React.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
