### PR TITLE
fix: fix draft.js focus behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
     "@rewired/commitlint-circle": "^3.1.0",
     "@types/aphrodite": "^2.0.0",
+    "@types/draft-js": "^0.10.45",
     "@types/express-rate-limit": "^5.1.1",
     "@types/faker": "^5.1.5",
     "@types/lodash": "^4.14.168",

--- a/src/components/ScriptEditor.tsx
+++ b/src/components/ScriptEditor.tsx
@@ -85,7 +85,6 @@ const UnrecognizedField: React.FC = (props) => (
 );
 
 interface Props {
-  name: string;
   scriptText: string;
   scriptFields: string[];
   onChange: (value: string) => Promise<void> | void;
@@ -224,8 +223,6 @@ class ScriptEditor extends React.Component<Props, State> {
   }
 
   render() {
-    const { name } = this.props;
-
     const text = this.state.editorState.getCurrentContent().getPlainText();
     const info = getCharCount(replaceEasyGsmWins(text));
 
@@ -233,7 +230,6 @@ class ScriptEditor extends React.Component<Props, State> {
       <div>
         <div style={styles.editor} onClick={this.focus}>
           <Editor
-            name={name}
             editorState={this.state.editorState}
             onChange={this.onEditorChange}
             ref={(el) => {

--- a/src/components/ScriptEditor.tsx
+++ b/src/components/ScriptEditor.tsx
@@ -109,7 +109,9 @@ class ScriptEditor extends React.Component<Props, State> {
 
   componentDidMount() {
     if (this.props.receiveFocus === true) {
-      this.focus();
+      const { editorState: oldState } = this.state;
+      const editorState = EditorState.moveFocusToEnd(oldState);
+      this.setState({ editorState });
     }
   }
 
@@ -183,9 +185,9 @@ class ScriptEditor extends React.Component<Props, State> {
   };
 
   focus = () => {
-    const { editorState: oldState } = this.state;
-    const editorState = EditorState.moveFocusToEnd(oldState);
-    this.setState({ editorState });
+    if (this.editorRef) {
+      this.editorRef.focus();
+    }
   };
 
   addCustomField = (field: string) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3731,6 +3731,14 @@
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
   integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
 
+"@types/draft-js@^0.10.45":
+  version "0.10.45"
+  resolved "https://registry.yarnpkg.com/@types/draft-js/-/draft-js-0.10.45.tgz#4ab5b0785fcacdea7d5a836d0024158fa8108e70"
+  integrity sha512-ozmVQEI088kGQfY2XPB0b+YRNbkv1mxdxcLieBLCc2F4IkVWMs6mnIaEbBRExmM3H/Amm9CvhlmIYmDL4CjBvA==
+  dependencies:
+    "@types/react" "*"
+    immutable "~3.7.4"
+
 "@types/eslint-scope@^3.7.0":
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.0.tgz#4792816e31119ebd506902a482caec4951fabd86"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Only move the cursor to end of the field's text on mount.

## Motivation and Context

ScriptEditor.focus() is called from the wrapping div's onClick method. This was causing the curor
to move to the end any time the script field was clicked.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
