### PR TITLE
fix(trollbot): prevent adding invalid tokens

### DIFF
--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -3259,6 +3259,13 @@ const rootMutations = {
     },
     addToken: async (_root, { token, organizationId }, { user }) => {
       await accessRequired(user, organizationId, "SUPERVOLUNTEER");
+
+      try {
+        await r.knex.raw(`select to_tsquery(?)`, [token]);
+      } catch (err) {
+        throw new Error("invalid tsquery token");
+      }
+
       await r
         .knex("troll_trigger")
         .insert({ token, organization_id: parseInt(organizationId, 10) });

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -3257,11 +3257,11 @@ const rootMutations = {
 
       return true;
     },
-    addToken: async (_root, { token, organizationId }, { user }) => {
+    addToken: async (_root, { token, organizationId }, { user, db }) => {
       await accessRequired(user, organizationId, "SUPERVOLUNTEER");
 
       try {
-        await r.knex.raw(`select to_tsquery(?)`, [token]);
+        await db.reader.raw(`select to_tsquery(?)`, [token]);
       } catch (err) {
         throw new Error("invalid tsquery token");
       }


### PR DESCRIPTION
## Description

Prevent adding tokens that will throw an error in `to_tsquery()`.

## Motivation and Context

Invalid tokens will otherwise fail silently at runtime.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This has been tested locally using `c'mon` (valid) and `'c'mon'` (invalid).

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
