### PR TITLE
feat: make slack team sync crontab configurable

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -633,6 +633,10 @@ const validators = {
       "If true, Spoke team membership will be synced with matching Slack channel membership",
     default: false
   }),
+  SLACK_SYNC_CHANNELS_CRONTAB: str({
+    desc: "The crontab schedule to run the team sync on",
+    default: "*/10 * * * *"
+  }),
   STATIC_BASE_URL: str({
     desc: "Alternate static base url",
     example: "https://s3.us-east-1.amazonaws.com/my-spoke-bucket/spoke/static/",

--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -102,7 +102,7 @@ export const getWorker = async (attempt = 0): Promise<PgComposeWorker> => {
       m.cronJobs!.push({
         name: "sync-slack-team-members",
         task_name: "sync-slack-team-members",
-        pattern: `*/10 * * * *`,
+        pattern: config.SLACK_SYNC_CHANNELS_CRONTAB,
         time_zone: config.TZ
       });
     } else {


### PR DESCRIPTION
## Description

Allow overriding the default crontab schedule for the sync Slack teams job.

## Motivation and Context

Some clients require more frequent syncs and have few enough Slack workspace members that this will not cause problems with Slack API rate limits.

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
