### PR TITLE
fix(manual-assignment): remove unused expensive query

### DIFF
--- a/src/workers/jobs/index.js
+++ b/src/workers/jobs/index.js
@@ -997,27 +997,6 @@ export async function assignTexters(job) {
         })
       );
 
-      // TODO: re-enable once dynamic assignment is fixed (#548)
-      // const isDynamic = campaign.use_dynamic_assignment;
-      const isDynamic = false;
-
-      // dynamic assignments, having zero initially is ok
-      if (!isDynamic) {
-        // TODO - MySQL Specific. Look up in separate query as MySQL does not support LIMIT within subquery
-        // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-        const assignmentIds = await trx("assignment")
-          .select("assignment.id as id")
-          .where("assignment.campaign_id", cid)
-          .leftJoin(
-            "campaign_contact",
-            "assignment.id",
-            "campaign_contact.assignment_id"
-          )
-          .groupBy("assignment.id")
-          .havingRaw("COUNT(campaign_contact.id) = 0")
-          .map((result) => result.id);
-      }
-
       if (job.id) {
         await r.knex("job_request").delete().where({ id: job.id });
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Some clients with larger `campaign_contact` tables reporting manual assignment failing - upon investigation, this query was responsible, sometimes taking over 30 seconds and causing the whole transaction to abort. 

The query could be optimized as:
```sql
 select assignment.id as id 
from assignment 
where not exists (
  select 1
  from campaign_contact 
  where campaign_contact.assignment_id = assignment.id
    and campaign_contact.archived = false
)
and assignment.campaign_id =  $1;
```
but it wasn't being used anyways, so we can just remove it!

The query was originally part of a check to delete assignments which no longer had contacts associated with them, but we don't do that anymore since:
a) We might just end up recreating them in the future, and
b) It violated opt out foreign key constraints

## How Has This Been Tested?

This has not been tested

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

No

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
