### PR TITLE
fix(canned-responses): restore dialog to full width

### DIFF
--- a/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/components/CannedResponseDialog.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/components/CannedResponseDialog.tsx
@@ -30,7 +30,7 @@ const CannedResponseDialog: React.FC<CannedResponseDialogProps> = (props) => {
   const title = getTitleContext(context);
 
   return (
-    <Dialog open={open}>
+    <Dialog open={open} fullWidth maxWidth={false}>
       <DialogTitle>{title}</DialogTitle>
       <DialogContent>
         <CannedResponseEditor {...props} />

--- a/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/components/CannedResponseDialog.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/components/CannedResponseDialog.tsx
@@ -24,7 +24,7 @@ const getTitleContext = (context: ResponseEditorContext) => {
   }
 };
 
-const CannedResponseDialog: React.SFC<CannedResponseDialogProps> = (props) => {
+const CannedResponseDialog: React.FC<CannedResponseDialogProps> = (props) => {
   const { open, context } = props;
 
   const title = getTitleContext(context);


### PR DESCRIPTION
## Description

Restore the canned response dialog to full width.

## Motivation and Context

This is how it was previously and is much easier to draft in.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
