### PR TITLE
fix(texters): assign from pool of all unassigned conversations

### DIFF
--- a/src/server/tasks/assign-texters.spec.ts
+++ b/src/server/tasks/assign-texters.spec.ts
@@ -6,7 +6,7 @@ import {
 } from "../../../__test__/testbed-preparation/core";
 import { config } from "../../config";
 import { DateTime } from "../../lib/datetime";
-import { AssignmentRecord } from "../api/types";
+import { AssignmentRecord, MessageStatusType } from "../api/types";
 import {
   AssignmentTarget,
   assignPayloads,
@@ -252,5 +252,40 @@ describe("assign-texters", () => {
     expect(assignedCounts[0]).toBe(100);
     expect(assignedCounts[1]).toBe(200);
     expect(assignedCounts[2]).toBe(300);
+  });
+
+  test("it assigns conversations when no needsMessage conversations exist", async () => {
+    const {
+      campaign,
+      texters,
+      assignments,
+      contacts
+    } = await createCompleteCampaign(client, {
+      texters: 1,
+      contacts: [
+        { messageStatus: MessageStatusType.NeedsMessage },
+        { messageStatus: MessageStatusType.NeedsResponse },
+        { messageStatus: MessageStatusType.Conversation },
+        { messageStatus: MessageStatusType.Messaged }
+      ]
+    });
+
+    const assignmentTarget: AssignmentTarget = {
+      id: `${assignments[0].id}`,
+      userId: `${texters[0].id}`,
+      contactsCount: contacts.length,
+      operation: "insert"
+    };
+
+    await assignPayloads({
+      client,
+      campaignId: campaign.id,
+      isArchived: campaign.is_archived!,
+      assignmentTargets: [assignmentTarget]
+    });
+
+    const assignedCount = await texterContactCount(client, texters[0].id);
+
+    expect(assignedCount).toBe(contacts.length);
   });
 });

--- a/src/server/tasks/assign-texters.ts
+++ b/src/server/tasks/assign-texters.ts
@@ -181,7 +181,16 @@ export const assignPayloads = async (options: AssignPayloadsOptions) => {
           campaign_id = $3
           and archived = ${isArchived}
           and assignment_id is null
-          and message_status = 'needsMessage'
+        order by
+          -- prioritize conversations requiring action
+          (case
+            when message_status = 'needsMessage' then 10
+            when message_status = 'needsResponse' then 20
+            when message_status = 'convo' then 30
+            when message_status = 'messaged' then 40
+            when message_status = 'closed' then 50
+            else 60
+          end) asc
       ),
       final_payloads as (
         select ap.assignment_id, ac.campaign_contact_id


### PR DESCRIPTION
## Description

Assign from pool of all unassigned conversations rather than just `needsMessage`.

## Motivation and Context

The Texters section UI shows counts for Assigned and Unassigned but does not scope these numbers to
needsMessage conversations. The assignment query is limited to needsMessage, however, resulting in
behavior where assigning n messages to a texter in the frontend results in 0 assigned converations
because while there are n unassigned conversations none of them are needsMessage.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

See changes to `assign-texters.spec.ts`.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
