### PR TITLE
fix: fix crash editing interaction step

### DIFF
--- a/src/components/ScriptEditor.jsx
+++ b/src/components/ScriptEditor.jsx
@@ -90,6 +90,12 @@ class ScriptEditor extends React.Component {
     };
   }
 
+  componentDidMount() {
+    if (this.props.receiveFocus === true) {
+      this.focus();
+    }
+  }
+
   UNSAFE_componentWillReceiveProps() {
     const { scriptFields } = this.props;
     const { editorState } = this.state;
@@ -155,9 +161,9 @@ class ScriptEditor extends React.Component {
   };
 
   focus = () => {
-    if (this.editorRef) {
-      this.editorRef.focus();
-    }
+    const { editorState: oldState } = this.state;
+    const editorState = EditorState.moveFocusToEnd(oldState);
+    this.setState({ editorState });
   };
 
   addCustomField = (field) => {
@@ -241,7 +247,8 @@ ScriptEditor.propTypes = {
   name: PropTypes.string.isRequired,
   scriptText: PropTypes.string.isRequired,
   scriptFields: PropTypes.array.isRequired,
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
+  receiveFocus: PropTypes.bool
 };
 
 export default ScriptEditor;

--- a/src/components/forms/GSScriptOptionsField.jsx
+++ b/src/components/forms/GSScriptOptionsField.jsx
@@ -34,12 +34,7 @@ class GSScriptOptionsField extends GSFormField {
     event.stopPropagation();
     event.preventDefault();
 
-    this.setState(
-      { scriptTarget: scriptVersion, scriptDraft: scriptVersion },
-      () => {
-        if (this.inputRef) this.inputRef.focus();
-      }
-    );
+    this.setState({ scriptTarget: scriptVersion, scriptDraft: scriptVersion });
   };
 
   createDeleteHandler = (scriptVersion) => () => {
@@ -142,6 +137,7 @@ class GSScriptOptionsField extends GSFormField {
           name={name}
           scriptText={scriptDraft}
           scriptFields={scriptFields}
+          receiveFocus
           expandable
           onChange={(val) => this.setState({ scriptDraft: val.trim() })}
         />

--- a/src/components/forms/GSScriptOptionsField.jsx
+++ b/src/components/forms/GSScriptOptionsField.jsx
@@ -167,8 +167,8 @@ class GSScriptOptionsField extends GSFormField {
       "multiLine",
       "name",
       "data-test",
-      "onBlur",
-      "onChange"
+      "onBlur"
+      // We manage onChange ourselves so don't pass it though
     ]);
 
     const canDelete = scriptVersions.length > 1;


### PR DESCRIPTION
## Description

This fixes a crash caused by editing TextField content rather than ScriptEditor content.

## Motivation and Context

The field's default onChange behavior (updating the GSForm value) was being attached to the
read-only TextField. Clicking into this TextField opens the script editor pop-up but if changes are
made to the script while the TextField has focus then onChange is incorrectly called with a string,
rather than an array of strings.

The script editor pop-up should steal focus as soon as it is opened, preventing/masking this bug,
but that functionality was broken. This PR restores focus-on-open behavior to the ScriptEditor
pop up.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
