### PR TITLE
fix: fix texter crash when clearing a survey response

### DIFF
--- a/src/components/AssignmentTexterSurveys.jsx
+++ b/src/components/AssignmentTexterSurveys.jsx
@@ -63,7 +63,7 @@ class AssignmentTexterSurveys extends Component {
   handleSelectChange = async (interactionStep, answerIndex, value) => {
     const { onQuestionResponseChange } = this.props;
     let questionResponseValue = null;
-    let nextScript = null;
+    let nextScript = "";
 
     if (value !== "clearResponse") {
       questionResponseValue = value;

--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -277,7 +277,7 @@ export class AssignmentTexterContact extends React.Component {
           script,
           customFields: campaign.customFields
         })
-      : null;
+      : "";
   };
 
   getStartingMessageText = () => {
@@ -501,8 +501,9 @@ export class AssignmentTexterContact extends React.Component {
   };
 
   handleChangeScript = (newScript) => {
-    const messageVersionHash = md5(newScript);
-    const messageText = this.getMessageTextFromScript(newScript);
+    const safeScript = newScript || "";
+    const messageVersionHash = md5(safeScript);
+    const messageText = this.getMessageTextFromScript(safeScript);
     this.setState({ messageText, messageVersionHash });
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This fixes a crash in the texter application caused by passing `null` instead of an empty string.

## Motivation and Context

`md5()` and `<MessageLengthInfo>` both break on `messageText = null`.

## How Has This Been Tested?

This has been tested locally.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
