### PR TITLE
fix(van): send phone object

### DIFF
--- a/migrations/20210526012107_add-phone-object-to-van-sync.js
+++ b/migrations/20210526012107_add-phone-object-to-van-sync.js
@@ -1,0 +1,176 @@
+exports.up = function up(knex) {
+  return knex.raw(`
+    create or replace function public.queue_sync_campaign_to_van(campaign_id integer)
+      returns void as $$
+    declare
+      v_system_id uuid;
+      v_username text;
+      v_api_key_ref text;
+      v_missing_configs integer;
+      v_job_request_id integer;
+      v_contact_count integer;
+    begin
+      select external_system_id
+      from campaign where id = queue_sync_campaign_to_van.campaign_id
+      into v_system_id;
+
+      if v_system_id is null then
+        raise 'No external system configured for campaign with id %', queue_sync_campaign_to_van.campaign_id;
+      end if;
+
+      select username, api_key_ref
+      from external_system
+      where id = v_system_id
+      into v_username, v_api_key_ref;
+
+      if v_api_key_ref is null then
+        raise 'No API key configured for with id %', v_system_id;
+      end if;
+
+      select count(*)
+      from external_sync_question_response_configuration qrc
+      where
+        qrc.campaign_id = queue_sync_campaign_to_van.campaign_id
+        and qrc.system_id = v_system_id
+        and is_missing = true
+        and is_required = true
+      into v_missing_configs;
+
+      if v_missing_configs > 0 then
+        raise 'Campaign % is missing % required configs', queue_sync_campaign_to_van.campaign_id, v_missing_configs;
+      end if;
+
+      select count(*)
+      from campaign_contact
+      where campaign_contact.campaign_id = queue_sync_campaign_to_van.campaign_id
+      into v_contact_count;
+
+      insert into public.job_request (campaign_id, payload, result_message, queue_name, job_type, status)
+      values (
+        campaign_id,
+        json_build_object('contact_count', v_contact_count)::text,
+        json_build_object('message', 'Synced 0 of ' || v_contact_count || ' contacts to VAN')::text,
+        campaign_id::text || ':sync_campaign',
+        'sync_van_campaign',
+        0
+      )
+      returning id
+      into v_job_request_id;
+
+      perform
+        graphile_worker.add_job(
+          'van-sync-campaign-contact',
+          json_build_object(
+            'username', v_username,
+            'api_key', json_build_object('__secret', v_api_key_ref),
+            'system_id', v_system_id,
+            'cc_created_at', cc.created_at,
+            'campaign_id', cc.campaign_id,
+            'contact_id', cc.id,
+            'external_id', cc.external_id,
+            'phone_id', ((cc.custom_fields)::json->>'phone_id')::integer,
+            'phone_number', cc.cell,
+            '__context', json_build_object(
+              'job_request_id', v_job_request_id,
+              'contact_count', v_contact_count
+            )
+          ),
+          'van-api',
+          priority => 10
+        )
+      from public.campaign_contact cc
+      where
+        cc.campaign_id = queue_sync_campaign_to_van.campaign_id
+      ;
+    end;
+    $$ language plpgsql volatile security definer set search_path = "public";
+  `);
+};
+
+exports.down = function down(knex) {
+  return knex.raw(`
+    create function public.queue_sync_campaign_to_van(campaign_id integer)
+      returns void as $$
+    declare
+      v_system_id uuid;
+      v_username text;
+      v_api_key_ref text;
+      v_missing_configs integer;
+      v_job_request_id integer;
+      v_contact_count integer;
+    begin
+      select external_system_id
+      from campaign where id = queue_sync_campaign_to_van.campaign_id
+      into v_system_id;
+
+      if v_system_id is null then
+      raise 'No external system configured for campaign with id %', queue_sync_campaign_to_van.campaign_id;
+      end if;
+
+      select username, api_key_ref
+      from external_system
+      where id = v_system_id
+      into v_username, v_api_key_ref;
+
+      if v_api_key_ref is null then
+        raise 'No API key configured for with id %', v_system_id;
+      end if;
+
+      select count(*)
+      from external_sync_question_response_configuration qrc
+      where
+        qrc.campaign_id = queue_sync_campaign_to_van.campaign_id
+        and qrc.system_id = v_system_id
+        and is_missing = true
+        and is_required = true
+      into v_missing_configs;
+
+      if v_missing_configs > 0 then
+        raise 'Campaign % is missing % required configs', queue_sync_campaign_to_van.campaign_id, v_missing_configs;
+      end if;
+
+      select count(*)
+      from campaign_contact
+      where campaign_contact.campaign_id = queue_sync_campaign_to_van.campaign_id
+      into v_contact_count;
+
+      insert into public.job_request (campaign_id, payload, result_message, queue_name, job_type, status)
+      values (
+        campaign_id,
+        json_build_object('contact_count', v_contact_count)::text,
+        json_build_object('message', 'Synced 0 of ' || v_contact_count || ' contacts to VAN')::text,
+        campaign_id::text || ':sync_campaign',
+        'sync_van_campaign',
+        0
+      )
+      returning id
+      into v_job_request_id;
+
+      perform
+        graphile_worker.add_job(
+          'van-sync-campaign-contact',
+          json_build_object(
+            'username', v_username,
+            'api_key', json_build_object('__secret', v_api_key_ref),
+            'system_id', v_system_id,
+            'cc_created_at', cc.created_at,
+            'campaign_id', cc.campaign_id,
+            'contact_id', cc.id,
+            'external_id', cc.external_id,
+            'phone_id', ((cc.custom_fields)::json->>'phone_id')::integer,
+            '__context', json_build_object(
+              'job_request_id', v_job_request_id,
+              'contact_count', v_contact_count
+            )
+          ),
+          'van-api',
+          priority => 10
+        )
+      from public.campaign_contact cc
+      where
+        cc.campaign_id = queue_sync_campaign_to_van.campaign_id
+      ;
+    end;
+    $$ language plpgsql volatile security definer set search_path = "public";
+  `);
+};

--- a/schema-dump.sql
+++ b/schema-dump.sql
@@ -885,7 +885,7 @@ CREATE FUNCTION public.queue_sync_campaign_to_van(campaign_id integer) RETURNS v
       into v_system_id;
 
       if v_system_id is null then
-       raise 'No external system configured for campaign with id %', queue_sync_campaign_to_van.campaign_id;
+        raise 'No external system configured for campaign with id %', queue_sync_campaign_to_van.campaign_id;
       end if;
 
       select username, api_key_ref
@@ -939,6 +939,7 @@ CREATE FUNCTION public.queue_sync_campaign_to_van(campaign_id integer) RETURNS v
             'contact_id', cc.id,
             'external_id', cc.external_id,
             'phone_id', ((cc.custom_fields)::json->>'phone_id')::integer,
+            'phone_number', cc.cell,
             '__context', json_build_object(
               'job_request_id', v_job_request_id,
               'contact_count', v_contact_count

--- a/src/server/tasks/sync-campaign-contact-to-van.spec.ts
+++ b/src/server/tasks/sync-campaign-contact-to-van.spec.ts
@@ -131,6 +131,7 @@ describe("fetchCanvassResponses", () => {
 
 describe("formatCanvassResponsePayload", () => {
   const phoneId = 5432;
+  const phoneNumber = "+16463893770";
   const canvassedResultCode = 1234;
 
   test("correctly formats an opted-out contact without survey responses", () => {
@@ -145,6 +146,7 @@ describe("formatCanvassResponsePayload", () => {
     const canvassResponse = formatCanvassResponsePayload({
       canvassResultRow,
       phoneId,
+      phoneNumber,
       canvassedResultCode,
       optOutResultCode
     });
@@ -164,6 +166,7 @@ describe("formatCanvassResponsePayload", () => {
     const canvassResponse = formatCanvassResponsePayload({
       canvassResultRow,
       phoneId,
+      phoneNumber,
       canvassedResultCode,
       optOutResultCode
     });
@@ -183,6 +186,7 @@ describe("formatCanvassResponsePayload", () => {
     const canvassResponse = formatCanvassResponsePayload({
       canvassResultRow,
       phoneId,
+      phoneNumber,
       canvassedResultCode,
       optOutResultCode
     });
@@ -196,6 +200,10 @@ describe("hasPayload", () => {
     const nullResponsesResponse: VANCanvassResponse = {
       canvassContext: {
         phoneId: 1234,
+        phone: {
+          dialingPrefix: "1",
+          phoneNumber: "+16463893770"
+        },
         dateCanvassed: "2021-01-21"
       },
       resultCodeId: null,
@@ -206,6 +214,10 @@ describe("hasPayload", () => {
     const emptyResponsesResponse: VANCanvassResponse = {
       canvassContext: {
         phoneId: 1234,
+        phone: {
+          dialingPrefix: "1",
+          phoneNumber: "+16463893770"
+        },
         dateCanvassed: "2021-01-21"
       },
       resultCodeId: null,
@@ -218,6 +230,10 @@ describe("hasPayload", () => {
     const resultCodeResponse: VANCanvassResponse = {
       canvassContext: {
         phoneId: 1234,
+        phone: {
+          dialingPrefix: "1",
+          phoneNumber: "+16463893770"
+        },
         dateCanvassed: "2021-01-21"
       },
       resultCodeId: 5432,
@@ -230,6 +246,10 @@ describe("hasPayload", () => {
     const resultCodeResponse: VANCanvassResponse = {
       canvassContext: {
         phoneId: 1234,
+        phone: {
+          dialingPrefix: "1",
+          phoneNumber: "+16463893770"
+        },
         dateCanvassed: "2021-01-21"
       },
       resultCodeId: null,

--- a/src/server/tasks/sync-campaign-contact-to-van.ts
+++ b/src/server/tasks/sync-campaign-contact-to-van.ts
@@ -18,8 +18,14 @@ class VANSyncError extends Error {
 
 export const CANVASSED_TAG_NAME = "Canvassed";
 
+export interface VANCanvassContextPhone {
+  dialingPrefix: "1";
+  phoneNumber: string;
+}
+
 export interface VANCanvassContext {
   phoneId: number;
+  phone: VANCanvassContextPhone;
   contactTypeId?: number; //	Optional; a valid contact type ID
   inputTypeId?: number; //	Optional; a valid input type ID (defaults to 11 → API)
   dateCanvassed?: string; //	Optional; the ISO-8601 formatted date that the canvass attempt was made (defaults to today’s date)
@@ -224,6 +230,7 @@ export const fetchCanvassedResultCode = async (
 export interface FormatCanvassResponsePayloadOptions {
   canvassResultRow: CanvassResultRow;
   phoneId: number;
+  phoneNumber: string;
   optOutResultCode: number | null;
   canvassedResultCode: number | null;
 }
@@ -231,6 +238,7 @@ export interface FormatCanvassResponsePayloadOptions {
 export const formatCanvassResponsePayload = ({
   canvassResultRow,
   phoneId,
+  phoneNumber,
   optOutResultCode,
   canvassedResultCode
 }: FormatCanvassResponsePayloadOptions) => {
@@ -273,6 +281,10 @@ export const formatCanvassResponsePayload = ({
   const canvassResponse: VANCanvassResponse = {
     canvassContext: {
       phoneId,
+      phone: {
+        dialingPrefix: "1",
+        phoneNumber: phoneNumber.replace("+1", "")
+      },
       dateCanvassed
     },
     resultCodeId,
@@ -295,6 +307,7 @@ export interface SyncCampaignContactToVANPayload extends VanAuthPayload {
   cc_created_at: string;
   external_id: string;
   phone_id: number;
+  phone_number: string;
 }
 
 export const syncCampaignContactToVAN: Task = async (
@@ -306,7 +319,8 @@ export const syncCampaignContactToVAN: Task = async (
     contact_id: contactId,
     // canvassed_at: dateCanvassed,
     external_id: vanId,
-    phone_id: phoneId
+    phone_id: phoneId,
+    phone_number: phoneNumber
   } = payload;
 
   const {
@@ -336,6 +350,7 @@ export const syncCampaignContactToVAN: Task = async (
     formatCanvassResponsePayload({
       canvassResultRow,
       phoneId,
+      phoneNumber,
       optOutResultCode,
       canvassedResultCode
     })


### PR DESCRIPTION
## Description

This sends the `phone` object in addition to the `phoneId` string;

## Motivation and Context

From VAN support:
> Phone number will be required. Eventually, phoneid-only will not be sufficient.

See https://secure.helpscout.net/conversation/1517362472/4308.

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
