### PR TITLE
perf: fix sequential scan on campaign_contact

### DIFF
--- a/src/server/tasks/assign-texters.ts
+++ b/src/server/tasks/assign-texters.ts
@@ -158,7 +158,9 @@ export const assignPayloads = async (options: AssignPayloadsOptions) => {
           assignment_id,
           generate_series(1, desired_count - (
             select count(*) from campaign_contact
-            where campaign_contact.assignment_id = raw_assignments.assignment_id
+            where
+              campaign_id = $3
+              and campaign_contact.assignment_id = raw_assignments.assignment_id
           ))
         from raw_assignments
       ),

--- a/src/server/tasks/assign-texters.ts
+++ b/src/server/tasks/assign-texters.ts
@@ -160,6 +160,7 @@ export const assignPayloads = async (options: AssignPayloadsOptions) => {
             select count(*) from campaign_contact
             where
               campaign_id = $3
+              and archived = ${isArchived}
               and campaign_contact.assignment_id = raw_assignments.assignment_id
           ))
         from raw_assignments


### PR DESCRIPTION
## Description

Dramatically improve performance of `assignPayloads` query for clients with a large number of `campaign_contact` rows.

## Motivation and Context

There is only a partial index on `campaign_contact.assignment_id` so the `assignment_counts` CTE was doing a full scan
on `campaign_contact` for that stage. Adding the `campaign_id` condition turns that into an index scan
with `assignment_id` as a filter condition.

It could be further improved by limiting the use of the Texters section to unarchived campaigns: https://explain.depesz.com/s/fvsH

The `ensureAssignments` query being blocked by the `assignPayloads` query can likely be explained by:

1. User saves Texter section
2. `assignPayloads` takes a long time to run
3. User cancels the job; `assignPayloads` query continues to run in the background (see #981)
4. User saves Texters section again
5. Second job's `ensureAssignments` gets stuck on the first job's `assignPayloads`


## How Has This Been Tested?

Old explain: https://explain.depesz.com/s/uGxg
New explain: https://explain.depesz.com/s/iThU

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
