### PR TITLE
feat(p2): add toggle for excluding newer contacts

### DIFF
--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -278,6 +278,11 @@ const rootSchema = `
     externalLists(organizationId: String!, systemId: String!, after: Cursor, first: Int): ExternalListPage!
   }
 
+  input SecondPassInput {
+    excludeAgeInHours: Float
+    excludeNewer: Boolean!
+  }
+
   type RootMutation {
     createInvite(invite:InviteInput!): Invite
     createCampaign(campaign:CampaignInput!): Campaign
@@ -327,7 +332,7 @@ const rootSchema = `
     requestTexts(count: Int!, email: String!, organizationId: String!, preferredTeamId: Int!): String!
     releaseMessages(campaignId: String!, target: ReleaseActionTarget!, ageInHours: Float): String!
     releaseAllUnhandledReplies(organizationId: String!, ageInHours: Float, releaseOnRestricted: Boolean, limitToCurrentlyTextableContacts: Boolean): ReleaseAllUnhandledRepliesResult!
-    markForSecondPass(campaignId: String!, excludeAgeInHours: Float): String!
+    markForSecondPass(campaignId: String!, input: SecondPassInput!): String!
     unMarkForSecondPass(campaignId: String!): String!
     deleteNeedsMessage(campaignId: String!): String!
     insertLinkDomain(organizationId: String!, domain: String!, maxUsageCount: Int!): LinkDomain!

--- a/src/containers/CampaignList/CampaignListMenu.tsx
+++ b/src/containers/CampaignList/CampaignListMenu.tsx
@@ -47,6 +47,7 @@ export const CampaignListMenu: React.FC<Props> = (props) => {
       <MenuItem
         primaryText="Mark for a Second Pass"
         onClick={startOperation("markForSecondPass", campaign, {
+          excludeNewer: true,
           excludeRecentlyTexted: true,
           days: 3,
           hours: 0

--- a/src/containers/CampaignList/OperationDialog.jsx
+++ b/src/containers/CampaignList/OperationDialog.jsx
@@ -22,12 +22,8 @@ export const operations = {
   markForSecondPass: {
     title: (campaign) =>
       `Mark Unresponded to Messages in ${campaign.title} for a Second Pass`,
-    body: () => `Marking unresponded to messages for this campaign will reset the state of messages that have\
-      not been responded to by the contact, causing them to show up as needing a first text, as long as the campaign\
-      is not past due. After running this operation, the texts will still be assigned to the same texter, so please\
-      run 'Release Unsent Messages' after if you'd like these second pass messages to be available for auto-assignment.\
-      \n\
-      Note: you should not run this operation if all initial messages have not yet been sent.`
+    body: () => `Marking messages that have not been responded to on this campaign will reset the state of those\
+      messages, causing them to show up as needing a first text for a second time.`
   },
   releaseUnrepliedMessages: {
     title: (campaign) =>
@@ -116,53 +112,31 @@ export const OperationDialogBody = (props) => {
   }
 
   if (operationName === "markForSecondPass") {
-    const { excludeRecentlyTexted, days, hours } = operationArs;
+    const { excludeNewer, excludeRecentlyTexted, days, hours } = operationArs;
     return (
       <div>
         <p>{operationDefinition.body(campaign)}</p>
+        <p>
+          To read about best practices for second passes, head{" "}
+          <a
+            href="https://docs.spokerewired.com/article/101-running-a-second-pass"
+            rel="noreferrer"
+            target="_blank"
+          >
+            here
+          </a>
+          .
+        </p>
         <br />
-        <Toggle
-          label="Exclude recently texted contacts?"
-          toggled={excludeRecentlyTexted}
-          onToggle={(ev, val) =>
-            setState((prevState) => {
-              const nextInProgress = prevState.inProgress.slice();
-              nextInProgress[2].excludeRecentlyTexted = val;
-              return {
-                inProgress: nextInProgress
-              };
-            })
-          }
-        />
-        {excludeRecentlyTexted && (
-          <p>Exlcude contacts messaged within the last:</p>
-        )}
-        {excludeRecentlyTexted && (
-          <div style={{ display: "flex" }}>
-            <TextField
-              style={{ flexGrow: 1, margin: "10px" }}
-              type="number"
-              floatingLabelText="Number of Days"
-              value={days}
-              onChange={(ev, val) =>
+        <div style={{ width: "100%", display: "flex", flexDirection: "row" }}>
+          <div style={{ flexGrow: 1 }}>
+            <Toggle
+              label="Exclude recently texted contacts?"
+              toggled={excludeRecentlyTexted}
+              onToggle={(ev, val) =>
                 setState((prevState) => {
                   const nextInProgress = prevState.inProgress.slice();
-                  nextInProgress[2].days = parseInt(val, 10);
-                  return {
-                    inProgress: nextInProgress
-                  };
-                })
-              }
-            />
-            <TextField
-              style={{ flexGrow: 1, margin: "10px" }}
-              type="number"
-              floatingLabelText="Number of Hours"
-              value={hours}
-              onChange={(ev, val) =>
-                setState((prevState) => {
-                  const nextInProgress = prevState.inProgress.slice();
-                  nextInProgress[2].hours = parseInt(val, 10);
+                  nextInProgress[2].excludeRecentlyTexted = val;
                   return {
                     inProgress: nextInProgress
                   };
@@ -170,7 +144,59 @@ export const OperationDialogBody = (props) => {
               }
             />
           </div>
-        )}
+          <div style={{ flexGrow: 1 }}>
+            {excludeRecentlyTexted &&
+              "Exlcude contacts messaged within the last:"}
+            {excludeRecentlyTexted && (
+              <div style={{ display: "flex" }}>
+                <TextField
+                  style={{ flexGrow: 1, margin: "10px" }}
+                  type="number"
+                  floatingLabelText="Number of Days"
+                  value={days}
+                  onChange={(ev, val) =>
+                    setState((prevState) => {
+                      const nextInProgress = prevState.inProgress.slice();
+                      nextInProgress[2].days = parseInt(val, 10);
+                      return {
+                        inProgress: nextInProgress
+                      };
+                    })
+                  }
+                />
+                <TextField
+                  style={{ flexGrow: 1, margin: "10px" }}
+                  type="number"
+                  floatingLabelText="Number of Hours"
+                  value={hours}
+                  onChange={(ev, val) =>
+                    setState((prevState) => {
+                      const nextInProgress = prevState.inProgress.slice();
+                      nextInProgress[2].hours = parseInt(val, 10);
+                      return {
+                        inProgress: nextInProgress
+                      };
+                    })
+                  }
+                />
+              </div>
+            )}
+          </div>
+        </div>
+        <br />
+        <Toggle
+          label="Exclude contacts uploaded on a newer campaign?"
+          toggled={excludeNewer}
+          onToggle={(ev, val) =>
+            setState((prevState) => {
+              const nextInProgress = prevState.inProgress.slice();
+              nextInProgress[2].excludeNewer = val;
+              return {
+                inProgress: nextInProgress
+              };
+            })
+          }
+        />
       </div>
     );
   }
@@ -245,7 +271,7 @@ export class OperationDialog extends React.Component {
         ];
 
     return (
-      <Dialog open onClose={clearInProgress}>
+      <Dialog open maxWidth="lg" onClose={clearInProgress}>
         <DialogTitle>{operationDefinition.title(campaign)}</DialogTitle>
         <DialogContent>
           <OperationDialogBody {...this.props} />

--- a/src/containers/CampaignList/index.jsx
+++ b/src/containers/CampaignList/index.jsx
@@ -140,22 +140,22 @@ const mutations = {
   }),
   markForSecondPass: (_ownProps) => (
     campaignId,
-    { excludeRecentlyTexted, days, hours }
+    { excludeNewer, excludeRecentlyTexted, days, hours }
   ) => ({
     mutation: gql`
       mutation markForSecondPass(
         $campaignId: String!
-        $excludeAgeInHours: Float
+        $input: SecondPassInput!
       ) {
-        markForSecondPass(
-          campaignId: $campaignId
-          excludeAgeInHours: $excludeAgeInHours
-        )
+        markForSecondPass(campaignId: $campaignId, input: $input)
       }
     `,
     variables: {
-      excludeAgeInHours: excludeRecentlyTexted ? days * 24 + hours : undefined,
-      campaignId
+      campaignId,
+      input: {
+        excludeNewer,
+        excludeAgeInHours: excludeRecentlyTexted ? days * 24 + hours : undefined
+      }
     }
   }),
   releaseUnrepliedMessages: (_ownProps) => (campaignId, { ageInHours }) => ({

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -2182,7 +2182,7 @@ const rootMutations = {
 
     markForSecondPass: async (
       _ignore,
-      { campaignId, excludeAgeInHours },
+      { campaignId, input: { excludeAgeInHours, excludeNewer } },
       { user }
     ) => {
       // verify permissions
@@ -2200,21 +2200,7 @@ const rootMutations = {
         queryArgs.push(parseFloat(excludeAgeInHours));
       }
 
-      /**
-       * "Mark Campaign for Second Pass", will only mark contacts for a second
-       * pass that do not have a more recently created membership in another campaign.
-       * Using SQL injection to avoid passing archived as a binding
-       * Should help with guaranteeing partial index usage
-       */
-      const updateResultRaw = await r.knex.raw(
-        `
-        update
-          campaign_contact as current_contact
-        set
-          message_status = 'needsMessage'
-        where current_contact.campaign_id = ?
-          and current_contact.message_status = 'messaged'
-          and current_contact.archived = ${campaign.is_archived}
+      const excludeNewerSql = `
           and not exists (
             select
               cell
@@ -2224,6 +2210,23 @@ const rootMutations = {
               newer_contact.cell = current_contact.cell
               and newer_contact.created_at > current_contact.created_at
           )
+      `;
+
+      /**
+       * "Mark Campaign for Second Pass", will only mark contacts for a second
+       * pass that do not have a more recently created membership in another campaign.
+       * Using SQL injection to avoid passing archived as a binding
+       * Should help with guaranteeing partial index usage
+       */
+      const updateSql = `
+        update
+          campaign_contact as current_contact
+        set
+          message_status = 'needsMessage'
+        where current_contact.campaign_id = ?
+          and current_contact.message_status = 'messaged'
+          and current_contact.archived = ${campaign.is_archived}
+          ${excludeNewer ? excludeNewerSql : ""}
           and not exists (
             select 1
             from message
@@ -2236,10 +2239,9 @@ const rootMutations = {
               : ""
           }
         ;
-      `,
-        queryArgs
-      );
+      `;
 
+      const updateResultRaw = await r.knex.raw(updateSql, queryArgs);
       const updateResult = updateResultRaw.rowCount;
 
       return `Marked ${updateResult} campaign contacts for a second pass.`;


### PR DESCRIPTION
## Description

This adds a new toggle to the "Mark for second pass" operation dialog. The toggle controls whether to exclude from the operation contacts that have been uploaded in a newer campaign.

## Motivation and Context

Closes #935

## How Has This Been Tested?


The value of `updateSql` has been verified locally.

## Screenshots (if appropriate):

<table><tr><td>

<img width="1439" alt="Spoke" src="https://user-images.githubusercontent.com/2145526/114554330-99f2f100-9c34-11eb-91ef-3a71aa9628c3.png">

</td></tr></table>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

@kohlee has already drafted an update for documentation at https://docs.spokerewired.com/article/101-running-a-second-pass

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] My change requires a change to the documentation.
- [x] I have included updates for the documentation accordingly.
