### PR TITLE
chore: force use of yarn package manager

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ that goal. See [`HOWTO_migrate-from-moveon-main.md`](./docs/HOWTO_migrate-from-m
 
 Prerequisites:
 
-- Node -- See [How to Install Node](https://nodejs.dev/learn/how-to-install-nodejs)
-- Yarn -- See [Installing Yarn](https://classic.yarnpkg.com/en/docs/install)
+- Node (>= 14.15) -- See [How to Install Node](https://nodejs.dev/learn/how-to-install-nodejs)
+- Yarn (>= 1.19.1) -- See [Installing Yarn](https://classic.yarnpkg.com/en/docs/install)
 - Postgres -- See [install](https://postgresql.org/download) and [start](https://www.postgresql.org/docs/current/server-start.html) documentation
 
 Clone the repo:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "node": "^14.15.2"
   },
   "scripts": {
+    "preinstall": "node -e \"if(process.env.npm_execpath.indexOf('yarn') === -1) throw new Error('spoke must be installed with Yarn: https://yarnpkg.com/')\"",
     "test": "jest --runInBand --forceExit",
     "test:coverage": "jest --coverage",
     "test:jest": "jest __test__/backend.test.js",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Spoke",
   "main": "src/server",
   "engines": {
+    "npm": "please-use-yarn",
+    "yarn": ">= 1.19.1",
     "node": "^14.15.2"
   },
   "scripts": {


### PR DESCRIPTION
## Description

Prevent `npm install`. Sadly, this does not prevent `npm install <package>` (see [npm issue](https://github.com/yarnpkg/yarn/issues/4895)).

## Motivation and Context

Use of npm breaks the dependency resolutions in `yarn.lock`, creating its own in `package-lock.json`. This can result in unpredictable behavior (ref #960).

## How Has This Been Tested?

This has been tested locally with `npm install`.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
