### PR TITLE
fix(van): add deprecation warning for disconnected result code

### DIFF
--- a/src/api/external-result-code.ts
+++ b/src/api/external-result-code.ts
@@ -9,6 +9,17 @@ export interface ExternalResultCode {
   updatedAt: string;
 }
 
+export const resultCodeWarning = (
+  resultCode: ExternalResultCode
+): string | undefined => {
+  switch (resultCode.name) {
+    case "Disconnected":
+      return "VAN recommends using Deliverability Error instead!";
+    default:
+      return undefined;
+  }
+};
+
 export const schema = `
   type ExternalResultCode {
     id: String!

--- a/src/components/AddMapping.tsx
+++ b/src/components/AddMapping.tsx
@@ -15,7 +15,10 @@ import React from "react";
 import { compose } from "recompose";
 
 import { ExternalActivistCode } from "../api/external-activist-code";
-import { ExternalResultCode } from "../api/external-result-code";
+import {
+  ExternalResultCode,
+  resultCodeWarning
+} from "../api/external-result-code";
 import { ExternalSurveyQuestion } from "../api/external-survey-question";
 import {
   ExternalSyncConfigTarget,
@@ -297,13 +300,20 @@ class AddMapping extends React.Component<InnerProps, State> {
                 autoWidth
                 onChange={this.handleOnChangeResultCode}
               >
-                {this.props.resultCodes.edges.map(({ node }) => (
-                  <MenuItem
-                    key={node.id}
-                    value={node.id}
-                    primaryText={node.name}
-                  />
-                ))}
+                {this.props.resultCodes.edges.map(({ node }) => {
+                  const warning = resultCodeWarning(node);
+                  const name = warning
+                    ? `${node.name} - ${warning}`
+                    : node.name;
+                  return (
+                    <MenuItem
+                      key={node.id}
+                      value={node.id}
+                      primaryText={name}
+                      disabled={warning !== undefined}
+                    />
+                  );
+                })}
               </SelectField>
             )}
             {this.state.type === MappingType.ResponseOption && (

--- a/src/components/QuestionResponseConfig/components/ResultCodeMapping.tsx
+++ b/src/components/QuestionResponseConfig/components/ResultCodeMapping.tsx
@@ -9,13 +9,15 @@ import { ExternalResultCode } from "../../../api/external-result-code";
 
 interface Props {
   resultCode: ExternalResultCode;
+  warning?: string;
   onClickDelete(): void;
 }
 
-export const ResultCodeMapping: React.SFC<Props> = (props) => {
+export const ResultCodeMapping: React.FC<Props> = (props) => {
   return (
     <ListItem
       primaryText={props.resultCode.name}
+      secondaryText={props.warning}
       leftIcon={<InputIcon color={green200} />}
       rightIconButton={
         <IconButton onClick={props.onClickDelete}>

--- a/src/components/QuestionResponseConfig/index.tsx
+++ b/src/components/QuestionResponseConfig/index.tsx
@@ -23,7 +23,10 @@ import React from "react";
 import { compose } from "recompose";
 
 import { ExternalActivistCode } from "../../api/external-activist-code";
-import { ExternalResultCode } from "../../api/external-result-code";
+import {
+  ExternalResultCode,
+  resultCodeWarning
+} from "../../api/external-result-code";
 import { ExternalSurveyQuestion } from "../../api/external-survey-question";
 import {
   ExternalSyncQuestionResponseConfig,
@@ -172,10 +175,12 @@ class QuestionResponseConfig extends React.Component<InnerProps> {
                     );
                   }
                   if (isResultCode(target)) {
+                    const warning = resultCodeWarning(target.resultCode);
                     return (
                       <ResultCodeMapping
                         key={target.id}
                         resultCode={target.resultCode}
+                        warning={warning}
                         onClickDelete={this.makeHandleOnClickDeleteTarget(
                           target.id
                         )}


### PR DESCRIPTION
## Description

Add deprecation warning to the "Disconnected" VAN result code.

## Motivation and Context

VAN announced:

> Going forward, you should default to Deliverability Error when a call or SMS to a phone number cannot be completed but you are unsure if the phone number is truly disconnected. Only use Disconnected when you are very confident that the number is truly disconnected.
>
> [We] will be allowing our clients to restrict which vendors can apply Disconnected contact results and your API keys may lose this permission.

## How Has This Been Tested?

See attached screenshots.

## Screenshots (if appropriate):

<table><tr><td>

<img width="740" alt="Screen Shot 2021-05-25 at 10 13 50 PM" src="https://user-images.githubusercontent.com/2145526/119592473-8ba50280-bda6-11eb-973a-26eafbf33895.png">
<br />
<center><i>New Mappings</i></center>

</td></tr>

<tr><td>

<img width="564" alt="Screen Shot 2021-05-25 at 10 05 40 PM" src="https://user-images.githubusercontent.com/2145526/119592466-88aa1200-bda6-11eb-9eff-305f01549614.png">
<br />
<center><i>Existing Mappings</i></center>

</td></tr></table>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

I think this is self-documenting. Others may disagree.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
