### PR TITLE
feat(trollbot): improve navigation of troll alarms

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
     "timezonecomplete": "^5.11.0",
     "twilio": "^2.11.0",
     "tzdata": "^1.0.18",
+    "use-query-params": "^1.2.2",
     "uuid": "^3.1.0",
     "winston": "^3.2.1",
     "yup": "^0.32.9",

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -3,8 +3,9 @@ import { css, StyleSheet } from "aphrodite";
 import MuiThemeProviderv0 from "material-ui/styles/MuiThemeProvider";
 import React, { useEffect, useState } from "react";
 import { ApolloProvider } from "react-apollo";
-import { BrowserRouter as Router } from "react-router-dom";
+import { BrowserRouter as Router, Route } from "react-router-dom";
 import request from "superagent";
+import { QueryParamProvider } from "use-query-params";
 
 import ApolloClientSingleton from "../network/apollo-client-singleton";
 import AppRoutes from "../routes";
@@ -41,7 +42,9 @@ const App: React.FC = () => {
             <div className={css(styles.root)}>
               <VersionNotifier />
               <Router>
-                <AppRoutes />
+                <QueryParamProvider ReactRouterRoute={Route}>
+                  <AppRoutes />
+                </QueryParamProvider>
               </Router>
             </div>
           </ApolloProvider>

--- a/src/containers/AdminTrollAlarms/index.tsx
+++ b/src/containers/AdminTrollAlarms/index.tsx
@@ -10,8 +10,14 @@ import Paper from "material-ui/Paper";
 import RaisedButton from "material-ui/RaisedButton";
 import Snackbar from "material-ui/Snackbar";
 import Toggle from "material-ui/Toggle";
-import React from "react";
+import React, { useState } from "react";
 import { RouteChildrenProps } from "react-router-dom";
+import {
+  BooleanParam,
+  NumberParam,
+  StringParam,
+  useQueryParam
+} from "use-query-params";
 
 import { TrollAlarm } from "../../api/trollbot";
 import { dataSourceItem, DataSourceItemType } from "../../components/utils";
@@ -42,98 +48,92 @@ interface Props
   };
 }
 
-interface State {
-  tokenSearchText: string;
-  copiedAlarmID?: string;
-  pageSize: number;
-  page: number;
-  dismissed: boolean;
-  token: string | null;
-  selectedAlarmIds: string[];
-  isWorking: boolean;
-  error?: string;
-}
+const AdminTrollAlarms: React.FC<Props> = (props) => {
+  // UI Widgets
+  const [tokenSearchText, setTokenSearchText] = useState("");
+  const [copiedAlarmID, setCopiedAlarmID] = useState<string | undefined>(
+    undefined
+  );
 
-class AdminTrollAlarms extends React.Component<Props, State> {
-  state: State = {
-    // UI Widgets
-    tokenSearchText: "",
-    copiedAlarmID: undefined,
+  // Operations
+  const [selectedAlarmIds, setSelectedAlarmIds] = useState<string[]>([]);
+  const [isWorking, setIsWorking] = useState(false);
+  const [error, setError] = useState<string | undefined>(undefined);
 
-    // Query params
-    pageSize: 25,
-    page: 0,
-    dismissed: false,
-    token: null,
+  // Query params
+  const [pageSize, setPageSize] = useQueryParam("pageSize", NumberParam);
+  const [page, setPage] = useQueryParam("page", NumberParam);
+  const [dismissed, setDismissed] = useQueryParam("dismissed", BooleanParam);
+  const [token, setToken] = useQueryParam("token", StringParam);
 
-    // Operations
-    selectedAlarmIds: [],
-    isWorking: false,
-    error: undefined
-  };
-
-  handleOnCancelError = () => this.setState({ error: undefined });
+  const handleOnCancelError = () => setError(undefined);
 
   // Query conditions
-  handleFocusTokenSearch = () =>
-    this.setState({ tokenSearchText: "", token: null });
+  const handleFocusTokenSearch = () => {
+    setTokenSearchText("");
+    setToken(null);
+  };
 
-  handleTokenSearchTextChange = (tokenSearchText: string) =>
-    this.setState({ tokenSearchText });
+  const handleTokenSearchTextChange = (newTokenSearchText: string) =>
+    setTokenSearchText(newTokenSearchText);
 
-  handleTokenSelected = (
+  const handleTokenSelected = (
     selection: DataSourceItemType | string,
     index: number
   ) => {
-    let token: string | null = null;
+    let foundToken: string | null = null;
     if (index > -1 && typeof selection !== "string") {
-      token = selection.value.key as string;
+      foundToken = selection.value.key as string;
     } else {
-      const { trollTokens } = this.props.trollTokens;
-      token =
+      const { trollTokens } = props.trollTokens;
+      foundToken =
         trollTokens.find(({ token: trollToken }) => trollToken === selection)
           ?.token ?? null;
     }
-    if (token) {
-      this.setState({ token, selectedAlarmIds: [] });
+    if (foundToken) {
+      setToken(foundToken);
+      setSelectedAlarmIds([]);
     }
   };
 
-  handleToggleDismissed = (_event: any, dismissed: boolean) =>
-    this.setState({ dismissed, selectedAlarmIds: [] });
+  const handleToggleDismissed = (_event: any, newDismissed: boolean) => {
+    setPage(0);
+    setDismissed(newDismissed);
+    setSelectedAlarmIds([]);
+  };
 
   // Actions
-  handleDismissSelected = async () => {
-    const { selectedAlarmIds } = this.state;
-    this.setState({ isWorking: true, error: undefined });
+  const handleDismissSelected = async () => {
+    setIsWorking(true);
+    setError(undefined);
     try {
-      await this.props.mutations.dismissAlarms(selectedAlarmIds);
-      this.setState({ selectedAlarmIds: [] });
+      await props.mutations.dismissAlarms(selectedAlarmIds);
+      setSelectedAlarmIds([]);
     } catch (err) {
-      this.setState({ error: err.message });
+      setError(err.message);
     } finally {
-      this.setState({ isWorking: false });
+      setIsWorking(false);
     }
   };
 
-  handleDismissMatching = async () => {
-    const { token } = this.state;
+  const handleDismissMatching = async () => {
     if (!token) return;
 
-    this.setState({ isWorking: true, error: undefined });
+    setIsWorking(true);
+    setError(undefined);
     try {
-      await this.props.mutations.dismissMatchingAlarms(token);
-      this.setState({ selectedAlarmIds: [] });
+      await props.mutations.dismissMatchingAlarms(token);
+      setSelectedAlarmIds([]);
     } catch (err) {
-      this.setState({ error: err.message });
+      setError(err.message);
     } finally {
-      this.setState({ isWorking: false });
+      setIsWorking(false);
     }
   };
 
-  handleDismissCopyAlarm = () => this.setState({ copiedAlarmID: undefined });
+  const handleDismissCopyAlarm = () => setCopiedAlarmID(undefined);
 
-  handleCopyAlarm = (alarm: TrollAlarm) => {
+  const handleCopyAlarm = (alarm: TrollAlarm) => {
     const clipboardContents = [
       `Triggered Token: ${alarm.token}`,
       `Campaign ID: ${alarm.contact.campaign.id}`,
@@ -147,110 +147,106 @@ class AdminTrollAlarms extends React.Component<Props, State> {
 
     try {
       navigator.clipboard.writeText(clipboardContents);
-      this.setState({ copiedAlarmID: alarm.id });
+      setCopiedAlarmID(alarm.id);
     } catch (err) {
-      this.setState({ error: err.message });
+      setError(err.message);
     }
   };
 
   // Table selection
-  handleAlarmSelectionChange = (selectedAlarmIds: string[]) =>
-    this.setState({ selectedAlarmIds });
+  const handleAlarmSelectionChange = (newSelectedAlarmIds: string[]) =>
+    setSelectedAlarmIds(newSelectedAlarmIds);
 
   // Pagination
-  handlePageSizeChange = (pageSize: number) => this.setState({ pageSize });
+  const handlePageSizeChange = (newPageSize: number) =>
+    setPageSize(newPageSize);
 
-  handlePageChange = (page: number) => this.setState({ page });
+  const handlePageChange = (newPage: number) => setPage(newPage);
 
-  render() {
-    const { tokenSearchText, copiedAlarmID } = this.state;
-    const { pageSize, page, dismissed, token } = this.state;
-    const { selectedAlarmIds, isWorking, error } = this.state;
-    const { match } = this.props;
+  const { match } = props;
 
-    const { trollTokens } = this.props.trollTokens;
-    const dataSource = trollTokens.map(({ token: trollToken }) =>
-      dataSourceItem(trollToken, trollToken)
-    );
+  const { trollTokens } = props.trollTokens;
+  const dataSource = trollTokens.map(({ token: trollToken }) =>
+    dataSourceItem(trollToken, trollToken)
+  );
 
-    const deleteAllSuffix = token ? `"${token}"` : "Token";
-    const isDeleteSelectedDisabled = selectedAlarmIds.length === 0 || isWorking;
+  const deleteAllSuffix = token ? `"${token}"` : "Token";
+  const isDeleteSelectedDisabled = selectedAlarmIds.length === 0 || isWorking;
 
-    const errorActions = [
-      <FlatButton
-        key="close"
-        label="Close"
-        primary
-        onClick={this.handleOnCancelError}
+  const errorActions = [
+    <FlatButton
+      key="close"
+      label="Close"
+      primary
+      onClick={handleOnCancelError}
+    />
+  ];
+
+  return (
+    <div>
+      <Paper style={styles.controlsContainer}>
+        <AutoComplete
+          floatingLabelText="Token"
+          hintText="Search for a trigger token"
+          style={{ marginRight: "10px", ...styles.controlsColumn }}
+          fullWidth
+          maxSearchResults={8}
+          searchText={tokenSearchText}
+          dataSource={dataSource}
+          filter={AutoComplete.caseInsensitiveFilter}
+          onFocus={handleFocusTokenSearch}
+          onUpdateInput={handleTokenSearchTextChange}
+          onNewRequest={handleTokenSelected}
+        />
+        <Toggle
+          label="Dismissed Alarms"
+          style={{ ...styles.controlsColumn, width: "0px" }}
+          onToggle={handleToggleDismissed}
+          toggled={dismissed}
+        />
+        <RaisedButton
+          label={`Dismiss All Matching ${deleteAllSuffix}`}
+          style={{ marginRight: "10px" }}
+          secondary
+          disabled={token === null}
+          onClick={handleDismissMatching}
+        />
+        <RaisedButton
+          label={`Dismiss Selected (${selectedAlarmIds.length})`}
+          secondary
+          disabled={isDeleteSelectedDisabled}
+          onClick={handleDismissSelected}
+        />
+      </Paper>
+      <br />
+      <TrollAlarmList
+        organizationId={match?.params.organizationId}
+        pageSize={pageSize ?? 25}
+        page={page ?? 0}
+        dismissed={dismissed ?? false}
+        token={token ?? null}
+        selectedAlarmIds={selectedAlarmIds}
+        onAlarmSelectionChange={handleAlarmSelectionChange}
+        onPageSizeChange={handlePageSizeChange}
+        onPageChange={handlePageChange}
+        onCopyAlarm={handleCopyAlarm}
       />
-    ];
-
-    return (
-      <div>
-        <Paper style={styles.controlsContainer}>
-          <AutoComplete
-            floatingLabelText="Token"
-            hintText="Search for a trigger token"
-            style={{ marginRight: "10px", ...styles.controlsColumn }}
-            fullWidth
-            maxSearchResults={8}
-            searchText={tokenSearchText}
-            dataSource={dataSource}
-            filter={AutoComplete.caseInsensitiveFilter}
-            onFocus={this.handleFocusTokenSearch}
-            onUpdateInput={this.handleTokenSearchTextChange}
-            onNewRequest={this.handleTokenSelected}
-          />
-          <Toggle
-            label="Dismissed Alarms"
-            style={{ ...styles.controlsColumn, width: "0px" }}
-            onToggle={this.handleToggleDismissed}
-            toggled={dismissed}
-          />
-          <RaisedButton
-            label={`Dismiss All Matching ${deleteAllSuffix}`}
-            style={{ marginRight: "10px" }}
-            secondary
-            disabled={token === null}
-            onClick={this.handleDismissMatching}
-          />
-          <RaisedButton
-            label={`Dismiss Selected (${selectedAlarmIds.length})`}
-            secondary
-            disabled={isDeleteSelectedDisabled}
-            onClick={this.handleDismissSelected}
-          />
-        </Paper>
-        <br />
-        <TrollAlarmList
-          organizationId={match?.params.organizationId}
-          pageSize={pageSize}
-          page={page}
-          dismissed={dismissed}
-          token={token}
-          selectedAlarmIds={selectedAlarmIds}
-          onAlarmSelectionChange={this.handleAlarmSelectionChange}
-          onPageSizeChange={this.handlePageSizeChange}
-          onPageChange={this.handlePageChange}
-          onCopyAlarm={this.handleCopyAlarm}
-        />
-        <Dialog open={error !== undefined} onClose={this.handleOnCancelError}>
-          <DialogTitle>Error</DialogTitle>
-          <DialogContent>
-            <DialogContentText>{error || ""}</DialogContentText>
-          </DialogContent>
-          <DialogActions>{errorActions}</DialogActions>
-        </Dialog>
-        <Snackbar
-          open={copiedAlarmID !== undefined}
-          message={`Alarm ${copiedAlarmID || ""} details copied to clipboard`}
-          autoHideDuration={4000}
-          onRequestClose={this.handleDismissCopyAlarm}
-        />
-      </div>
-    );
-  }
-}
+      <Dialog open={error !== undefined} onClose={handleOnCancelError}>
+        <DialogTitle>Error</DialogTitle>
+        <DialogContent>
+          <DialogContentText>{error || ""}</DialogContentText>
+        </DialogContent>
+        <DialogActions>{errorActions}</DialogActions>
+      </Dialog>
+      <Snackbar
+        open={copiedAlarmID !== undefined}
+        message={`Alarm ${copiedAlarmID || ""} details copied to clipboard`}
+        autoHideDuration={4000}
+        onRequestClose={handleDismissCopyAlarm}
+      />
+    </div>
+  );
+};
 
 const queries: QueryMap<Props> = {
   trollTokens: {

--- a/src/containers/AdminTrollAlarms/index.tsx
+++ b/src/containers/AdminTrollAlarms/index.tsx
@@ -190,6 +190,7 @@ const AdminTrollAlarms: React.FC<Props> = (props) => {
           hintText="Search for a trigger token"
           style={{ marginRight: "10px", ...styles.controlsColumn }}
           fullWidth
+          value={token ?? undefined}
           maxSearchResults={8}
           searchText={tokenSearchText}
           dataSource={dataSource}

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -3893,7 +3893,7 @@ const rootResolvers = {
           "campaign_contact.first_name as cc_first_name",
           "campaign_contact.last_name as cc_last_name"
         )
-        .orderBy("troll_alarm.message_id")
+        .orderBy("troll_alarm.message_id", "desc")
         .limit(limit)
         .offset(offset)
         .map(

--- a/yarn.lock
+++ b/yarn.lock
@@ -20508,6 +20508,11 @@ serialize-javascript@^5.0.1:
   dependencies:
     randombytes "^2.1.0"
 
+serialize-query-params@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/serialize-query-params/-/serialize-query-params-1.3.3.tgz#a4bf0fc0ab9e80c92b93cdf9d84ec521d769ecbe"
+  integrity sha512-rJIIETRuGUVbLekC73IiXV3738ylEHbHK1kxaXAbhxbxfio0yvVXaRMF+OyLZOBMwdgDHYLaj6EMBAEiSf8C/g==
+
 serve-index@^1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.1.tgz#d3768d69b1e7d82e5ce050fff5b453bea12a9239"
@@ -22735,6 +22740,13 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-query-params@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/use-query-params/-/use-query-params-1.2.2.tgz#4c4b274133d699605301510b5aa01047f92b5ce0"
+  integrity sha512-Uyfe+/TECsNNzCSkgUM1MM24OEGxGE4aeWvZEf0a14iQFp/m43wiqI1HZ9oTlrRSZwD5yABeLc9rN+wtiB5B3Q==
+  dependencies:
+    serialize-query-params "^1.3.3"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
## Description

Store pagination state in query parameters and sort troll alarms by most recent first.

## Motivation and Context

The number of troll alarms can quickly become unwieldy. Even with a page size of 500, it can be very time consuming to navigate to the correct page. Showing more recent alarms first and exposing the page number in the URL mitigate this.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<table><tr><td>

<img width="1439" alt="Spoke_and_Comparing_master___feat-troll-alarm-sort-order_·_politics-rewired_Spoke" src="https://user-images.githubusercontent.com/2145526/115641358-e3070d00-a2e6-11eb-871b-d7bcc3ec10a9.png">

</td></tr></table>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
