### PR TITLE
fix: set answer actions to correct value

### DIFF
--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/resolvers.ts
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/resolvers.ts
@@ -118,7 +118,7 @@ export const stageAddInteractionStep: Resolver = (
       questionText: payload.questionText ?? "",
       scriptOptions: payload.scriptOptions ?? [""],
       answerOption: payload.answerOption ?? "",
-      answerActions: payload.answerOption ?? "",
+      answerActions: payload.answerActions ?? "",
       isDeleted: false,
       isModified: true,
       createdAt: DateTime.local().toISO()


### PR DESCRIPTION
## Description

Fix bug where `answerActions` was set to `answerOptions`.

## Motivation and Context

This results in error messages like `Cannot find module '../action_handlers/NO they will not donate.js'`

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
