### PR TITLE
fix: remove timeout fetching instance settings

### DIFF
--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -15,7 +15,4 @@ const main = (settings: InstanceSettings) => {
   ReactDOM.render(<App />, document.getElementById("mount"));
 };
 
-request
-  .get("/settings/instance")
-  .timeout(500)
-  .then(({ body: settings }) => main(settings));
+request.get("/settings/instance").then(({ body: settings }) => main(settings));


### PR DESCRIPTION
## Description

Remove the 500ms timeout on the initial instance settings fetch.

## Motivation and Context

Some users may have consistently slow internet connections that cause the settings fetch to timeout on every request.

## How Has This Been Tested?

This has not been tested.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
