### PR TITLE
chore: remove shutdown delays outside of production mode

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -24,7 +24,7 @@ process.on("unhandledRejection", (err) => {
 
 const lightship = createLightship({
   detectKubernetes: true,
-  shutdownDelay: config.SHUTDOWN_GRACE_PERIOD,
+  shutdownDelay: config.isProduction ? config.SHUTDOWN_GRACE_PERIOD : 0,
   port: 9000,
   signals: ["SIGTERM", "SIGINT"],
   terminate: () => {
@@ -43,7 +43,7 @@ if (config.MODE === ServerMode.Server || config.MODE === ServerMode.Dual) {
         resolve(undefined);
       });
       lightship.registerShutdownHandler(async () => {
-        const spokeGracePeriodMs = 30 * 1000;
+        const spokeGracePeriodMs = config.isProduction ? 30 * 1000 : 0;
         logger.info(
           `Received kill signal, waiting ${spokeGracePeriodMs}ms before shutting down Spoke app...`
         );


### PR DESCRIPTION
## Description

Remove graceful shutdown delays if we're not running in production.

## Motivation and Context

Foreman has trouble with this and we sometimes get dirty restarts where the old http server is still running on port 8090 and the new process fails to start.

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
