### PR TITLE
fix: use correct date format for luxon

### DIFF
--- a/src/components/AssignmentSummary/index.tsx
+++ b/src/components/AssignmentSummary/index.tsx
@@ -108,7 +108,7 @@ export const AssignmentSummary: React.FC<Props> = (props) => {
   } = assignment.campaign;
   const { maxContacts } = assignment;
   const dueByText = dueBy
-    ? DateTime.fromISO(dueBy).toFormat("MMM D YYYY")
+    ? DateTime.fromISO(dueBy).toFormat("MMM d, yyyy")
     : "No Due Date";
   const subtitle = `${description} - ${dueByText}`;
 


### PR DESCRIPTION
## Description

This fixes the date format by using the correct [tokens for Luxon](https://moment.github.io/luxon/#/formatting?id=table-of-tokens).

## Motivation and Context

The previous format "works" but looks ugly and unprofessional.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<table><tr><td>

![Spoke](https://user-images.githubusercontent.com/2145526/127879494-4292c7e1-3101-49c6-96c8-37cb370b0e3f.png)

</td></tr></table>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
