### PR TITLE
fix: only show paste-over-block button for root step

### DIFF
--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/components/InteractionStepCard.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/components/InteractionStepCard.tsx
@@ -93,7 +93,8 @@ export const InteractionStepCard: React.FC<Props> = (props) => {
 
   const stepHasScript = scriptOptions && scriptOptions.length > 0;
   const stepHasQuestion = questionText;
-  const stepCanHaveChildren = !parentInteractionId || answerOption;
+  const isRootStep = !parentInteractionId;
+  const stepCanHaveChildren = isRootStep || answerOption;
   const isAbleToAddResponse =
     stepHasQuestion && stepHasScript && stepCanHaveChildren;
 
@@ -123,7 +124,7 @@ export const InteractionStepCard: React.FC<Props> = (props) => {
             disabled={disabled || !clipboardEnabled}
             onClick={() => onCopyBlock(interactionStep)}
           />
-          {hasBlockCopied && (
+          {hasBlockCopied && isRootStep && (
             <RaisedButton
               label="+ Paste Block"
               disabled={disabled || !clipboardEnabled}


### PR DESCRIPTION
## Description

Pasting over a block and its children should only be allowed for the root interaction step.

Re-doing #956 because I screwed up the merge.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #922
Depends on #955 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
