### PR TITLE
feat: add button to remove all users from organization

### DIFF
--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -292,6 +292,7 @@ const rootSchema = `
     joinOrganization(organizationUuid: String!): Organization!
     editOrganizationMembership(id: String!, level: RequestAutoApprove, role: String): OrganizationMembership!
     editOrganizationSettings(id: String!, input: OrganizationSettingsInput!): OranizationSettings!
+    purgeOrganizationUsers(organizationId: String!): Int!
     editUser(organizationId: String!, userId: Int!, userData:UserInput): User
     resetUserPassword(organizationId: String!, userId: Int!): String!
     changeUserPassword(userId: Int!, formData: UserPasswordChange): User

--- a/src/containers/AdminPeople/Dialogs.tsx
+++ b/src/containers/AdminPeople/Dialogs.tsx
@@ -1,3 +1,4 @@
+import Button from "@material-ui/core/Button";
 import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
@@ -135,10 +136,45 @@ const ConfirmSuperAdmin: React.StatelessComponent<ConfirmSuperAdminProps> = ({
   </div>
 );
 
+interface ConfirmRemoveUsersProps {
+  open: boolean;
+  onClose: () => Promise<void> | void;
+  onConfirmRemoveUsers: () => Promise<void> | void;
+}
+
+const ConfirmRemoveUsers: React.FC<ConfirmRemoveUsersProps> = ({
+  open,
+  onClose,
+  onConfirmRemoveUsers
+}) => (
+  <Dialog open={open} onClose={onClose}>
+    <DialogTitle>Confirm Remove Users</DialogTitle>
+    <DialogContent>
+      This will remove all users from the organization who are not Superadmins.
+      Are you sure you would like to do this?
+    </DialogContent>
+    <DialogActions>
+      <Button {...dataTest("removeUsersCancel")} onClick={onClose}>
+        Cancel
+      </Button>
+      <Button
+        {...dataTest("removeUsersOk")}
+        onClick={onConfirmRemoveUsers}
+        variant="contained"
+        color="primary"
+        autoFocus
+      >
+        Confirm
+      </Button>
+    </DialogActions>
+  </Dialog>
+);
+
 const Dialogs = {
   InvitePerson,
   EditPerson,
   ResetPassword,
-  ConfirmSuperAdmin
+  ConfirmSuperAdmin,
+  ConfirmRemoveUsers
 };
 export default Dialogs;

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -984,6 +984,29 @@ const rootMutations = {
       return orgMembership;
     },
 
+    purgeOrganizationUsers: async (
+      _root,
+      { organizationId },
+      { user: authUser, db }
+    ) => {
+      const orgId = parseInt(organizationId, 10);
+      await accessRequired(authUser, orgId, "OWNER", true);
+      const { rowCount } = await db.primary.raw(
+        `
+          delete
+          from user_organization uo
+          using public.user u
+          where
+            u.id = uo.user_id
+            and u.is_superadmin is not true
+            and uo.organization_id = ?
+            and uo.role <> 'OWNER'
+        `,
+        [orgId]
+      );
+      return rowCount;
+    },
+
     editOrganizationSettings: async (
       _root,
       { id, input },


### PR DESCRIPTION
## Description

Allow organization owners to remove all users from an organization.

## Motivation and Context

This has become a semi-frequent source of help desk tickets.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

![Fullscreen_4_8_21__11_11_AM](https://user-images.githubusercontent.com/2145526/114052401-07310b80-985c-11eb-92b4-a2391e31a869.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A -- this is a self-documenting feature.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
