### PR TITLE
fix: fix start campaign button

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -335,11 +335,6 @@ const validators = {
     example: "assignment.message.received,assignment.updated",
     default: ""
   }),
-  DISABLE_CAMPAIGN_EDIT_TEXTERS: bool({
-    desc: "Whether to disable showing the texters panel on campaign edit.",
-    default: "false",
-    isClient: true
-  }),
   DISABLE_SIDEBAR_BADGES: bool({
     desc: "Whether to disable showing the badge counts on the admin sidebar.",
     default: "false",

--- a/src/containers/AdminCampaignEdit/index.jsx
+++ b/src/containers/AdminCampaignEdit/index.jsx
@@ -4,7 +4,6 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import { withTheme } from "@material-ui/core/styles";
-import gql from "graphql-tag";
 import isEqual from "lodash/isEqual";
 import pick from "lodash/pick";
 import Avatar from "material-ui/Avatar";
@@ -26,6 +25,17 @@ import { camelCase, dataTest } from "../../lib/attributes";
 import { DateTime } from "../../lib/datetime";
 import theme from "../../styles/theme";
 import { loadData } from "../hoc/with-operations";
+import {
+  ARCHIVE_CAMPAIGN,
+  DELETE_JOB,
+  EDIT_CAMPAIGN,
+  GET_CAMPAIGN_JOBS,
+  GET_EDIT_CAMPAIGN_DATA,
+  GET_ORGANIZATION_ACTIONS,
+  GET_ORGANIZATION_DATA,
+  START_CAMPAIGN,
+  UNARCHIVE_CAMPAIGN
+} from "./queries";
 import CampaignAutoassignModeForm from "./sections/CampaignAutoassignModeForm";
 import CampaignBasicsForm from "./sections/CampaignBasicsForm";
 import CampaignCannedResponsesForm from "./sections/CampaignCannedResponsesForm";
@@ -39,43 +49,6 @@ import CampaignTextersForm from "./sections/CampaignTextersForm";
 import CampaignTextingHoursForm from "./sections/CampaignTextingHoursForm";
 
 const disableTexters = window.DISABLE_CAMPAIGN_EDIT_TEXTERS;
-
-// TODO: replace with Fragment
-const campaignInfoFragment = `
-  id
-  title
-  description
-  dueBy
-  isStarted
-  isArchived
-  contactsCount
-  datawarehouseAvailable
-  customFields
-  useDynamicAssignment
-  logoImageUrl
-  introHtml
-  primaryColor
-  textingHoursStart
-  textingHoursEnd
-  isAssignmentLimitedToTeams
-  isAutoassignEnabled
-  timezone
-  teams {
-    id
-    title
-  }
-  interactionSteps {
-    id
-    questionText
-    scriptOptions
-    answerOption
-    answerActions
-    parentInteractionId
-    isDeleted
-    createdAt
-  }
-  editors
-`;
 
 const extractStageAndStatus = (percentComplete) => {
   if (percentComplete > 100) {
@@ -916,20 +889,7 @@ AdminCampaignEdit.propTypes = {
 
 const queries = {
   pendingJobsData: {
-    query: gql`
-      query getCampaignJobs($campaignId: String!) {
-        campaign(id: $campaignId) {
-          id
-          pendingJobs {
-            id
-            jobType
-            assigned
-            status
-            resultMessage
-          }
-        }
-      }
-    `,
+    query: GET_CAMPAIGN_JOBS,
     options: (ownProps) => ({
       variables: {
         campaignId: ownProps.match.params.campaignId
@@ -938,11 +898,7 @@ const queries = {
     })
   },
   campaignData: {
-    query: gql`query getCampaign($campaignId: String!) {
-      campaign(id: $campaignId) {
-        ${campaignInfoFragment}
-      }
-    }`,
+    query: GET_EDIT_CAMPAIGN_DATA,
     options: (ownProps) => ({
       variables: {
         campaignId: ownProps.match.params.campaignId
@@ -951,38 +907,7 @@ const queries = {
     })
   },
   organizationData: {
-    query: gql`
-      query getOrganizationData($organizationId: String!) {
-        organization(id: $organizationId) {
-          id
-          uuid
-          teams {
-            id
-            title
-          }
-          ${
-            disableTexters
-              ? ""
-              : `
-          texters: people {
-            id
-            firstName
-            lastName
-            displayName
-          }
-          `
-          }
-          numbersApiKey
-          campaigns(cursor: { offset: 0, limit: 5000 }) {
-            campaigns {
-              id
-              title
-              createdAt
-            }
-          }
-        }
-      }
-    `,
+    query: GET_ORGANIZATION_DATA,
     options: (ownProps) => ({
       variables: {
         organizationId: ownProps.match.params.organizationId
@@ -990,15 +915,7 @@ const queries = {
     })
   },
   availableActionsData: {
-    query: gql`
-      query getActions($organizationId: String!) {
-        availableActions(organizationId: $organizationId) {
-          name
-          display_name
-          instructions
-        }
-      }
-    `,
+    query: GET_ORGANIZATION_ACTIONS,
     options: (ownProps) => ({
       variables: {
         organizationId: ownProps.match.params.organizationId
@@ -1008,53 +925,28 @@ const queries = {
   }
 };
 
-// Right now we are copying the result fields instead of using a fragment because of https://github.com/apollostack/apollo-client/issues/451
 const mutations = {
   archiveCampaign: (_ownProps) => (campaignId) => ({
-    mutation: gql`mutation archiveCampaign($campaignId: String!) {
-          archiveCampaign(id: $campaignId) {
-            ${campaignInfoFragment}
-          }
-        }`,
+    mutation: ARCHIVE_CAMPAIGN,
     variables: { campaignId }
   }),
   unarchiveCampaign: (_ownProps) => (campaignId) => ({
-    mutation: gql`mutation unarchiveCampaign($campaignId: String!) {
-        unarchiveCampaign(id: $campaignId) {
-          ${campaignInfoFragment}
-        }
-      }`,
+    mutation: UNARCHIVE_CAMPAIGN,
     variables: { campaignId }
   }),
   startCampaign: (_ownProps) => (campaignId) => ({
-    mutation: gql`mutation startCampaign($campaignId: String!) {
-        startCampaign(id: $campaignId) {
-          ${campaignInfoFragment}
-        }
-      }`,
+    mutation: START_CAMPAIGN,
     variables: { campaignId }
   }),
   editCampaign: (_ownProps) => (campaignId, campaign) => ({
-    mutation: gql`
-      mutation editCampaign($campaignId: String!, $campaign: CampaignInput!) {
-        editCampaign(id: $campaignId, campaign: $campaign) {
-          ${campaignInfoFragment}
-        }
-      },
-    `,
+    mutation: EDIT_CAMPAIGN,
     variables: {
       campaignId,
       campaign
     }
   }),
   deleteJob: (ownProps) => (jobId) => ({
-    mutation: gql`
-      mutation deleteJob($campaignId: String!, $id: String!) {
-        deleteJob(campaignId: $campaignId, id: $id) {
-          id
-        }
-      }
-    `,
+    mutation: DELETE_JOB,
     variables: {
       campaignId: ownProps.match.params.campaignId,
       id: jobId

--- a/src/containers/AdminCampaignEdit/index.jsx
+++ b/src/containers/AdminCampaignEdit/index.jsx
@@ -48,8 +48,6 @@ import CampaignTeamsForm from "./sections/CampaignTeamsForm";
 import CampaignTextersForm from "./sections/CampaignTextersForm";
 import CampaignTextingHoursForm from "./sections/CampaignTextingHoursForm";
 
-const disableTexters = window.DISABLE_CAMPAIGN_EDIT_TEXTERS;
-
 const extractStageAndStatus = (percentComplete) => {
   if (percentComplete > 100) {
     return `Filtering out landlines. ${percentComplete - 100}% complete`;
@@ -506,10 +504,7 @@ class AdminCampaignEdit extends React.Component {
       }
     ];
 
-    return (disableTexters
-      ? sections.filter((section) => section.title !== "Texters")
-      : sections
-    ).filter((section) => !section.exclude);
+    return sections.filter((section) => !section.exclude);
   };
 
   sectionSaveStatus = (section) => {

--- a/src/containers/AdminCampaignEdit/index.jsx
+++ b/src/containers/AdminCampaignEdit/index.jsx
@@ -48,6 +48,7 @@ const campaignInfoFragment = `
   dueBy
   isStarted
   isArchived
+  contactsCount
   datawarehouseAvailable
   customFields
   useDynamicAssignment

--- a/src/containers/AdminCampaignEdit/queries.ts
+++ b/src/containers/AdminCampaignEdit/queries.ts
@@ -112,8 +112,8 @@ export const ARCHIVE_CAMPAIGN = gql`
     archiveCampaign(id: $campaignId) {
       ...EditCampaignFragment
     }
-    ${EditCampaignFragment}
   }
+  ${EditCampaignFragment}
 `;
 
 export const UNARCHIVE_CAMPAIGN = gql`

--- a/src/containers/AdminCampaignEdit/queries.ts
+++ b/src/containers/AdminCampaignEdit/queries.ts
@@ -1,0 +1,144 @@
+import gql from "graphql-tag";
+
+export const GET_ORGANIZATION_DATA = gql`
+  query getOrganizationData($organizationId: String!) {
+    organization(id: $organizationId) {
+      id
+      uuid
+      teams {
+        id
+        title
+      }
+      texters: people {
+        id
+        firstName
+        lastName
+        displayName
+      }
+      numbersApiKey
+      campaigns(cursor: { offset: 0, limit: 5000 }) {
+        campaigns {
+          id
+          title
+          createdAt
+        }
+      }
+    }
+  }
+`;
+
+export const GET_ORGANIZATION_ACTIONS = gql`
+  query getActions($organizationId: String!) {
+    availableActions(organizationId: $organizationId) {
+      name
+      display_name
+      instructions
+    }
+  }
+`;
+
+export const GET_CAMPAIGN_JOBS = gql`
+  query getCampaignJobs($campaignId: String!) {
+    campaign(id: $campaignId) {
+      id
+      pendingJobs {
+        id
+        jobType
+        assigned
+        status
+        resultMessage
+      }
+    }
+  }
+`;
+
+export const DELETE_JOB = gql`
+  mutation deleteJob($campaignId: String!, $id: String!) {
+    deleteJob(campaignId: $campaignId, id: $id) {
+      id
+    }
+  }
+`;
+
+export const EditCampaignFragment = gql`
+  fragment EditCampaignFragment on Campaign {
+    id
+    title
+    description
+    dueBy
+    isStarted
+    isArchived
+    contactsCount
+    datawarehouseAvailable
+    customFields
+    useDynamicAssignment
+    logoImageUrl
+    introHtml
+    primaryColor
+    textingHoursStart
+    textingHoursEnd
+    isAssignmentLimitedToTeams
+    isAutoassignEnabled
+    timezone
+    teams {
+      id
+      title
+    }
+    interactionSteps {
+      id
+      questionText
+      scriptOptions
+      answerOption
+      answerActions
+      parentInteractionId
+      isDeleted
+      createdAt
+    }
+    editors
+  }
+`;
+
+export const GET_EDIT_CAMPAIGN_DATA = gql`
+  query getCampaign($campaignId: String!) {
+    campaign(id: $campaignId) {
+      ...EditCampaignFragment
+    }
+  }
+  ${EditCampaignFragment}
+`;
+
+export const ARCHIVE_CAMPAIGN = gql`
+  mutation archiveCampaign($campaignId: String!) {
+    archiveCampaign(id: $campaignId) {
+      ...EditCampaignFragment
+    }
+    ${EditCampaignFragment}
+  }
+`;
+
+export const UNARCHIVE_CAMPAIGN = gql`
+  mutation unarchiveCampaign($campaignId: String!) {
+    unarchiveCampaign(id: $campaignId) {
+      ...EditCampaignFragment
+    }
+  }
+  ${EditCampaignFragment}
+`;
+
+export const START_CAMPAIGN = gql`
+  mutation startCampaign($campaignId: String!) {
+    startCampaign(id: $campaignId) {
+      ...EditCampaignFragment
+    }
+  }
+  ${EditCampaignFragment}
+`;
+
+export const EDIT_CAMPAIGN = gql`
+  mutation editCampaign($campaignId: String!, $campaign: CampaignInput!) {
+    editCampaign(id: $campaignId, campaign: $campaign) {
+      ...EditCampaignFragment
+    }
+  }
+  ${EditCampaignFragment}
+`;


### PR DESCRIPTION
## Description

Fix the start campaign button by fixing the legacy readiness check for the Contacts section.

## Motivation and Context

The `contactsCount` field is used by the legacy readiness check. Once all sections are converted to standalone sections, these legacy section checks can be replaced with the new `readiness` fields.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
