### PR TITLE
fix: harden clipboard usage

### DIFF
--- a/src/client/lib/index.ts
+++ b/src/client/lib/index.ts
@@ -1,3 +1,3 @@
 /* eslint-disable import/prefer-default-export */
 export const supportsClipboard = () =>
-  navigator.clipboard.readText !== undefined;
+  navigator?.clipboard?.readText !== undefined;

--- a/src/client/lib/index.ts
+++ b/src/client/lib/index.ts
@@ -1,3 +1,16 @@
-/* eslint-disable import/prefer-default-export */
 export const supportsClipboard = () =>
   navigator?.clipboard?.readText !== undefined;
+
+export const readClipboardText = async () => {
+  if (navigator?.clipboard?.readText) {
+    return navigator.clipboard.readText().catch(() => "");
+  }
+  return Promise.resolve("");
+};
+
+export const writeClipboardText = async (text: string) => {
+  if (navigator?.clipboard?.writeText) {
+    return navigator.clipboard.writeText(text).catch(() => {});
+  }
+  return Promise.resolve();
+};

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/utils.ts
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/utils.ts
@@ -1,0 +1,10 @@
+/* eslint-disable import/prefer-default-export */
+
+export const isBlock = (text: string) => {
+  try {
+    const _newBlock = JSON.parse(text);
+    return true;
+  } catch (ex) {
+    return false;
+  }
+};


### PR DESCRIPTION
## Description

Add more defensive fixes for accessing the new asynchronous clipboard API.

## Motivation and Context

This addresses new reports of application crashes in Safari due to attempted clipboard access.

Calling `updateClipboardHasBlock()` in a context outside of a user-initiated action (e.g. from `componentDidMount()`) may be the problem. If browsers widely adopt the requirement that clipboard API methods be called in response to user actions then we will need to drop `hasBlockCopied` and instead display an error if "Paste Block" is clicked without valid clipboard data.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This has not been tested with the latest Safari version yet.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
