### PR TITLE
feat(van): use 'SMS Text' contact type for canvass responses

### DIFF
--- a/src/server/tasks/sync-campaign-contact-to-van.ts
+++ b/src/server/tasks/sync-campaign-contact-to-van.ts
@@ -18,6 +18,8 @@ class VANSyncError extends Error {
 
 export const CANVASSED_TAG_NAME = "Canvassed";
 
+export const VAN_SMS_TEXT_CONTACT_TYPE_ID = 37;
+
 export interface VANCanvassContextPhone {
   dialingPrefix: "1";
   phoneNumber: string;
@@ -285,6 +287,7 @@ export const formatCanvassResponsePayload = ({
         dialingPrefix: "1",
         phoneNumber: phoneNumber.replace("+1", "")
       },
+      contactTypeId: VAN_SMS_TEXT_CONTACT_TYPE_ID,
       dateCanvassed
     },
     resultCodeId,


### PR DESCRIPTION
## Description

Pass the "SMS Text" contact type for VAN canvass responses.

## Motivation and Context

Closes #988 

## How Has This Been Tested?

Nikki at NGP VAN confirmed that contact type IDs are consistent across VAN instances.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
