### PR TITLE
fix: fix admin navigation menu rotation in firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@babel/runtime-corejs3": "^7.9.2",
     "@google-cloud/storage": "^5.7.4",
     "@material-ui/core": "^4.11.3",
+    "@material-ui/icons": "^4.11.2",
     "@passport-next/passport": "^3.1.0",
     "@rewired/passport-slack": "^1.0.6",
     "@slack/web-api": "^6.0.0",

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,7 +1,9 @@
+import IconButton from "@material-ui/core/IconButton";
 import { useTheme } from "@material-ui/core/styles";
+import ArrowBackIosIcon from "@material-ui/icons/ArrowBackIos";
+import ArrowForwardIosIcon from "@material-ui/icons/ArrowForwardIos";
 import { css, StyleSheet } from "aphrodite";
 import camelCase from "lodash/camelCase";
-import { FlatButton } from "material-ui";
 import Avatar from "material-ui/Avatar";
 import Divider from "material-ui/Divider";
 import { List, ListItem } from "material-ui/List";
@@ -14,13 +16,7 @@ import { dataTest } from "../lib/attributes";
 const styles = StyleSheet.create({
   sideBarWithMenu: {
     width: 256,
-    height: "100%",
-    writingMode: "sideways-lr"
-  },
-  sideBarWithoutMenu: {
-    writingMode: "vertical-rl",
-    padding: "5px",
-    paddingTop: "20px"
+    height: "100%"
   }
 });
 
@@ -29,6 +25,7 @@ export interface NavigationSection {
   path: string;
   role: string;
   badge?: { count: number };
+  url: string;
 }
 
 interface Props {
@@ -54,7 +51,9 @@ const Navigation: React.FC<Props> = (props) => {
           }}
         >
           <div style={{ display: "flex", justifyContent: "flex-end" }}>
-            <FlatButton label="Close Menu" onClick={props.onToggleMenu} />
+            <IconButton onClick={props.onToggleMenu}>
+              <ArrowBackIosIcon />
+            </IconButton>
           </div>
           <List>
             {sections.map((section) => (
@@ -83,12 +82,9 @@ const Navigation: React.FC<Props> = (props) => {
     );
   }
   return (
-    <div
-      className={css(styles.sideBarWithoutMenu)}
-      onClick={props.onToggleMenu}
-    >
-      <span style={{ cursor: "pointer" }}>SHOW MENU</span>
-    </div>
+    <IconButton onClick={props.onToggleMenu}>
+      <ArrowForwardIosIcon />
+    </IconButton>
   );
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3070,6 +3070,13 @@
     react-is "^16.8.0 || ^17.0.0"
     react-transition-group "^4.4.0"
 
+"@material-ui/icons@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.11.2.tgz#b3a7353266519cd743b6461ae9fdfcb1b25eb4c5"
+  integrity sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+
 "@material-ui/styles@^4.11.3":
   version "4.11.3"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.3.tgz#1b8d97775a4a643b53478c895e3f2a464e8916f2"


### PR DESCRIPTION
## Description

Fix rotation of admin navigation menu in Firefox.

## Motivation and Context

It seems like Firefox is the only browser to have implemented `writing-mode` correctly. This property was being used to rotate the menu button in the collapsed state but was also being used incorrectly on the expanded menu.

Element rotation is hard. This replaces the text buttons with icon buttons to alleviate the need for rotation entirely.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<table>
<tr>
<td>
<img width="232" alt="Screen Shot 2021-04-15 at 3 25 10 PM" src="https://user-images.githubusercontent.com/2145526/114926802-c65a6900-9dfe-11eb-9259-f816b13491d4.png">
</td>
<td>
<img width="514" alt="Screen Shot 2021-04-15 at 3 26 13 PM" src="https://user-images.githubusercontent.com/2145526/114926943-ec800900-9dfe-11eb-9193-4aa627fd6878.png">
</td>
</tr>
<tr>
<td>Chrome - Closed</td>
<td>Chrome - Open</td>
</tr>

<tr>
<td>

<img width="321" alt="Screen Shot 2021-04-15 at 3 26 57 PM" src="https://user-images.githubusercontent.com/2145526/114927070-133e3f80-9dff-11eb-8d8d-4400a30e3270.png">

</td>
<td>

<img width="512" alt="Screen Shot 2021-04-15 at 3 27 43 PM" src="https://user-images.githubusercontent.com/2145526/114927115-20f3c500-9dff-11eb-80ed-031ec1c6f848.png">

</td>
</tr>
<tr>
<td>Firefox - Closed</td>
<td>Firefox - Open</td>
</tr>
</table>


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
