### PR TITLE
perf: consolidate texter assignment query

### DIFF
--- a/src/server/tasks/assign-texters.spec.ts
+++ b/src/server/tasks/assign-texters.spec.ts
@@ -1,0 +1,256 @@
+import { Pool, PoolClient } from "pg";
+
+import {
+  createCompleteCampaign,
+  createTexter
+} from "../../../__test__/testbed-preparation/core";
+import { config } from "../../config";
+import { DateTime } from "../../lib/datetime";
+import { AssignmentRecord } from "../api/types";
+import {
+  AssignmentTarget,
+  assignPayloads,
+  ensureAssignments,
+  zeroOutDeleted
+} from "./assign-texters";
+
+const texterContactCount = async (client: PoolClient, texterId: number) => {
+  const {
+    rows: [{ count }]
+  } = await client.query<{ count: number }>(
+    `
+      select count(*)::integer as count
+      from campaign_contact cc
+      join assignment a on a.id = cc.assignment_id
+      where user_id = $1
+    `,
+    [texterId]
+  );
+  return count;
+};
+
+describe("assign-texters", () => {
+  let pool: Pool;
+  let client: PoolClient;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: config.TEST_DATABASE_URL });
+    client = await pool.connect();
+  });
+
+  beforeEach(async () => {
+    client.query(`begin`);
+  });
+
+  afterEach(async () => {
+    client.query(`rollback`);
+  });
+
+  afterAll(async () => {
+    if (client) client.release();
+    if (pool) await pool.end();
+  });
+
+  test("creates missing assignments", async () => {
+    const {
+      campaign,
+      texters: [texter0]
+    } = await createCompleteCampaign(client, {
+      texters: 1
+    });
+    const texter1 = await createTexter(client, {});
+
+    const { rows: initialAssignments } = await client.query<AssignmentRecord>(
+      `select * from assignment where campaign_id = $1`,
+      [campaign.id]
+    );
+    expect(initialAssignments).toHaveLength(1);
+    expect(initialAssignments[0].user_id).toBe(texter0.id);
+
+    await ensureAssignments({
+      client,
+      campaignId: campaign.id,
+      texters: [
+        { id: `${texter0.id}`, contactsCount: 1 },
+        { id: `${texter1.id}`, contactsCount: 1 }
+      ]
+    });
+
+    const { rows: finalAssignments } = await client.query<AssignmentRecord>(
+      `select * from assignment where campaign_id = $1 order by user_id`,
+      [campaign.id]
+    );
+    expect(finalAssignments).toHaveLength(2);
+    expect(finalAssignments[0].user_id).toBe(texter0.id);
+    expect(finalAssignments[1].user_id).toBe(texter1.id);
+  });
+
+  test('zeroes out "deleted" assignments for simple case', async () => {
+    const { campaign, texters, assignments } = await createCompleteCampaign(
+      client,
+      {
+        texters: 1,
+        contacts: 150
+      }
+    );
+
+    await client.query(
+      `update campaign_contact set assignment_id = $1 where campaign_id = $2`,
+      [assignments[0].id, campaign.id]
+    );
+
+    const initalContactCount = await texterContactCount(client, texters[0].id);
+    expect(initalContactCount).toBe(150);
+
+    await zeroOutDeleted({
+      client,
+      campaignId: campaign.id,
+      isArchived: campaign.is_archived!,
+      assignmentIds: [],
+      ignoreAfterDate: DateTime.local().toUTC().plus({ hour: 1 }).toISO()
+    });
+
+    const finalContactCount = await texterContactCount(client, texters[0].id);
+    expect(finalContactCount).toBe(0);
+  });
+
+  test('zeroes out "deleted" assignments for "complex" case', async () => {
+    const { campaign, texters, assignments } = await createCompleteCampaign(
+      client,
+      {
+        texters: 2,
+        contacts: 150
+      }
+    );
+
+    await client.query(
+      `
+        update campaign_contact
+        set assignment_id = $1
+        where id in (
+          select id from campaign_contact
+          where campaign_id = $2
+            and assignment_id is null
+          limit $3
+        )`,
+      [assignments[0].id, campaign.id, 75]
+    );
+
+    await client.query(
+      `
+        update campaign_contact
+        set assignment_id = $1
+        where id in (
+          select id from campaign_contact
+          where campaign_id = $2
+            and assignment_id is null
+          limit $3
+        )`,
+      [assignments[1].id, campaign.id, 75]
+    );
+
+    const initalContactCount0 = await texterContactCount(client, texters[0].id);
+    const initalContactCount1 = await texterContactCount(client, texters[1].id);
+    expect(initalContactCount0).toBe(75);
+    expect(initalContactCount1).toBe(75);
+
+    await zeroOutDeleted({
+      client,
+      campaignId: campaign.id,
+      isArchived: campaign.is_archived!,
+      assignmentIds: [assignments[0].id],
+      ignoreAfterDate: DateTime.local().toUTC().plus({ hour: 1 }).toISO()
+    });
+
+    const finalContactCount0 = await texterContactCount(client, texters[0].id);
+    const finalContactCount1 = await texterContactCount(client, texters[1].id);
+    expect(finalContactCount0).toBe(75);
+    expect(finalContactCount1).toBe(0);
+  });
+
+  test("it does basic assignment", async () => {
+    const { campaign, texters, assignments } = await createCompleteCampaign(
+      client,
+      {
+        texters: 3,
+        contacts: 600
+      }
+    );
+
+    const assignmentTargets: AssignmentTarget[] = assignments.map(
+      (assignment, index) => ({
+        id: `${assignment.id}`,
+        userId: `${texters[index].id}`,
+        contactsCount: (index + 1) * 100,
+        operation: "insert"
+      })
+    );
+
+    await assignPayloads({
+      client,
+      campaignId: campaign.id,
+      isArchived: campaign.is_archived!,
+      assignmentTargets
+    });
+
+    const assignedCounts = await Promise.all(
+      texters.map(({ id }) => texterContactCount(client, id))
+    );
+
+    expect(assignedCounts).toHaveLength(3);
+    expect(assignedCounts[0]).toBe(100);
+    expect(assignedCounts[1]).toBe(200);
+    expect(assignedCounts[2]).toBe(300);
+  });
+
+  test("it does assignment with existing conversations", async () => {
+    const { campaign, texters, assignments } = await createCompleteCampaign(
+      client,
+      {
+        texters: 3,
+        contacts: 600
+      }
+    );
+
+    for (const assignment of assignments) {
+      await client.query(
+        `
+          update campaign_contact
+          set assignment_id = $1
+          where id in (
+            select id from campaign_contact
+            where campaign_id = $2
+              and assignment_id is null
+            limit $3
+          )
+        `,
+        [assignment.id, campaign.id, 50]
+      );
+    }
+
+    const assignmentTargets: AssignmentTarget[] = assignments.map(
+      (assignment, index) => ({
+        id: `${assignment.id}`,
+        userId: `${texters[index].id}`,
+        contactsCount: (index + 1) * 100,
+        operation: "insert"
+      })
+    );
+
+    await assignPayloads({
+      client,
+      campaignId: campaign.id,
+      isArchived: campaign.is_archived!,
+      assignmentTargets
+    });
+
+    const assignedCounts = await Promise.all(
+      texters.map(({ id }) => texterContactCount(client, id))
+    );
+
+    expect(assignedCounts).toHaveLength(3);
+    expect(assignedCounts[0]).toBe(100);
+    expect(assignedCounts[1]).toBe(200);
+    expect(assignedCounts[2]).toBe(300);
+  });
+});

--- a/src/server/tasks/assign-texters.ts
+++ b/src/server/tasks/assign-texters.ts
@@ -1,3 +1,5 @@
+import { Pool, PoolClient } from "pg";
+
 import { DateTime } from "../../lib/datetime";
 import { CampaignRecord } from "../api/types";
 import { Notifications, sendUserNotification } from "../notifications";
@@ -10,6 +12,221 @@ interface Texter {
   id: string;
   contactsCount: number;
 }
+
+export interface AssignmentTarget {
+  id: string;
+  userId: string;
+  contactsCount: number;
+  operation: string;
+}
+
+interface EnsureAssignmentsOptions {
+  client: PoolClient | Pool;
+  campaignId: number;
+  texters: Texter[];
+}
+
+export const ensureAssignments = async (options: EnsureAssignmentsOptions) => {
+  const { client, campaignId, texters } = options;
+  const assignmentTargets: AssignmentTarget[] = [];
+  for (const texter of texters) {
+    const {
+      rows: [{ id, operation }]
+    } = await client.query<{ id: string; operation: string }>(
+      `
+        insert into assignment (user_id, campaign_id)
+        values ($1, $2)
+        on conflict (user_id, campaign_id)
+          -- force return value
+          do update set user_id = EXCLUDED.user_id
+        returning
+          id,
+          (case when created_at = updated_at then 'insert' else 'update' end) as operation
+      `,
+      [texter.id, campaignId]
+    );
+    assignmentTargets.push({
+      id,
+      userId: texter.id,
+      contactsCount: texter.contactsCount,
+      operation
+    });
+  }
+  return assignmentTargets;
+};
+
+interface ZeroOutDeletedOptions {
+  client: PoolClient | Pool;
+  campaignId: number;
+  isArchived: boolean;
+  assignmentIds: number[];
+  ignoreAfterDate: string;
+}
+
+export const zeroOutDeleted = async (options: ZeroOutDeletedOptions) => {
+  const {
+    client,
+    campaignId,
+    isArchived,
+    assignmentIds,
+    ignoreAfterDate
+  } = options;
+  await client.query(
+    `
+      update campaign_contact
+      set assignment_id = null
+      where
+        campaign_id = $1
+        and archived = ${isArchived}
+        and assignment_id is not null
+        and (cardinality($2::integer[]) = 0 or assignment_id <> ANY($2))
+        and updated_at < $3
+    `,
+    [campaignId, assignmentIds, ignoreAfterDate]
+  );
+};
+
+interface FreeUpTextersOptions {
+  client: PoolClient;
+  campaignId: number;
+  isArchived: boolean;
+  assignmentTargets: AssignmentTarget[];
+  onProgress?: (percentComplete: number) => void | Promise<void>;
+}
+
+export const freeUpTexters = async (options: FreeUpTextersOptions) => {
+  const {
+    client,
+    campaignId,
+    isArchived,
+    assignmentTargets,
+    onProgress
+  } = options;
+  for (let index = 0; index < assignmentTargets.length; index += 1) {
+    const assignmentTarget = assignmentTargets[index];
+    const { id: assignmentId, contactsCount } = assignmentTarget;
+    await client.query(
+      `
+        with cc_ids_to_keep as (
+          select id
+          from campaign_contact
+          where
+            campaign_id = $1
+            and archived = ${isArchived}
+            and assignment_id = $2
+          order by id asc
+          limit $3
+        )
+        update campaign_contact
+        set assignment_id = null
+        where
+          campaign_id = $4
+          and archived = ${isArchived}
+          and assignment_id = $5
+          and id not in (select id from cc_ids_to_keep)
+      `,
+      [campaignId, assignmentId, contactsCount, campaignId, assignmentId]
+    );
+
+    if (onProgress && index % 10 === 0) {
+      const stagePercentCompelte = Math.floor(
+        (index / assignmentTargets.length) * 100
+      );
+      await onProgress(stagePercentCompelte);
+    }
+  }
+};
+
+interface AssignPayloadsOptions {
+  client: PoolClient;
+  campaignId: number;
+  isArchived: boolean;
+  assignmentTargets: AssignmentTarget[];
+}
+
+export const assignPayloads = async (options: AssignPayloadsOptions) => {
+  const { client, campaignId, isArchived, assignmentTargets } = options;
+
+  const assignmentIds = assignmentTargets.map(({ id }) => parseInt(id, 10));
+  const contactsCounts = assignmentTargets.map(
+    ({ contactsCount }) => contactsCount
+  );
+
+  await client.query(
+    `
+      with raw_assignments as (
+        select * from unnest($1::integer[], $2::integer[]) as t (assignment_id, desired_count)
+      ),
+      assignment_counts as (
+        select
+          assignment_id,
+          generate_series(1, desired_count - (
+            select count(*) from campaign_contact
+            where campaign_contact.assignment_id = raw_assignments.assignment_id
+          ))
+        from raw_assignments
+      ),
+      assignments_payload as (
+        select
+          row_number() over () as row,
+          assignment_id
+        from assignment_counts
+      ),
+      assignable_contacts as (
+        select
+          row_number() over () as row,
+          id as campaign_contact_id
+          from campaign_contact
+        where
+          campaign_id = $3
+          and archived = ${isArchived}
+          and assignment_id is null
+          and message_status = 'needsMessage'
+      ),
+      final_payloads as (
+        select ap.assignment_id, ac.campaign_contact_id
+        from assignments_payload ap
+        join assignable_contacts ac on ac.row = ap.row
+      )
+      update campaign_contact cc
+      set assignment_id = fp.assignment_id
+      from final_payloads fp
+      where cc.id = fp.campaign_contact_id
+    `,
+    [assignmentIds, contactsCounts, campaignId]
+  );
+};
+
+interface SendAssignmentNotificationsOptions {
+  campaignId: number;
+  assignmentTargets: AssignmentTarget[];
+}
+
+const sendAssignmentNotifications = async (
+  options: SendAssignmentNotificationsOptions
+) => {
+  const { campaignId, assignmentTargets } = options;
+  await Promise.all(
+    assignmentTargets.map(async (assignmentTarget) => {
+      const assignment = {
+        user_id: assignmentTarget.userId,
+        campaign_id: campaignId
+      };
+      if (assignmentTarget.operation === "insert") {
+        return sendUserNotification({
+          type: Notifications.ASSIGNMENT_CREATED,
+          assignment
+        });
+      }
+      if (assignmentTarget.operation === "update") {
+        return sendUserNotification({
+          type: Notifications.ASSIGNMENT_UPDATED,
+          assignment
+        });
+      }
+    })
+  );
+};
 
 export interface AssignTextersPayload {
   campaignId: number;
@@ -33,159 +250,55 @@ export const assignTexters: ProgressTask<AssignTextersPayload> = async (
     ])
     .then(({ rows: [row] }) => row);
 
-  await helpers.withPgClient((poolClient) =>
+  const targets = await helpers.withPgClient((poolClient) =>
     withTransaction(poolClient, async (trx) => {
       // Ensure assignments for all texters
-      const assignmentTargets = [];
-      for (const texter of texters) {
-        const {
-          rows: [{ id, operation }]
-        } = await trx.query<{ id: string; operation: string }>(
-          `
-            insert into assignment (user_id, campaign_id)
-            values ($1, $2)
-            on conflict (user_id, campaign_id)
-              -- force return value
-              do update set user_id = EXCLUDED.user_id
-            returning
-              id,
-              (case when created_at = updated_at then 'insert' else 'update' end) as operation
-          `,
-          [texter.id, campaignId]
-        );
-        assignmentTargets.push({
-          id,
-          userId: texter.id,
-          contactsCount: texter.contactsCount,
-          operation
-        });
-      }
-
+      const assignmentTargets = await ensureAssignments({
+        client: trx,
+        campaignId,
+        texters
+      });
       await helpers.updateStatus(10);
 
       // Zero out "deleted" texters
-      const assignmentIds = assignmentTargets.map(({ id }) => id);
-      await trx.query(
-        `
-          update campaign_contact
-          set assignment_id = null
-          where
-            campaign_id = $1
-            and archived = ${campaign.is_archived}
-            and assignment_id is not null
-            and assignment_id <> ANY($2)
-            and updated_at < $3
-        `,
-        [campaignId, assignmentIds, ignoreAfterDate]
-      );
-
+      const assignmentIds = assignmentTargets.map(({ id }) => parseInt(id, 10));
+      await zeroOutDeleted({
+        client: trx,
+        campaignId,
+        isArchived: campaign.is_archived ?? false,
+        assignmentIds,
+        ignoreAfterDate
+      });
       await helpers.updateStatus(20);
 
       // Free up contacts from assignment counts that have decreased
-      for (let index = 0; index < assignmentTargets.length; index += 1) {
-        const assignmentTarget = assignmentTargets[index];
-        const { id: assignmentId, contactsCount } = assignmentTarget;
-        await trx.query(
-          `
-            with cc_ids_to_keep as (
-              select id
-              from campaign_contact
-              where
-                campaign_id = $1
-                and archived = ${campaign.is_archived}
-                and assignment_id = $2
-              order by id asc
-              limit $3
-            )
-            update campaign_contact
-            set assignment_id = null
-            where
-              campaign_id = $4
-              and archived = ${campaign.is_archived}
-              and assignment_id = $5
-              and id not in (select id from cc_ids_to_keep)
-          `,
-          [campaignId, assignmentId, contactsCount, campaignId, assignmentId]
-        );
-
-        if (index % 10 === 0) {
-          const stagePercentCompelte = Math.floor(
-            (index / assignmentTargets.length) * 30
-          );
-          await helpers.updateStatus(20 + stagePercentCompelte);
-        }
-      }
-
+      await freeUpTexters({
+        client: trx,
+        campaignId,
+        isArchived: campaign.is_archived ?? false,
+        assignmentTargets,
+        onProgress: (stagePercentComplete) =>
+          helpers.updateStatus(20 + stagePercentComplete * 30)
+      });
       await helpers.updateStatus(50);
 
       // Assign desired payloads to texters
-      for (let index = 0; index < assignmentTargets.length; index += 1) {
-        const assignmentTarget = assignmentTargets[index];
-        const { id: assignmentId, contactsCount } = assignmentTarget;
-        await trx.query(
-          `
-            with desired_contacts as (
-              select id
-              from campaign_contact
-              where
-                campaign_id = $1
-                and archived = ${campaign.is_archived}
-                and (
-                  -- Existing contacts
-                  assignment_id = $2
-                  -- Unmessaged contacts
-                  or (
-                    assignment_id is null
-                    and message_status = 'needsMessage'
-                  )
-                )
-              order by assignment_id asc nulls last
-              limit $3
-              for update skip locked
-            )
-            update campaign_contact
-            set assignment_id = $4
-            where
-              id in (
-                select id from desired_contacts where assignment_id is null
-              )
-              and archived = ${campaign.is_archived}
-          `,
-          [campaignId, assignmentId, contactsCount, assignmentId]
-        );
-
-        if (index % 10 === 0) {
-          const stagePercentCompelte = Math.floor(
-            (index / assignmentTargets.length) * 45
-          );
-          await helpers.updateStatus(50 + stagePercentCompelte);
-        }
-      }
-
+      await assignPayloads({
+        client: trx,
+        campaignId,
+        isArchived: campaign.is_archived ?? false,
+        assignmentTargets
+      });
       await helpers.updateStatus(95);
 
-      await Promise.all(
-        assignmentTargets.map(async (assignmentTarget) => {
-          const assignment = {
-            user_id: assignmentTarget.userId,
-            campaign_id: campaignId
-          };
-          if (assignmentTarget.operation === "insert") {
-            return sendUserNotification({
-              type: Notifications.ASSIGNMENT_CREATED,
-              assignment
-            });
-          }
-          if (assignmentTarget.operation === "update") {
-            return sendUserNotification({
-              type: Notifications.ASSIGNMENT_UPDATED,
-              assignment
-            });
-          }
-        })
-      );
+      return assignmentTargets;
     })
   );
+
+  await sendAssignmentNotifications({
+    campaignId,
+    assignmentTargets: targets
+  });
 };
 
 export const addAssignTexters = async (payload: AssignTextersPayload) =>

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -11,11 +11,16 @@ export const errToObj = (err: any): any =>
     return acc;
   }, {});
 
-export type WithClientFn<T> = (client: PoolClient | Client) => Promise<T>;
+export type WithClientFn<T, C extends PoolClient | Client> = (
+  client: C
+) => Promise<T>;
 
-export const withTransaction = async <T extends unknown>(
-  client: PoolClient | Client,
-  callback: WithClientFn<T>
+export const withTransaction = async <
+  T extends unknown,
+  C extends PoolClient | Client
+>(
+  client: C,
+  callback: WithClientFn<T, C>
 ) => {
   await client.query("begin");
   try {


### PR DESCRIPTION
## Description

Consolidate the assignment steps to one query and add tests.

## Motivation and Context

The current assignment queries are slow and untested.

## How Has This Been Tested?

See `assign-texters.spec.ts`.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
