### PR TITLE
fix(van): fix sync for contacts with both opt out and responses

### DIFF
--- a/src/server/tasks/sync-campaign-contact-to-van.spec.ts
+++ b/src/server/tasks/sync-campaign-contact-to-van.spec.ts
@@ -150,8 +150,9 @@ describe("formatCanvassResponsePayload", () => {
       canvassedResultCode,
       optOutResultCode
     });
-    expect(canvassResponse.responses).toBeNull();
-    expect(canvassResponse.resultCodeId).toBe(optOutResultCode);
+    expect(canvassResponse).toHaveLength(1);
+    expect(canvassResponse[0].responses).toBeNull();
+    expect(canvassResponse[0].resultCodeId).toBe(optOutResultCode);
   });
 
   test("correctly formats a messaged contact without survey responses", () => {
@@ -170,8 +171,9 @@ describe("formatCanvassResponsePayload", () => {
       canvassedResultCode,
       optOutResultCode
     });
-    expect(canvassResponse.responses).toBeNull();
-    expect(canvassResponse.resultCodeId).toBe(canvassedResultCode);
+    expect(canvassResponse).toHaveLength(1);
+    expect(canvassResponse[0].responses).toBeNull();
+    expect(canvassResponse[0].resultCodeId).toBe(canvassedResultCode);
   });
 
   test("correctly formats a contact with both survey responses and a canvass result code", () => {
@@ -190,8 +192,9 @@ describe("formatCanvassResponsePayload", () => {
       canvassedResultCode,
       optOutResultCode
     });
-    expect(canvassResponse.responses).toHaveLength(1);
-    expect(canvassResponse.resultCodeId).toBeNull();
+    expect(canvassResponse).toHaveLength(1);
+    expect(canvassResponse[0].responses).toHaveLength(1);
+    expect(canvassResponse[0].resultCodeId).toBeNull();
   });
 
   test("correctly formats a contact with both survey responses and an opt-out result code", () => {
@@ -209,8 +212,11 @@ describe("formatCanvassResponsePayload", () => {
       canvassedResultCode,
       optOutResultCode
     });
-    expect(canvassResponse.responses).toBeNull();
-    expect(canvassResponse.resultCodeId).toBe(optOutResultCode);
+    expect(canvassResponse).toHaveLength(2);
+    expect(canvassResponse[0].responses).toHaveLength(1);
+    expect(canvassResponse[0].resultCodeId).toBeNull();
+    expect(canvassResponse[1].responses).toBeNull();
+    expect(canvassResponse[1].resultCodeId).toBe(optOutResultCode);
   });
 });
 

--- a/src/server/tasks/sync-campaign-contact-to-van.spec.ts
+++ b/src/server/tasks/sync-campaign-contact-to-van.spec.ts
@@ -193,6 +193,25 @@ describe("formatCanvassResponsePayload", () => {
     expect(canvassResponse.responses).toHaveLength(1);
     expect(canvassResponse.resultCodeId).toBeNull();
   });
+
+  test("correctly formats a contact with both survey responses and an opt-out result code", () => {
+    const optOutResultCode = 4321;
+
+    const canvassResultRow: CanvassResultRow = {
+      canvassed_at: "2021-01-21",
+      result_codes: [],
+      activist_codes: [],
+      response_options: [{ survey_question_id: 999, response_option_id: 888 }]
+    };
+    const canvassResponse = formatCanvassResponsePayload({
+      canvassResultRow,
+      phoneId,
+      canvassedResultCode,
+      optOutResultCode
+    });
+    expect(canvassResponse.responses).toBeNull();
+    expect(canvassResponse.resultCodeId).toBe(optOutResultCode);
+  });
 });
 
 describe("hasPayload", () => {

--- a/src/server/tasks/sync-campaign-contact-to-van.spec.ts
+++ b/src/server/tasks/sync-campaign-contact-to-van.spec.ts
@@ -211,6 +211,7 @@ describe("formatCanvassResponsePayload", () => {
     const canvassResponse = formatCanvassResponsePayload({
       canvassResultRow,
       phoneId,
+      phoneNumber,
       canvassedResultCode,
       optOutResultCode
     });

--- a/src/server/tasks/sync-campaign-contact-to-van.spec.ts
+++ b/src/server/tasks/sync-campaign-contact-to-van.spec.ts
@@ -150,9 +150,11 @@ describe("formatCanvassResponsePayload", () => {
       canvassedResultCode,
       optOutResultCode
     });
-    expect(canvassResponse).toHaveLength(1);
+    expect(canvassResponse).toHaveLength(2);
     expect(canvassResponse[0].responses).toBeNull();
-    expect(canvassResponse[0].resultCodeId).toBe(optOutResultCode);
+    expect(canvassResponse[0].resultCodeId).toBeNull();
+    expect(canvassResponse[1].responses).toBeNull();
+    expect(canvassResponse[1].resultCodeId).toBe(optOutResultCode);
   });
 
   test("correctly formats a messaged contact without survey responses", () => {

--- a/src/server/tasks/sync-campaign-contact-to-van.ts
+++ b/src/server/tasks/sync-campaign-contact-to-van.ts
@@ -76,6 +76,11 @@ export interface CanvassResultRow {
   }[];
 }
 
+export const formatPhone = (phoneNumber: string): VANCanvassContextPhone => ({
+  dialingPrefix: "1",
+  phoneNumber: phoneNumber.replace("+1", "")
+});
+
 export interface FetchCanvassResponsesOptions {
   systemId: string;
   contactId: number;
@@ -284,10 +289,7 @@ export const formatCanvassResponsePayload = ({
     {
       canvassContext: {
         phoneId,
-        phone: {
-          dialingPrefix: "1",
-          phoneNumber: phoneNumber.replace("+1", "")
-        },
+        phone: formatPhone(phoneNumber),
         contactTypeId: VAN_SMS_TEXT_CONTACT_TYPE_ID,
         dateCanvassed
       },
@@ -300,10 +302,7 @@ export const formatCanvassResponsePayload = ({
     result.push({
       canvassContext: {
         phoneId,
-        phone: {
-          dialingPrefix: "1",
-          phoneNumber: phoneNumber.replace("+1", "")
-        },
+        phone: formatPhone(phoneNumber),
         contactTypeId: VAN_SMS_TEXT_CONTACT_TYPE_ID,
         dateCanvassed
       },


### PR DESCRIPTION
## Description

Fix edge case where canvass result with both result code _and_ responses is sent to VAN by recording responses and opt-outs separately.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This was prompted by a customer ticket regarding sync errors. Inspecting the Spoke logs showed a few 400 responses from VAN:

```json
{
  "errors": [
    {
      "code": "INVALID_PARAMETER",
      "text": "'resultCodeId' must be null when responses are specified.",
      "properties": [
        "resultCodeId"
      ]
    }
  ]
}
```

The only code path that allows a `resultCodeId` _and_ `responses` is if the contact is opted out. Spot checking the `campaign_contact` records for these failed syncs confirmed this hypothesis.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

See changes to `sync-campaign-contact-to-van.spec.ts`.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
