### PR TITLE
fix(texters): fix assignment bugs

### DIFF
--- a/src/api/assignment.ts
+++ b/src/api/assignment.ts
@@ -3,6 +3,11 @@ import { CampaignContact } from "./campaign-contact";
 import { CannedResponse } from "./canned-response";
 import { User } from "./user";
 
+export interface TexterAssignmentInput {
+  userId: string;
+  contactsCount: number;
+}
+
 export interface Assignment {
   id: string;
   texter: User;

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -82,14 +82,12 @@ const rootSchema = `
   }
 
   input TexterAssignmentInput {
-    id: String!
+    userId: String!
     contactsCount: Int!
-    needsMessageCount: Int
-    maxContacts: Int
   }
 
   input TexterInput {
-    texters: [TexterAssignmentInput!]!
+    assignmentInputs: [TexterAssignmentInput!]!
     ignoreAfterDate: Date!
   }
 

--- a/src/containers/AdminCampaignEdit/sections/CampaignTextersForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignTextersForm/index.tsx
@@ -10,6 +10,7 @@ import React, { useState } from "react";
 import { withApollo, WithApolloClient } from "react-apollo";
 import { compose } from "recompose";
 
+import { TexterAssignmentInput } from "../../../../api/assignment";
 import { Campaign } from "../../../../api/campaign";
 import { User } from "../../../../api/user";
 import { DateTime } from "../../../../lib/datetime";
@@ -90,7 +91,7 @@ interface InnerProps extends FullComponentProps, HocProps {
 
 interface Values {
   texters: {
-    texters: any[];
+    assignmentInputs: TexterAssignmentInput[];
     ignoreAfterDate: string;
   };
 }
@@ -180,14 +181,12 @@ const CampaignTextersForm: React.FC<InnerProps> = (props) => {
 
   const handleSubmit = async () => {
     const { editCampaign } = props.mutations;
-    const textersInput = stagedTexters.map((texter) => ({
-      id: texter.id,
-      needsMessageCount: texter.assignment.needsMessageCount,
-      maxContacts: texter.assignment.maxContacts,
+    const assignmentInputs = stagedTexters.map((texter) => ({
+      userId: texter.id,
       contactsCount: texter.assignment.contactsCount
     }));
     const texterInput = {
-      texters: textersInput,
+      assignmentInputs,
       ignoreAfterDate: lastReset.toUTC().toISO()
     };
     setWorking(true);

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -331,10 +331,10 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
     memoizer.invalidate(cacheOpts.CampaignTeams.key, { campaignId: id });
   }
   if (Object.prototype.hasOwnProperty.call(campaign, "texters")) {
-    const { texters, ignoreAfterDate } = campaign.texters;
+    const { assignmentInputs, ignoreAfterDate } = campaign.texters;
     await addAssignTexters({
       campaignId: id,
-      texters,
+      assignmentInputs,
       ignoreAfterDate
     });
   }

--- a/src/server/tasks/assign-texters.spec.ts
+++ b/src/server/tasks/assign-texters.spec.ts
@@ -249,7 +249,6 @@ describe("assign-texters", () => {
     );
 
     // Assign replies for first 3 texters
-    console.log(assignments.slice(0, 3).map(({ id }) => id));
     for (const assignment of assignments.slice(0, 3)) {
       await assignContacts(client, assignment.id, campaign.id, 15);
     }

--- a/src/server/tasks/assign-texters.spec.ts
+++ b/src/server/tasks/assign-texters.spec.ts
@@ -71,9 +71,9 @@ describe("assign-texters", () => {
     await ensureAssignments({
       client,
       campaignId: campaign.id,
-      texters: [
-        { id: `${texter0.id}`, contactsCount: 1 },
-        { id: `${texter1.id}`, contactsCount: 1 }
+      assignmentInputs: [
+        { userId: `${texter0.id}`, contactsCount: 1 },
+        { userId: `${texter1.id}`, contactsCount: 1 }
       ]
     });
 

--- a/src/server/tasks/assign-texters.ts
+++ b/src/server/tasks/assign-texters.ts
@@ -75,7 +75,7 @@ export const zeroOutDeleted = async (options: ZeroOutDeletedOptions) => {
         campaign_id = $1
         and archived = ${isArchived}
         and assignment_id is not null
-        and (cardinality($2::integer[]) = 0 or assignment_id <> ANY($2))
+        and not assignment_id = ANY($2)
         and updated_at < $3
     `,
     [campaignId, assignmentIds, ignoreAfterDate]


### PR DESCRIPTION
## Description

This fixes a bug causing more assignments to be zeroed out than expected.

## Motivation and Context

The problem lies in how the `ANY` operator was inverted. The correct inversions are `not assignment_id = ANY($2)` or `assignment_id <> ALL($2)`; `assignment_id <> ANY($2)` is not a correct inversion.

The PR includes changes to tests and a small refactor to the GraphQL mutation to rule out payload issues.

## How Has This Been Tested?

See changes to `assign-texters.spec.ts`.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
