### PR TITLE
feat: add additional styling

### DIFF
--- a/src/containers/AdminCampaignEdit/components/SectionWrapper.tsx
+++ b/src/containers/AdminCampaignEdit/components/SectionWrapper.tsx
@@ -4,6 +4,7 @@ import Avatar from "material-ui/Avatar";
 import { Card, CardActions, CardHeader, CardText } from "material-ui/Card";
 import CircularProgress from "material-ui/CircularProgress";
 import RaisedButton from "material-ui/RaisedButton";
+import muiThemeable from "material-ui/styles/muiThemeable";
 import DoneIcon from "material-ui/svg-icons/action/done";
 import WarningIcon from "material-ui/svg-icons/alert/warning";
 import CancelIcon from "material-ui/svg-icons/navigation/cancel";
@@ -13,6 +14,7 @@ import { compose, withProps } from "recompose";
 import { withAuthzContext } from "../../../components/AuthzProvider";
 import { camelCase, dataTest } from "../../../lib/attributes";
 import theme from "../../../styles/theme";
+import { MuiThemeProviderProps } from "../../../styles/types";
 import { loadData } from "../../hoc/with-operations";
 import { CampaignReadinessType } from "../types";
 
@@ -27,7 +29,7 @@ interface DeleteJobType {
   (jobId: string): ApolloQueryResult<{ id: string }>;
 }
 
-interface WrapperProps {
+interface WrapperProps extends MuiThemeProviderProps {
   // Required Props
   campaignId: string;
   active: boolean;
@@ -78,7 +80,7 @@ const unpackJob = (job?: PendingJobType) => ({
   isSaving: job !== undefined && !job.resultMessage
 });
 
-const SectionWrapper: React.SFC<WrapperProps> = (props) => {
+const SectionWrapper: React.FC<WrapperProps> = (props) => {
   const {
     // Required props
     active,
@@ -91,6 +93,9 @@ const SectionWrapper: React.SFC<WrapperProps> = (props) => {
 
     // Authz HOC
     adminPerms,
+
+    // MUI Theme HOC
+    muiTheme,
 
     // withProps HOC
     isExpandable,
@@ -127,7 +132,8 @@ const SectionWrapper: React.SFC<WrapperProps> = (props) => {
         size={25}
       />
     );
-    cardHeaderStyle.backgroundColor = theme.colors.green;
+    cardHeaderStyle.backgroundColor =
+      muiTheme?.palette?.primary1Color ?? theme.colors.green;
   } else if (!sectionIsDone) {
     avatar = (
       <Avatar
@@ -136,7 +142,8 @@ const SectionWrapper: React.SFC<WrapperProps> = (props) => {
         size={25}
       />
     );
-    cardHeaderStyle.backgroundColor = theme.colors.yellow;
+    cardHeaderStyle.backgroundColor =
+      muiTheme?.palette?.primary2Color ?? theme.colors.yellow;
   }
 
   const handleDiscardJob = async () => {
@@ -308,6 +315,7 @@ interface AuthzProviderProps {
 
 interface WrappedComponentProps
   extends RequiredComponentProps,
+    MuiThemeProviderProps,
     AuthzProviderProps {
   pendingJob?: PendingJobType;
   isExpandable: boolean;
@@ -320,6 +328,7 @@ export const asSection = (options: SectionOptions) => (
 ) =>
   compose<WrappedComponentProps, RequiredComponentProps>(
     withAuthzContext,
+    muiThemeable(),
     loadData({
       queries: makeQueries(options.jobQueueNames),
       mutations
@@ -360,6 +369,7 @@ export const asSection = (options: SectionOptions) => (
 
       // Authz HOC
       adminPerms,
+      muiTheme,
 
       // withProps HOC
       pendingJob,
@@ -382,6 +392,7 @@ export const asSection = (options: SectionOptions) => (
         isExpandable={isExpandable}
         sectionIsDone={sectionIsDone}
         deleteJob={deleteJob}
+        muiTheme={muiTheme}
       >
         <Component
           organizationId={organizationId}

--- a/src/containers/AdminCampaignEdit/index.jsx
+++ b/src/containers/AdminCampaignEdit/index.jsx
@@ -8,6 +8,7 @@ import Dialog from "material-ui/Dialog";
 import FlatButton from "material-ui/FlatButton";
 import RaisedButton from "material-ui/RaisedButton";
 import { red600 } from "material-ui/styles/colors";
+import muiThemeable from "material-ui/styles/muiThemeable";
 import DoneIcon from "material-ui/svg-icons/action/done";
 import WarningIcon from "material-ui/svg-icons/alert/warning";
 import CancelIcon from "material-ui/svg-icons/navigation/cancel";
@@ -772,7 +773,7 @@ class AdminCampaignEdit extends React.Component {
   render() {
     const sections = this.sections();
     const { expandedSection, requestError } = this.state;
-    const { adminPerms, match } = this.props;
+    const { adminPerms, match, muiTheme } = this.props;
     const campaignId = parseInt(match.params.campaignId, 10);
     const isNew = this.isNew();
     const saveLabel = isNew ? "Save and goto next section" : "Save";
@@ -842,7 +843,8 @@ class AdminCampaignEdit extends React.Component {
                 size={25}
               />
             );
-            cardHeaderStyle.backgroundColor = theme.colors.green;
+            cardHeaderStyle.backgroundColor =
+              muiTheme?.palette?.primary1Color ?? theme.colors.green;
           } else if (!sectionIsDone) {
             avatar = (
               <Avatar
@@ -851,7 +853,8 @@ class AdminCampaignEdit extends React.Component {
                 size={25}
               />
             );
-            cardHeaderStyle.backgroundColor = theme.colors.yellow;
+            cardHeaderStyle.backgroundColor =
+              muiTheme?.palette?.primary2Color ?? theme.colors.yellow;
           }
           return (
             <Card
@@ -1070,6 +1073,7 @@ const mutations = {
 };
 
 export default compose(
+  muiThemeable(),
   withAuthzContext,
   loadData({
     queries,

--- a/src/containers/AssignmentTexterContact/NoMessagesIcon.tsx
+++ b/src/containers/AssignmentTexterContact/NoMessagesIcon.tsx
@@ -1,0 +1,29 @@
+import muiThemeable from "material-ui/styles/muiThemeable";
+import CreateIcon from "material-ui/svg-icons/content/create";
+import React, { useContext } from "react";
+
+import SpokeContext from "../../client/spoke-context";
+import { MuiThemeProviderProps } from "../../styles/types";
+
+const NoMessagesIcon: React.FC<MuiThemeProviderProps> = ({
+  muiTheme,
+  ...iconProps
+}) => {
+  const context = useContext(SpokeContext);
+
+  if (context.theme?.firstMessageIconUrl) {
+    return (
+      <div {...iconProps}>
+        <img
+          src={context.theme?.firstMessageIconUrl}
+          style={{ display: "block", margin: "auto", height: "100%" }}
+        />
+      </div>
+    );
+  }
+
+  const iconColor = muiTheme?.palette?.primary1Color ?? "rgb(83, 180, 119)";
+  return <CreateIcon color={iconColor} {...iconProps} />;
+};
+
+export default muiThemeable()(NoMessagesIcon);

--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -9,7 +9,6 @@ import MenuItem from "material-ui/MenuItem";
 import RaisedButton from "material-ui/RaisedButton";
 import Snackbar from "material-ui/Snackbar";
 import { blueGrey100, grey100 } from "material-ui/styles/colors";
-import CreateIcon from "material-ui/svg-icons/content/create";
 import LocalOfferIcon from "material-ui/svg-icons/maps/local-offer";
 import MoreVertIcon from "material-ui/svg-icons/navigation/more-vert";
 import { Toolbar, ToolbarGroup } from "material-ui/Toolbar";
@@ -39,6 +38,7 @@ import { isContactNowWithinCampaignHours } from "../../lib/timezones";
 import ApplyTagDialog from "./ApplyTagDialog";
 import ContactActionDialog from "./ContactActionDialog";
 import MessageTextField from "./MessageTextField";
+import NoMessagesIcon from "./NoMessagesIcon";
 import TopFixedSection from "./TopFixedSection";
 
 const TexterDialogType = Object.freeze({
@@ -874,7 +874,7 @@ export class AssignmentTexterContact extends React.Component {
             ) : (
               <Empty
                 title={`This is your first message to ${contact.firstName}`}
-                icon={<CreateIcon color="rgb(83, 180, 119)" />}
+                icon={<NoMessagesIcon />}
                 style={{ flex: "1 1 auto" }}
               />
             )}

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -28,6 +28,7 @@ router.get("/settings/theme", async (req, res) => {
     primaryColor: getSetting("theme.primaryColor"),
     secondaryColor: getSetting("theme.secondaryColor"),
     logoUrl: getSetting("theme.logoUrl"),
+    firstMessageIconUrl: getSetting("theme.firstMessageIconUrl"),
     welcomeText: getSetting("theme.welcomeText")
   };
   return res.json(customTheme);

--- a/src/styles/mui-theme.ts
+++ b/src/styles/mui-theme.ts
@@ -15,7 +15,7 @@ export const createMuiTheme = (overrides: Partial<CustomTheme> = {}) =>
         textColor: baseTheme.text.body.color,
         primary2Color: overrides.secondaryColor || baseTheme.colors.orange,
         primary3Color: grey400,
-        accent1Color: baseTheme.colors.orange,
+        accent1Color: overrides.secondaryColor || baseTheme.colors.orange,
         accent2Color: baseTheme.colors.lightGray,
         accent3Color: grey500,
         alternateTextColor: baseTheme.colors.white,

--- a/src/styles/types.ts
+++ b/src/styles/types.ts
@@ -51,6 +51,7 @@ export interface CustomTheme {
   primaryColor?: string;
   secondaryColor?: string;
   logoUrl?: string;
+  firstMessageIconUrl?: string;
   welcomeText?: string;
 }
 

--- a/src/styles/types.ts
+++ b/src/styles/types.ts
@@ -29,7 +29,7 @@ export interface TextStyles {
   body: CSSProperties;
   link_light_bg: AphroditeCSSProperties;
   link_dark_bg: AphroditeCSSProperties;
-  header: CSSProperties;
+  header: AphroditeCSSProperties;
   secondaryHeader: CSSProperties;
 }
 


### PR DESCRIPTION
## Description

Apply overridden styles to components missed in the first pass.

## Motivation and Context

Requested by customer.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<table><tr><td>

<img width="1167" alt="Screen Shot 2021-03-04 at 8 20 45 AM" src="https://user-images.githubusercontent.com/2145526/109969991-8d3cbe00-7cc2-11eb-8239-17e6c199335d.png">

</td></tr><tr><td>

<img width="695" alt="Screen Shot 2021-03-04 at 8 21 34 AM" src="https://user-images.githubusercontent.com/2145526/109970109-ae9daa00-7cc2-11eb-85c7-40b0b7732d5d.png">

</td></tr><tr><td>

<img width="344" alt="Screen Shot 2021-03-04 at 8 22 45 AM" src="https://user-images.githubusercontent.com/2145526/109970235-cecd6900-7cc2-11eb-8e07-c090f2813626.png">

</td></tr></table>

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
