### PR TITLE
fix: fix VAN sync modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@babel/runtime": "^7.9.2",
     "@babel/runtime-corejs3": "^7.9.2",
     "@google-cloud/storage": "^5.7.4",
+    "@material-ui/core": "^4.11.3",
     "@passport-next/passport": "^3.1.0",
     "@rewired/passport-slack": "^1.0.6",
     "@slack/web-api": "^6.0.0",

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,5 +1,6 @@
+import { MuiThemeProvider } from "@material-ui/core/styles";
 import { css, StyleSheet } from "aphrodite";
-import MuiThemeProvider from "material-ui/styles/MuiThemeProvider";
+import MuiThemeProviderv0 from "material-ui/styles/MuiThemeProvider";
 import React, { useEffect, useState } from "react";
 import { ApolloProvider } from "react-apollo";
 import { BrowserRouter as Router } from "react-router-dom";
@@ -7,7 +8,7 @@ import request from "superagent";
 
 import ApolloClientSingleton from "../network/apollo-client-singleton";
 import AppRoutes from "../routes";
-import { createMuiTheme } from "../styles/mui-theme";
+import { createMuiThemev0, createMuiThemev1 } from "../styles/mui-theme";
 import baseTheme from "../styles/theme";
 import { CustomTheme } from "../styles/types";
 import SpokeContext from "./spoke-context";
@@ -29,20 +30,23 @@ const App: React.FC = () => {
     });
   }, []);
 
-  const muiTheme = createMuiTheme(customTheme);
+  const muiTheme = createMuiThemev1(customTheme);
+  const muiThemev0 = createMuiThemev0(customTheme);
 
   return (
     <SpokeContext.Provider value={{ theme: customTheme }}>
-      <ApolloProvider client={ApolloClientSingleton}>
-        <MuiThemeProvider muiTheme={muiTheme}>
-          <div className={css(styles.root)}>
-            <VersionNotifier />
-            <Router>
-              <AppRoutes />
-            </Router>
-          </div>
-        </MuiThemeProvider>
-      </ApolloProvider>
+      <MuiThemeProvider theme={muiTheme}>
+        <MuiThemeProviderv0 muiTheme={muiThemev0}>
+          <ApolloProvider client={ApolloClientSingleton}>
+            <div className={css(styles.root)}>
+              <VersionNotifier />
+              <Router>
+                <AppRoutes />
+              </Router>
+            </div>
+          </ApolloProvider>
+        </MuiThemeProviderv0>
+      </MuiThemeProvider>
     </SpokeContext.Provider>
   );
 };

--- a/src/components/SyncConfigurationModal/index.tsx
+++ b/src/components/SyncConfigurationModal/index.tsx
@@ -1,7 +1,11 @@
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
+import DialogTitle from "@material-ui/core/DialogTitle";
 import { ApolloQueryResult } from "apollo-client";
 import gql from "graphql-tag";
 import cloneDeep from "lodash/cloneDeep";
-import Dialog from "material-ui/Dialog";
 import FlatButton from "material-ui/FlatButton";
 import React from "react";
 import { compose } from "recompose";
@@ -86,37 +90,35 @@ const SyncConfigurationModal: React.SFC<InnerProps> = (props) => {
   };
 
   return (
-    <Dialog
-      open
-      title="Configure Mapping"
-      actions={actions}
-      autoScrollBodyContent
-      onRequestClose={props.onRequestClose}
-    >
-      <p>
-        For instructions on configuring mappings, please see the{" "}
-        <a
-          href="https://docs.spokerewired.com/article/93-van-list-loading"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          VAN Integration
-        </a>{" "}
-        page.
-      </p>
-      {responseMappings.map((responseMapping) => (
-        <QuestionResponseConfig
-          key={responseMapping.id}
-          campaignId={campaignId}
-          config={responseMapping}
-          surveyQuestions={surveyQuestions}
-          activistCodes={activistCodes}
-          resultCodes={resultCodes}
-          style={{ marginTop: "10px" }}
-          createConfig={makeOnCreateConfig(responseMapping.id)}
-          deleteConfig={makeOnDeleteConfig(responseMapping.id)}
-        />
-      ))}
+    <Dialog open scroll="body" onClose={props.onRequestClose}>
+      <DialogTitle>Configure Mapping</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          For instructions on configuring mappings, please see the{" "}
+          <a
+            href="https://docs.spokerewired.com/article/93-van-list-loading"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            VAN Integration
+          </a>{" "}
+          page.
+        </DialogContentText>
+        {responseMappings.map((responseMapping) => (
+          <QuestionResponseConfig
+            key={responseMapping.id}
+            campaignId={campaignId}
+            config={responseMapping}
+            surveyQuestions={surveyQuestions}
+            activistCodes={activistCodes}
+            resultCodes={resultCodes}
+            style={{ marginTop: "10px" }}
+            createConfig={makeOnCreateConfig(responseMapping.id)}
+            deleteConfig={makeOnDeleteConfig(responseMapping.id)}
+          />
+        ))}
+      </DialogContent>
+      <DialogActions>{actions}</DialogActions>
     </Dialog>
   );
 };

--- a/src/containers/AdminCampaignStats/VanSyncModal.tsx
+++ b/src/containers/AdminCampaignStats/VanSyncModal.tsx
@@ -1,7 +1,11 @@
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
+import DialogTitle from "@material-ui/core/DialogTitle";
 import { ApolloQueryResult } from "apollo-client";
 import gql from "graphql-tag";
 import { History } from "history";
-import Dialog from "material-ui/Dialog";
 import FlatButton from "material-ui/FlatButton";
 import RaisedButton from "material-ui/RaisedButton";
 import { green300, red500 } from "material-ui/styles/colors";
@@ -158,104 +162,103 @@ class VanSyncModal extends React.Component<InnerProps, State> {
     ];
 
     return (
-      <Dialog
-        open={open}
-        title="Sync to VAN"
-        actions={actions}
-        onRequestClose={this.props.onRequestClose}
-      >
-        <p>
-          This will sync question responses and tags to VAN. For more
-          information see{" "}
-          <a
-            href="https://docs.spokerewired.com/article/93-van-list-loading"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            VAN Integration
-          </a>
-          .
-        </p>
-        {isSyncing ? (
-          <div>
-            <p>Syncing campaign: {latestSyncAttempt.status}%</p>
-            {syncErrors.length > 0 && [
-              <p key="p">Encountered the following errors</p>,
-              <ul key="ul">
-                {syncErrors.map((error) => (
-                  <li key={error}>{error}</li>
-                ))}
-              </ul>
-            ]}
+      <Dialog open={open} onClose={this.props.onRequestClose}>
+        <DialogTitle>Sync to VAN</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            This will sync question responses and tags to VAN. For more
+            information see{" "}
+            <a
+              href="https://docs.spokerewired.com/article/93-van-list-loading"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              VAN Integration
+            </a>
+            .
+          </DialogContentText>
+          {isSyncing ? (
+            <div>
+              <p>Syncing campaign: {latestSyncAttempt.status}%</p>
+              {syncErrors.length > 0 && [
+                <p key="p">Encountered the following errors</p>,
+                <ul key="ul">
+                  {syncErrors.map((error) => (
+                    <li key={error}>{error}</li>
+                  ))}
+                </ul>
+              ]}
+              <RaisedButton
+                label="Cancel Sync"
+                primary
+                onClick={this.handleOnCancelSync(latestSyncAttempt.id)}
+              />
+              <br />
+              <br />
+            </div>
+          ) : (
+            <p>
+              Status:{" "}
+              {syncReadiness === ExternalSyncReadinessState.READY && (
+                <span style={{ color: green300 }}>
+                  Your campaign is ready to sync!
+                </span>
+              )}
+              {syncReadiness ===
+                ExternalSyncReadinessState.MISSING_REQUIRED_MAPPING && (
+                <span style={{ color: red500 }}>
+                  Your campaign is missing a required sync mapping!
+                </span>
+              )}
+              {syncReadiness ===
+                ExternalSyncReadinessState.INCLUDES_NOT_ACTIVE_TARGETS && (
+                <span style={{ color: red500 }}>
+                  Your campaign includes mappings to inactive or archived VAN
+                  options!
+                </span>
+              )}
+              {syncReadiness === ExternalSyncReadinessState.MISSING_SYSTEM && (
+                <span style={{ color: red500 }}>
+                  No integration has been set for this campaign!
+                </span>
+              )}
+            </p>
+          )}
+          {syncReadiness === ExternalSyncReadinessState.MISSING_SYSTEM && [
+            <p key="1">Edit the Integration section of the campaign.</p>,
             <RaisedButton
-              label="Cancel Sync"
+              key="2"
+              label="Edit Campaign"
               primary
-              onClick={this.handleOnCancelSync(latestSyncAttempt.id)}
+              disabled={isSyncing}
+              onClick={this.handleOnClickSetIntegration}
             />
-            <br />
-            <br />
-          </div>
-        ) : (
-          <p>
-            Status:{" "}
-            {syncReadiness === ExternalSyncReadinessState.READY && (
-              <span style={{ color: green300 }}>
-                Your campaign is ready to sync!
-              </span>
-            )}
-            {syncReadiness ===
-              ExternalSyncReadinessState.MISSING_REQUIRED_MAPPING && (
-              <span style={{ color: red500 }}>
-                Your campaign is missing a required sync mapping!
-              </span>
-            )}
-            {syncReadiness ===
-              ExternalSyncReadinessState.INCLUDES_NOT_ACTIVE_TARGETS && (
-              <span style={{ color: red500 }}>
-                Your campaign includes mappings to inactive or archived VAN
-                options!
-              </span>
-            )}
-            {syncReadiness === ExternalSyncReadinessState.MISSING_SYSTEM && (
-              <span style={{ color: red500 }}>
-                No integration has been set for this campaign!
-              </span>
-            )}
-          </p>
-        )}
-        {syncReadiness === ExternalSyncReadinessState.MISSING_SYSTEM && [
-          <p key="1">Edit the Integration section of the campaign.</p>,
-          <RaisedButton
-            key="2"
-            label="Edit Campaign"
-            primary
-            disabled={isSyncing}
-            onClick={this.handleOnClickSetIntegration}
-          />
-        ]}
-        {syncReadiness !== ExternalSyncReadinessState.MISSING_SYSTEM && (
-          <RaisedButton
-            label="Configure Mapping"
-            primary
-            disabled={isSyncing}
-            onClick={this.handleOnClickConfigureMapping}
-          />
-        )}
-        {isMappingOpen && (
-          <SyncConfigurationModal
-            organizationId={organizationId}
-            campaignId={campaignId}
-            onRequestClose={this.handleOnDismissConfigureMapping}
-          />
-        )}
-        {latestSyncAttempt && latestSyncAttempt.status === 100 && (
-          <p>
-            Last sync:
-            <br />
-            {new Date(latestSyncAttempt.updatedAt).toLocaleString()} -{" "}
-            {messageFromJobRquest(latestSyncAttempt)}
-          </p>
-        )}
+          ]}
+          {syncReadiness !== ExternalSyncReadinessState.MISSING_SYSTEM && (
+            <RaisedButton
+              label="Configure Mapping"
+              primary
+              disabled={isSyncing}
+              onClick={this.handleOnClickConfigureMapping}
+            />
+          )}
+          {isMappingOpen && (
+            <SyncConfigurationModal
+              organizationId={organizationId}
+              campaignId={campaignId}
+              onRequestClose={this.handleOnDismissConfigureMapping}
+            />
+          )}
+          {latestSyncAttempt && latestSyncAttempt.status === 100 && (
+            <DialogContentText>
+              Last sync:
+              <br />
+              {new Date(latestSyncAttempt.updatedAt).toLocaleString()} -{" "}
+              {messageFromJobRquest(latestSyncAttempt)}
+            </DialogContentText>
+          )}
+        </DialogContent>
+        <DialogActions>{actions}</DialogActions>
       </Dialog>
     );
   }

--- a/src/styles/mui-theme.ts
+++ b/src/styles/mui-theme.ts
@@ -1,4 +1,5 @@
 /* eslint-disable import/prefer-default-export */
+import { createMuiTheme } from "@material-ui/core/styles"; // v1.x
 import { darkBlack, grey400, grey500 } from "material-ui/styles/colors";
 import getMuiTheme from "material-ui/styles/getMuiTheme";
 import { fade } from "material-ui/utils/colorManipulator";
@@ -6,7 +7,7 @@ import { fade } from "material-ui/utils/colorManipulator";
 import baseTheme from "./theme";
 import { CustomTheme } from "./types";
 
-export const createMuiTheme = (overrides: Partial<CustomTheme> = {}) =>
+export const createMuiThemev0 = (overrides: Partial<CustomTheme> = {}) =>
   getMuiTheme(
     {
       fontFamily: "Poppins",
@@ -26,3 +27,7 @@ export const createMuiTheme = (overrides: Partial<CustomTheme> = {}) =>
     },
     { userAgent: "all" }
   );
+
+// TODO: return real theme once components beyond Dialog are converted
+export const createMuiThemev1 = (_overrides: Partial<CustomTheme> = {}) =>
+  createMuiTheme({});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2264,6 +2264,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.8.3":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
+  integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.5.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
@@ -2618,6 +2625,11 @@
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.6.6.tgz#62266c5f0eac6941fece302abad69f2ee7e25e44"
   integrity sha512-ojhgxzUHZ7am3D2jHkMzPpsBAiB005GF5YU4ea+8DNPybMk01JJUM9V9YRlF/GE95tcOm8DxQvWA2jq19bGalQ==
+
+"@emotion/hash@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
+  integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
 "@emotion/memoize@^0.6.1", "@emotion/memoize@^0.6.6":
   version "0.6.6"
@@ -3039,6 +3051,70 @@
     "@types/node" "*"
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
+
+"@material-ui/core@^4.11.3":
+  version "4.11.3"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.11.3.tgz#f22e41775b0bd075e36a7a093d43951bf7f63850"
+  integrity sha512-Adt40rGW6Uds+cAyk3pVgcErpzU/qxc7KBR94jFHBYretU4AtWZltYcNsbeMn9tXL86jjVL1kuGcIHsgLgFGRw==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/styles" "^4.11.3"
+    "@material-ui/system" "^4.11.3"
+    "@material-ui/types" "^5.1.0"
+    "@material-ui/utils" "^4.11.2"
+    "@types/react-transition-group" "^4.2.0"
+    clsx "^1.0.4"
+    hoist-non-react-statics "^3.3.2"
+    popper.js "1.16.1-lts"
+    prop-types "^15.7.2"
+    react-is "^16.8.0 || ^17.0.0"
+    react-transition-group "^4.4.0"
+
+"@material-ui/styles@^4.11.3":
+  version "4.11.3"
+  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.3.tgz#1b8d97775a4a643b53478c895e3f2a464e8916f2"
+  integrity sha512-HzVzCG+PpgUGMUYEJ2rTEmQYeonGh41BYfILNFb/1ueqma+p1meSdu4RX6NjxYBMhf7k+jgfHFTTz+L1SXL/Zg==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@emotion/hash" "^0.8.0"
+    "@material-ui/types" "^5.1.0"
+    "@material-ui/utils" "^4.11.2"
+    clsx "^1.0.4"
+    csstype "^2.5.2"
+    hoist-non-react-statics "^3.3.2"
+    jss "^10.5.1"
+    jss-plugin-camel-case "^10.5.1"
+    jss-plugin-default-unit "^10.5.1"
+    jss-plugin-global "^10.5.1"
+    jss-plugin-nested "^10.5.1"
+    jss-plugin-props-sort "^10.5.1"
+    jss-plugin-rule-value-function "^10.5.1"
+    jss-plugin-vendor-prefixer "^10.5.1"
+    prop-types "^15.7.2"
+
+"@material-ui/system@^4.11.3":
+  version "4.11.3"
+  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.11.3.tgz#466bc14c9986798fd325665927c963eb47cc4143"
+  integrity sha512-SY7otguNGol41Mu2Sg6KbBP1ZRFIbFLHGK81y4KYbsV2yIcaEPOmsCK6zwWlp+2yTV3J/VwT6oSBARtGIVdXPw==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.11.2"
+    csstype "^2.5.2"
+    prop-types "^15.7.2"
+
+"@material-ui/types@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-5.1.0.tgz#efa1c7a0b0eaa4c7c87ac0390445f0f88b0d88f2"
+  integrity sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==
+
+"@material-ui/utils@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-4.11.2.tgz#f1aefa7e7dff2ebcb97d31de51aecab1bb57540a"
+  integrity sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0 || ^17.0.0"
 
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents":
   version "2.1.8-no-fsevents"
@@ -4096,6 +4172,13 @@
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.2.4.tgz#c7416225987ccdb719262766c1483da8f826838d"
   integrity sha512-8DMUaDqh0S70TjkqU0DxOu80tFUiiaS9rxkWip/nb7gtvAsbqOXm02UCmR8zdcjWujgeYPiPNTVpVpKzUDotwA==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-transition-group@^4.2.0":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.1.tgz#e1a3cb278df7f47f17b5082b1b3da17170bd44b1"
+  integrity sha512-vIo69qKKcYoJ8wKCJjwSgCTM+z3chw3g18dkrDfVX665tMH7tmbDxEAnPdey4gTlwZz5QuHGzd+hul0OVZDqqQ==
   dependencies:
     "@types/react" "*"
 
@@ -7285,6 +7368,11 @@ clone@^1.0.0:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
+clsx@^1.0.4:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -8295,6 +8383,14 @@ css-tree@^1.1.2:
     mdn-data "2.0.14"
     source-map "^0.6.1"
 
+css-vendor@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-2.0.8.tgz#e47f91d3bd3117d49180a3c935e62e3d9f7f449d"
+  integrity sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==
+  dependencies:
+    "@babel/runtime" "^7.8.3"
+    is-in-browser "^1.0.2"
+
 css-what@2.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
@@ -8952,6 +9048,14 @@ dom-helpers@^3.2.0, dom-helpers@^3.4.0:
   integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
   dependencies:
     "@babel/runtime" "^7.1.2"
+
+dom-helpers@^5.0.1:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.0.tgz#57fd054c5f8f34c52a3eeffdb7e7e93cd357d95b"
+  integrity sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dom-serializer@0, dom-serializer@^0.2.1:
   version "0.2.2"
@@ -12092,7 +12196,7 @@ hoist-non-react-statics@^2.3.1:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
-hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -12431,6 +12535,11 @@ hyphenate-style-name@^1.0.2:
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz#097bb7fa0b8f1a9cf0bd5c734cf95899981a9b48"
   integrity sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ==
 
+hyphenate-style-name@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
+  integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
+
 iconv-lite@0.*, iconv-lite@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.5.1.tgz#b2425d3c7b18f7219f2ca663d103bddb91718d64"
@@ -12594,6 +12703,13 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
+
+indefinite-observable@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/indefinite-observable/-/indefinite-observable-2.0.1.tgz#574af29bfbc17eb5947793797bddc94c9d859400"
+  integrity sha512-G8vgmork+6H9S8lUAg1gtXEj2JxIQTo0g2PbFiYOdjkziSI0F7UYBiVwhZRuixhBCNGczAls34+5HJPyZysvxQ==
+  dependencies:
+    symbol-observable "1.2.0"
 
 indent-string@^2.1.0:
   version "2.1.0"
@@ -13065,6 +13181,11 @@ is-hexadecimal@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
   integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
+
+is-in-browser@^1.0.2, is-in-browser@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.1.3.tgz#56ff4db683a078c6082eb95dad7dc62e1d04f835"
+  integrity sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU=
 
 is-installed-globally@^0.3.1:
   version "0.3.2"
@@ -14649,6 +14770,77 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+jss-plugin-camel-case@^10.5.1:
+  version "10.5.1"
+  resolved "https://registry.yarnpkg.com/jss-plugin-camel-case/-/jss-plugin-camel-case-10.5.1.tgz#427b24a9951b4c2eaa7e3d5267acd2e00b0934f9"
+  integrity sha512-9+oymA7wPtswm+zxVti1qiowC5q7bRdCJNORtns2JUj/QHp2QPXYwSNRD8+D2Cy3/CEMtdJzlNnt5aXmpS6NAg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    hyphenate-style-name "^1.0.3"
+    jss "10.5.1"
+
+jss-plugin-default-unit@^10.5.1:
+  version "10.5.1"
+  resolved "https://registry.yarnpkg.com/jss-plugin-default-unit/-/jss-plugin-default-unit-10.5.1.tgz#2be385d71d50aee2ee81c2a9ac70e00592ed861b"
+  integrity sha512-D48hJBc9Tj3PusvlillHW8Fz0y/QqA7MNmTYDQaSB/7mTrCZjt7AVRROExoOHEtd2qIYKOYJW3Jc2agnvsXRlQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.5.1"
+
+jss-plugin-global@^10.5.1:
+  version "10.5.1"
+  resolved "https://registry.yarnpkg.com/jss-plugin-global/-/jss-plugin-global-10.5.1.tgz#0e1793dea86c298360a7e2004721351653c7e764"
+  integrity sha512-jX4XpNgoaB8yPWw/gA1aPXJEoX0LNpvsROPvxlnYe+SE0JOhuvF7mA6dCkgpXBxfTWKJsno7cDSCgzHTocRjCQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.5.1"
+
+jss-plugin-nested@^10.5.1:
+  version "10.5.1"
+  resolved "https://registry.yarnpkg.com/jss-plugin-nested/-/jss-plugin-nested-10.5.1.tgz#8753a80ad31190fb6ac6fdd39f57352dcf1295bb"
+  integrity sha512-xXkWKOCljuwHNjSYcXrCxBnjd8eJp90KVFW1rlhvKKRXnEKVD6vdKXYezk2a89uKAHckSvBvBoDGsfZrldWqqQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.5.1"
+    tiny-warning "^1.0.2"
+
+jss-plugin-props-sort@^10.5.1:
+  version "10.5.1"
+  resolved "https://registry.yarnpkg.com/jss-plugin-props-sort/-/jss-plugin-props-sort-10.5.1.tgz#ab1c167fd2d4506fb6a1c1d66c5f3ef545ff1cd8"
+  integrity sha512-t+2vcevNmMg4U/jAuxlfjKt46D/jHzCPEjsjLRj/J56CvP7Iy03scsUP58Iw8mVnaV36xAUZH2CmAmAdo8994g==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.5.1"
+
+jss-plugin-rule-value-function@^10.5.1:
+  version "10.5.1"
+  resolved "https://registry.yarnpkg.com/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.5.1.tgz#37f4030523fb3032c8801fab48c36c373004de7e"
+  integrity sha512-3gjrSxsy4ka/lGQsTDY8oYYtkt2esBvQiceGBB4PykXxHoGRz14tbCK31Zc6DHEnIeqsjMUGbq+wEly5UViStQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.5.1"
+    tiny-warning "^1.0.2"
+
+jss-plugin-vendor-prefixer@^10.5.1:
+  version "10.5.1"
+  resolved "https://registry.yarnpkg.com/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.5.1.tgz#45a183a3a0eb097bdfab0986b858d99920c0bbd8"
+  integrity sha512-cLkH6RaPZWHa1TqSfd2vszNNgxT1W0omlSjAd6hCFHp3KIocSrW21gaHjlMU26JpTHwkc+tJTCQOmE/O1A4FKQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    css-vendor "^2.0.8"
+    jss "10.5.1"
+
+jss@10.5.1, jss@^10.5.1:
+  version "10.5.1"
+  resolved "https://registry.yarnpkg.com/jss/-/jss-10.5.1.tgz#93e6b2428c840408372d8b548c3f3c60fa601c40"
+  integrity sha512-hbbO3+FOTqVdd7ZUoTiwpHzKXIo5vGpMNbuXH1a0wubRSWLWSBvwvaq4CiHH/U42CmjOnp6lVNNs/l+Z7ZdDmg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    csstype "^3.0.2"
+    indefinite-observable "^2.0.1"
+    is-in-browser "^1.1.3"
+    tiny-warning "^1.0.2"
 
 jsx-ast-utils@^2.2.1:
   version "2.2.3"
@@ -17448,6 +17640,11 @@ pnp-webpack-plugin@1.6.4:
   dependencies:
     ts-pnp "^1.1.6"
 
+popper.js@1.16.1-lts:
+  version "1.16.1-lts"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1-lts.tgz#cf6847b807da3799d80ee3d6d2f90df8a3f50b05"
+  integrity sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA==
+
 portfinder@^1.0.26:
   version "1.0.28"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"
@@ -18743,7 +18940,7 @@ react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
 
-react-is@^17.0.1:
+"react-is@^16.8.0 || ^17.0.0", react-is@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
@@ -18922,6 +19119,16 @@ react-transition-group@^2.2.1:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
+
+react-transition-group@^4.4.0:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
+  integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react@^16.14.0:
   version "16.14.0"
@@ -21363,7 +21570,7 @@ svgo@^1.0.0, svgo@^1.2.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-symbol-observable@^1.0.2, symbol-observable@^1.0.4:
+symbol-observable@1.2.0, symbol-observable@^1.0.2, symbol-observable@^1.0.4:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
@@ -21708,7 +21915,7 @@ tiny-invariant@^1.0.2:
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.6.tgz#b3f9b38835e36a41c843a3b0907a5a7b3755de73"
   integrity sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA==
 
-tiny-warning@^1.0.0, tiny-warning@^1.0.3:
+tiny-warning@^1.0.0, tiny-warning@^1.0.2, tiny-warning@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==


### PR DESCRIPTION
## Description

This fixes the context provider/consumer bug impacting the VAN sync modal.

## Motivation and Context

`material-ui@~0` renders dialog content outside the primary React DOM tree. This is fine for one level of dialogs when a `<Dialog>`'s child component consumes a React context (e.g. `react-apollo`).

`@latest` uses React portals to avoid this bug altogether.

This adds v0 and @latest side-by-side as described in [Migration From v0.x to v1](https://material-ui.com/guides/migration-v0x/).

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
