### PR TITLE
fix: serialize dates using ISO-8601 format

### DIFF
--- a/src/api/campaign.ts
+++ b/src/api/campaign.ts
@@ -87,8 +87,8 @@ export const schema = `
     assigned: Boolean
     status: Int
     resultMessage: String
-    createdAt: String!
-    updatedAt: String!
+    createdAt: Date!
+    updatedAt: Date!
   }
 
   type CampaignReadiness {

--- a/src/api/external-activist-code.ts
+++ b/src/api/external-activist-code.ts
@@ -27,8 +27,8 @@ export const schema = `
     description: String
     scriptQuestion: String
     status: ExternalDataCollectionStatus!
-    createdAt: String!
-    updatedAt: String!
+    createdAt: Date!
+    updatedAt: Date!
   }
 
   type ExternalActivistCodeEdge {

--- a/src/api/external-list.ts
+++ b/src/api/external-list.ts
@@ -17,8 +17,8 @@ export const schema = `
     description: String!
     listCount: Int!
     doorCount: Int!
-    createdAt: String!
-    updatedAt: String!
+    createdAt: Date!
+    updatedAt: Date!
   }
 
   type ExternalListEdge {

--- a/src/api/external-result-code.ts
+++ b/src/api/external-result-code.ts
@@ -17,8 +17,8 @@ export const schema = `
     name: String!
     mediumName: String!
     shortName: String!
-    createdAt: String!
-    updatedAt: String!
+    createdAt: Date!
+    updatedAt: Date!
   }
 
   type ExternalResultCodeEdge {

--- a/src/api/external-survey-question-response-option.ts
+++ b/src/api/external-survey-question-response-option.ts
@@ -17,8 +17,8 @@ export const schema = `
     name: String!
     mediumName: String!
     shortName: String!
-    createdAt: String!
-    updatedAt: String!
+    createdAt: Date!
+    updatedAt: Date!
   }
 
   type ExternalSurveyQuestionResponseOptionEdge {

--- a/src/api/external-survey-question.ts
+++ b/src/api/external-survey-question.ts
@@ -30,8 +30,8 @@ export const schema = `
     shortName: String!
     scriptQuestion: String!
     status: ExternalDataCollectionStatus!
-    createdAt: String!
-    updatedAt: String!
+    createdAt: Date!
+    updatedAt: Date!
     responseOptions(after: Cursor, first: Int): ExternalSurveyQuestionResponseOptionPage!
   }
 

--- a/src/api/external-sync-config.ts
+++ b/src/api/external-sync-config.ts
@@ -114,8 +114,8 @@ export const schema = `
     includesNotActive: Boolean!
     isMissing: Boolean!
     isRequired: Boolean!
-    createdAt: String
-    updatedAt: String
+    createdAt: Date
+    updatedAt: Date
     interactionStep: InteractionStep!
     targets(after: Cursor, first: Int): [ExternalSyncConfigTarget]
   }
@@ -137,8 +137,8 @@ export const schema = `
     includesNotActive: Boolean!
     isMissing: Boolean!
     isRequired: Boolean!
-    createdAt: String
-    updatedAt: String
+    createdAt: Date
+    updatedAt: Date
     tag: Tag!
     targets(after: Cursor, first: Int): ExternalSyncConfigTargetPage
   }

--- a/src/api/external-system.ts
+++ b/src/api/external-system.ts
@@ -79,9 +79,9 @@ export const schema = `
     username: String!
     apiKey: String!
     organizationId: Int!
-    createdAt: String!
-    updatedAt: String!
-    syncedAt: String
+    createdAt: Date!
+    updatedAt: Date!
+    syncedAt: Date
     operationMode: VanOperationMode!
     lists(after: Cursor, first: Int): ExternalListPage!
     surveyQuestions(filter: ExternalSurveyQuestionFilter, after: Cursor, first: Int): ExternalSurveyQuestionPage!

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -77,7 +77,7 @@ const rootSchema = `
     answerActions: String
     parentInteractionId: String
     isDeleted: Boolean
-    createdAt: String
+    createdAt: Date
     interactionSteps: [InteractionStepInput]
   }
 


### PR DESCRIPTION
## Description

Use actual GraphQL `Date` type for dates.

## Motivation and Context

`knex` returns Postgres `date` and `datetime`s as Javascript Dates. Previously, Apollo Server serialized these as strings. By default, Date.toString() uses a local format which is undesirable and causes bugs where client code expects to parse ISO-8601 strings.

The values remain as strings on the client because there is no parsing of custom scalars implemented client-side.

It seems like this broke with a recent knex upgrade but I can't find anything in knex's changelog to confirm that. A different option would be to force knex to return dates as strings:

```ts
// src/server/knex.js

const stringifyDates = (records) =>
  (records || []).map((record) =>
    Object.fromEntries(
      Object.entries(record).map(([columnName, value]) => [
        columnName,
        value instanceof Date ? value.toISOString() : value
      ])
    )
  );

const knexConfig = {
  client: "pg",
  postProcessResponse: (result, queryContext) => {
    // Raw result:
    if (Array.isArray(result)) {
      return stringifyDates(result);
    }

    // Query builder result
    result.rows = stringifyDates(result.rows);
    return result;
  },

  // ...
}
```

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
