### PR TITLE
fix: disable unsupported copy/paste block rather than crashing

### DIFF
--- a/src/client/lib/index.ts
+++ b/src/client/lib/index.ts
@@ -1,0 +1,3 @@
+/* eslint-disable import/prefer-default-export */
+export const supportsClipboard = () =>
+  navigator.clipboard.readText !== undefined;

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/components/InteractionStepCard.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/components/InteractionStepCard.tsx
@@ -11,6 +11,7 @@ import {
   InteractionStep,
   InteractionStepWithChildren
 } from "../../../../../api/interaction-step";
+import { supportsClipboard } from "../../../../../client/lib";
 import GSForm from "../../../../../components/forms/GSForm";
 import SpokeFormField from "../../../../../components/forms/SpokeFormField";
 import { dataTest } from "../../../../../lib/attributes";
@@ -95,6 +96,8 @@ export const InteractionStepCard: React.SFC<Props> = (props) => {
   const isAbleToAddResponse =
     stepHasQuestion && stepHasScript && stepCanHaveChildren;
 
+  const clipboardEnabled = supportsClipboard();
+
   return (
     <div key={stepId}>
       <Card key={stepId} style={styles.interactionStep}>
@@ -109,7 +112,7 @@ export const InteractionStepCard: React.SFC<Props> = (props) => {
         />
         <CardActions>
           <RaisedButton
-            disabled={disabled}
+            disabled={disabled || !clipboardEnabled}
             onClick={() => onCopyBlock(interactionStep)}
           >
             Copy Block
@@ -117,9 +120,12 @@ export const InteractionStepCard: React.SFC<Props> = (props) => {
           {hasBlockCopied && (
             <RaisedButton
               label="+ Paste Block"
-              disabled={disabled}
+              disabled={disabled || !clipboardEnabled}
               onClick={onRequestRootPaste}
             />
+          )}
+          {!clipboardEnabled && (
+            <span>Your browser does not support clipboard actions</span>
           )}
         </CardActions>
         <CardText>

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
@@ -14,6 +14,7 @@ import {
   InteractionStepWithChildren
 } from "../../../../api/interaction-step";
 import { Action } from "../../../../api/types";
+import { supportsClipboard } from "../../../../client/lib";
 import { dataTest } from "../../../../lib/attributes";
 import { DateTime } from "../../../../lib/datetime";
 import { makeTree } from "../../../../lib/interaction-step-helpers";
@@ -169,6 +170,8 @@ class CampaignInteractionStepsForm extends React.Component<InnerProps, State> {
   };
 
   createPasteBlockHandler = (parentInteractionId: string | null) => () => {
+    if (!supportsClipboard()) return;
+
     navigator.clipboard.readText().then((text) => {
       const idMap: Record<string, string> = {};
 
@@ -257,6 +260,8 @@ class CampaignInteractionStepsForm extends React.Component<InnerProps, State> {
   };
 
   updateClipboardHasBlock = () => {
+    if (!supportsClipboard()) return;
+
     navigator.clipboard.readText().then((text) => {
       try {
         const _newBlock = JSON.parse(text);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This disables the copy/paste block functionality with a warning message when `navigator.clipboard.readText()` is unavailable rather than crashing.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Firefox only supports `clipboard.read()` and `clipboard.readText()` in browser extensions that have specifically requested the permission ([ref](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/readText)). Crashing when we encounter this is bad UX.

Closes #854 

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

![Screen Shot 2021-03-12 at 7 02 03 AM](https://user-images.githubusercontent.com/2145526/110937798-e7f89a00-8300-11eb-82aa-2958ddcedf53.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
