### PR TITLE
fix: update copy for filter landlines section

### DIFF
--- a/src/containers/AdminCampaignEdit/sections/CampaignFilterLandlinesForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignFilterLandlinesForm.tsx
@@ -94,8 +94,8 @@ class FilterLandlinesForm extends React.Component<Props, State> {
               <span>
                 <p>
                   Filtering landlines or otherwise un-textable numbers will cost
-                  $.0025 (1/4 cent) per phone number, but as long as more than a
-                  third of your phone numbers are likely to be invalid, it will
+                  $.0025 (1/4 cent) per phone number, but as long as more than
+                  10-20% of your phone numbers are likely to be invalid, it will
                   save you money.
                 </p>
                 <p>


### PR DESCRIPTION
## Description

Updates the Filter Landlines copy to be more precise.

## Motivation and Context

Our original calculations for this did not take into account common message segment length distributions. @curtries looked into this a bunch more and found 10-20% to be a much more accurate threshold for when filter landlines saves a campaign money.

Closes #965

## How Has This Been Tested?

Big spreadsheet.

## Screenshots (if appropriate):

<table><tr><td>

<img width="1135" alt="Screen Shot 2021-06-11 at 9 24 15 AM" src="https://user-images.githubusercontent.com/2145526/121693126-d4db9e80-ca96-11eb-8e6a-b56d15ff42aa.png">

</td></tr></table>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

@curtries does this need to be updated anywhere on docs.spokerewired.com?

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
