### PR TITLE
fix: assemble numbers process delivery report

### DIFF
--- a/migrations/20210414202903_backfill-num-segments.js
+++ b/migrations/20210414202903_backfill-num-segments.js
@@ -1,0 +1,57 @@
+exports.up = (knex) => {
+  return knex.schema.raw(`
+    create or replace function backfill_segment_info(min_log_id bigint, max_log_id bigint)
+    returns bigint as $$
+      with info as (
+        select body::json->>'messageId' as service_id,
+          (body::json->'extra'->>'num_segments')::smallint as num_segments,
+          (body::json->'extra'->>'num_media')::smallint as num_media
+        from log
+        where id >= min_log_id
+          and id <= max_log_id
+      ),
+      update_result as (
+        update message
+        set num_segments = info.num_segments,
+            num_media = info.num_media
+        from info
+        where info.service_id = message.service_id
+        returning 1
+      )
+      select count(*)
+      from update_result
+    $$ language sql;
+
+    create or replace procedure backfill_all_segment_info(initial_min bigint, batch_size bigint) as $$
+    declare
+      v_current_min_log_id bigint;
+      v_max_log_id bigint;
+      v_count_updated bigint;
+    begin
+      select max(id)
+      from log
+      into v_max_log_id;
+      
+      select initial_min into v_current_min_log_id;
+
+      while v_current_min_log_id < v_max_log_id loop
+        select backfill_segment_info(v_current_min_log_id, v_current_min_log_id + batch_size)
+        into v_count_updated;
+    
+        raise notice 'Updated %s between %s and %s', 
+          v_count_updated, v_current_min_log_id, v_current_min_log_id + batch_size;
+
+        select v_current_min_log_id + batch_size
+        into v_current_min_log_id;
+      end loop;
+    end;
+    $$ language plpgsql;
+  `);
+};
+
+exports.down = (knex) => {
+  return knex.schema.raw(`
+    drop procedure backfill_all_segment_info;
+    drop function backfill_segment_info;
+  `);
+};

--- a/src/server/api/lib/assemble-numbers.ts
+++ b/src/server/api/lib/assemble-numbers.ts
@@ -279,7 +279,10 @@ export const processDeliveryReport = async (
     if (extra) {
       const payload: Record<string, unknown> = {};
 
-      if (extra.num_segments && extra.num_media) {
+      if (
+        typeof extra.num_segments === "number" ||
+        typeof extra.num_media === "number"
+      ) {
         payload.num_segments = extra.num_segments;
         payload.num_media = extra.num_media;
       }


### PR DESCRIPTION
## Description

This fixes `assemble-numbers.processDeliveryReport` to property write `num_segments` and `num_media` to the message when handling delivery reports.

The issue was that either `num_segments` or `num_media` was often 0, and 0 is falsy. As a result, that if statement that execute the update never ran.

This checks that at least one of them is a number instead.

This PR also adds a PostgreSQL procedure to easily backfill that data. After the included migration has run, just run:
```sql
call backfill_all_segment_info(0, 5000);
```
On the database, and the information will be backfilled.

## How Has This Been Tested?

In a local Node REPL with the external variables mocked.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
