### PR TITLE
feat: delete log record after processing

### DIFF
--- a/__mocks__/assemble-numbers.ts
+++ b/__mocks__/assemble-numbers.ts
@@ -1,0 +1,16 @@
+import faker from 'faker';
+
+import { NumbersDeliveryReportPayload, NumbersSendStatus } from "../src/server/api/lib/assemble-numbers";
+
+export const mockDeliveryReportBody = (messageId: string): NumbersDeliveryReportPayload => ({
+  errorCodes: [],
+  eventType: NumbersSendStatus.Delivered,
+  generatedAt: new Date().toISOString(),
+  messageId,
+  profileId: faker.random.uuid(),
+  sendingLocationId: faker.random.uuid(),
+  extra: {
+    num_segments: 1,
+    num_media: 0
+  }
+});

--- a/__mocks__/twilio.ts
+++ b/__mocks__/twilio.ts
@@ -1,0 +1,6 @@
+import faker from 'faker';
+
+export const mockDeliveryReportBody = (messageId: string) => ({
+  MessageSid: messageId,
+  MessageStatus: 'delivered'
+});

--- a/__test__/testbed-preparation/core.ts
+++ b/__test__/testbed-preparation/core.ts
@@ -229,6 +229,7 @@ export type CreateMessageOptions = {
   assignmentId: number;
 } & Partial<
   Pick<Message, "text" | "sendStatus"> & {
+    serviceId: string;
     contactNumber: string;
     isFromContact: boolean;
     userId: number;
@@ -243,8 +244,8 @@ export const createMessage = async (
   client
     .query<MessageRecord>(
       `
-        insert into public.message (campaign_contact_id, contact_number, assignment_id, is_from_contact, text, send_status, user_id, error_codes)
-        values ($1, $2, $3, $4, $5, $6, $7, $8)
+        insert into public.message (campaign_contact_id, contact_number, assignment_id, is_from_contact, text, send_status, user_id, service_id, error_codes)
+        values ($1, $2, $3, $4, $5, $6, $7, $8, $9)
         returning *
       `,
       [
@@ -255,6 +256,7 @@ export const createMessage = async (
         options.text ?? faker.lorem.paragraph(),
         options.sendStatus ?? MessageSendStatus.Delivered,
         options.userId ?? null,
+        options.serviceId ?? faker.random.uuid(),
         options.errorCodes ?? null
       ]
     )

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "google-libphonenumber": "^3.2.6",
     "google-palette": "^1.1.0",
     "graphile-scheduler": "^0.8.0",
-    "graphile-worker": "^0.9.0",
+    "graphile-worker": "^0.5.0",
     "graphql": "^0.13.2",
     "graphql-date": "^1.0.3",
     "graphql-tag": "^2.10.1",

--- a/src/server/api/lib/assemble-numbers.ts
+++ b/src/server/api/lib/assemble-numbers.ts
@@ -56,7 +56,7 @@ interface NumbersInboundMessagePayload {
   sendingLocationId: string;
 }
 
-interface NumbersDeliveryReportPayload {
+export interface NumbersDeliveryReportPayload {
   errorCodes: string[];
   eventType: NumbersSendStatus;
   generatedAt: string;

--- a/src/server/api/lib/assemble-numbers.ts
+++ b/src/server/api/lib/assemble-numbers.ts
@@ -283,26 +283,31 @@ export const processDeliveryReportBody = async (
   );
 
   // Update segment counts
-  if (
-    extra &&
-    (typeof extra.num_segments === "number" ||
-      typeof extra.num_media === "number")
-  ) {
-    await client.query(
-      `
-        update message
-        set
-          num_segments = coalesce($1, num_segments),
-          num_media = coalesce($2, num_media)
-        where
-          service_id = $3
-          and (
-            num_segments is null
-            or num_media is null
-          )
-      `,
-      [extra.num_segments || null, extra.num_media || null, messageId]
-    );
+  if (extra) {
+    const { num_segments, num_media } = extra;
+    const hasNumSegments = typeof num_segments === "number";
+    const hasNumMedia = typeof num_media === "number";
+
+    if (hasNumSegments || hasNumMedia) {
+      const numSegments = hasNumSegments ? num_segments : null;
+      const numMedia = hasNumMedia ? num_media : null;
+
+      await client.query(
+        `
+          update message
+          set
+            num_segments = coalesce($1, num_segments),
+            num_media = coalesce($2, num_media)
+          where
+            service_id = $3
+            and (
+              num_segments is null
+              or num_media is null
+            )
+        `,
+        [numSegments, numMedia, messageId]
+      );
+    }
   }
 };
 

--- a/src/server/api/lib/assemble-numbers.ts
+++ b/src/server/api/lib/assemble-numbers.ts
@@ -441,7 +441,7 @@ export default {
   inboundMessageValidator,
   deliveryReportValidator,
   handleDeliveryReport,
-  processDeliveryReport,
+  processDeliveryReportBody,
   handleIncomingMessage,
   convertMessagePartsToMessage
 };

--- a/src/server/api/lib/assemble-numbers.ts
+++ b/src/server/api/lib/assemble-numbers.ts
@@ -268,14 +268,16 @@ export const processDeliveryReportBody = async (
       set
         service_response_at = now(),
         send_status = $1,
-        error_codes = $2
+        error_codes = $2,
+        service_response = (coalesce(service_response, '[]')::jsonb || cast($3 as jsonb))::text
       where
-        service_id = $3
-        and send_status not in ($4, $5)
+        service_id = $4
+        and send_status not in ($5, $6)
     `,
     [
       getMessageStatus(eventType),
       errorCodes,
+      JSON.stringify([reportBody]),
       messageId,
       SpokeSendStatus.Delivered,
       SpokeSendStatus.Error

--- a/src/server/api/lib/twilio.js
+++ b/src/server/api/lib/twilio.js
@@ -328,13 +328,15 @@ export const processDeliveryReportBody = async (client, reportBody) => {
       update message
       set
         service_response_at = now(),
-        send_status = $1
+        send_status = $1,
+        service_response = (coalesce(service_response, '[]')::jsonb || cast($2 as jsonb))::text
       where
-        service_id = $2
-        and send_status not in  ($3, $4)
+        service_id = $3
+        and send_status not in  ($4, $5)
     `,
     [
       getMessageStatus(MessageStatus),
+      JSON.stringify([reportBody]),
       service_id,
       SpokeSendStatus.Delivered,
       SpokeSendStatus.Error

--- a/src/server/api/lib/twilio.js
+++ b/src/server/api/lib/twilio.js
@@ -320,20 +320,26 @@ const handleDeliveryReport = async (report) =>
     body: JSON.stringify(report)
   });
 
-export const processDeliveryReport = async (body) => {
-  const { MessageSid: service_id, MessageStatus } = body;
+export const processDeliveryReportBody = async (client, reportBody) => {
+  const { MessageSid: service_id, MessageStatus } = reportBody;
 
-  await r
-    .knex("message")
-    .update({
-      service_response_at: r.knex.fn.now(),
-      send_status: getMessageStatus(MessageStatus)
-    })
-    .where({ service_id })
-    .whereNotIn("send_status", [
+  await client.query(
+    `
+      update message
+      set
+        service_response_at = now(),
+        send_status = $1
+      where
+        service_id = $2
+        and send_status not in  ($3, $4)
+    `,
+    [
+      getMessageStatus(MessageStatus),
+      service_id,
       SpokeSendStatus.Delivered,
       SpokeSendStatus.Error
-    ]);
+    ]
+  );
 };
 
 async function handleIncomingMessage(message) {
@@ -382,6 +388,6 @@ export default {
   sendMessage,
   saveNewIncomingMessage,
   handleDeliveryReport,
-  processDeliveryReport,
+  processDeliveryReportBody,
   handleIncomingMessage
 };

--- a/src/server/api/types.ts
+++ b/src/server/api/types.ts
@@ -210,3 +210,12 @@ export interface ExternalResultCodeRecord {
   created_at: string;
   updated_at: string;
 }
+
+export interface LogRecord {
+  id: number;
+  message_sid: string;
+  body: string | null;
+  created_at: string;
+  updated_at: string;
+  service_type: MessagingServiceType | null;
+}

--- a/src/server/tasks/handle-delivery-report.spec.ts
+++ b/src/server/tasks/handle-delivery-report.spec.ts
@@ -69,6 +69,7 @@ describe("handle-delivery-report", () => {
     const preJobMessage = await getMessage();
     expect(preJobMessage.num_segments).toBeNull();
     expect(preJobMessage.num_media).toBeNull();
+    expect(preJobMessage.service_response).toEqual("[]");
 
     await client.query(
       `insert into log (message_sid, body, service_type) values ($1, $2, $3)`,
@@ -93,6 +94,9 @@ describe("handle-delivery-report", () => {
     expect(postJobMessage.num_segments).toBe(extra?.num_segments);
     expect(postJobMessage.num_media).toBe(extra?.num_media);
     expect(postJobMessage.send_status).toBe("DELIVERED");
+    expect(JSON.parse(postJobMessage.service_response)).toContainEqual(
+      deliveryReport
+    );
   });
 
   it("handles twilio delivery report", async () => {

--- a/src/server/tasks/handle-delivery-report.spec.ts
+++ b/src/server/tasks/handle-delivery-report.spec.ts
@@ -1,0 +1,133 @@
+import { runTaskListOnce, WorkerOptions } from "graphile-worker";
+import { Pool, PoolClient } from "pg";
+
+import { mockDeliveryReportBody as mockSwitchboardDeliveryReportBody } from "../../../__mocks__/assemble-numbers";
+import { mockDeliveryReportBody as mockTwilioDeliveryReportBody } from "../../../__mocks__/twilio";
+import {
+  createAssignment,
+  createCampaign,
+  createCampaignContact,
+  createMessage,
+  createOrganization,
+  createTexter
+} from "../../../__test__/testbed-preparation/core";
+import { config } from "../../config";
+import { MessageRecord, MessagingServiceType } from "../api/types";
+import { handleDeliveryReport } from "./handle-delivery-report";
+
+describe("handle-delivery-report", () => {
+  let pool: Pool;
+  let client: PoolClient;
+  let workerOptions: WorkerOptions;
+  let campaignContactId: number;
+  let assignmentId: number;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: config.TEST_DATABASE_URL });
+    workerOptions = { pgPool: pool };
+    client = await pool.connect();
+
+    // Set up campaign contact
+    const texter = await createTexter(client, {});
+    const organization = await createOrganization(client, {});
+    const campaign = await createCampaign(client, {
+      organizationId: organization.id
+    });
+    const campaignContact = await createCampaignContact(client, {
+      campaignId: campaign.id
+    });
+    const assignment = await createAssignment(client, {
+      campaignId: campaign.id,
+      userId: texter.id
+    });
+    campaignContactId = campaignContact.id;
+    assignmentId = assignment.id;
+  });
+
+  afterAll(async () => {
+    if (client) client.release();
+    if (pool) await pool.end();
+  });
+
+  it("handles assemble-numbers delivery report", async () => {
+    const message = await createMessage(client, {
+      assignmentId,
+      campaignContactId,
+      sendStatus: "SENT"
+    });
+    const deliveryReport = mockSwitchboardDeliveryReportBody(
+      message.service_id
+    );
+
+    const getMessage = () =>
+      client
+        .query<MessageRecord>(`select * from message where id = $1`, [
+          message.id
+        ])
+        .then(({ rows: [messageRecord] }) => messageRecord);
+
+    const preJobMessage = await getMessage();
+    expect(preJobMessage.num_segments).toBeNull();
+    expect(preJobMessage.num_media).toBeNull();
+
+    await client.query(
+      `insert into log (message_sid, body, service_type) values ($1, $2, $3)`,
+      [
+        message.service_id,
+        JSON.stringify(deliveryReport),
+        MessagingServiceType.AssembleNumbers
+      ]
+    );
+    await runTaskListOnce(
+      workerOptions,
+      {
+        "handle-delivery-report": handleDeliveryReport
+      },
+      client
+    );
+
+    const postJobMessage = await getMessage();
+    const { extra } = deliveryReport;
+    expect(postJobMessage.num_segments).not.toBeNull();
+    expect(postJobMessage.num_media).not.toBeNull();
+    expect(postJobMessage.num_segments).toBe(extra?.num_segments);
+    expect(postJobMessage.num_media).toBe(extra?.num_media);
+    expect(postJobMessage.send_status).toBe("DELIVERED");
+  });
+
+  it("handles twilio delivery report", async () => {
+    const message = await createMessage(client, {
+      assignmentId,
+      campaignContactId,
+      sendStatus: "SENT"
+    });
+    const deliveryReport = mockTwilioDeliveryReportBody(message.service_id);
+    await client.query(
+      `insert into log (message_sid, body, service_type) values ($1, $2, $3)`,
+      [
+        message.service_id,
+        JSON.stringify(deliveryReport),
+        MessagingServiceType.Twilio
+      ]
+    );
+    await runTaskListOnce(
+      workerOptions,
+      {
+        "handle-delivery-report": handleDeliveryReport
+      },
+      client
+    );
+
+    const {
+      rows: [messageRecord]
+    } = await client.query<MessageRecord>(
+      `select * from message where id = $1`,
+      [message.id]
+    );
+
+    expect(messageRecord.send_status).toBe("DELIVERED");
+    // Twilio segment counts are recorded at send-time
+    expect(messageRecord.num_segments).toBeNull();
+    expect(messageRecord.num_media).toBeNull();
+  });
+});

--- a/src/server/tasks/handle-delivery-report.spec.ts
+++ b/src/server/tasks/handle-delivery-report.spec.ts
@@ -133,5 +133,8 @@ describe("handle-delivery-report", () => {
     // Twilio segment counts are recorded at send-time
     expect(messageRecord.num_segments).toBeNull();
     expect(messageRecord.num_media).toBeNull();
+    expect(JSON.parse(messageRecord.service_response)).toContainEqual(
+      deliveryReport
+    );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -11864,20 +11864,6 @@ graphile-worker@^0.5.0:
     tslib "^1.9.3"
     yargs "^15.1.0"
 
-graphile-worker@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/graphile-worker/-/graphile-worker-0.9.0.tgz#aa1c794dea80acf7abeb68c5c8ce6a2c41675b1a"
-  integrity sha512-tb3zT0k3XCsVWUqReA1NlepkD4Pezmd1Ot9+9ItKxLLElK2T17eYpkMEsk48vH3yR7tMQSnwJHrEuirtn9z6fg==
-  dependencies:
-    "@types/debug" "^4.1.2"
-    "@types/pg" "^7.14.3"
-    chokidar "^3.4.0"
-    cosmiconfig "^7.0.0"
-    json5 "^2.1.3"
-    pg ">=6.5 <9"
-    tslib "^2.1.0"
-    yargs "^16.2.0"
-
 graphile-worker@~0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/graphile-worker/-/graphile-worker-0.8.1.tgz#101bc21fec8dfb1a307a9ebd290362ac7d3a3ec2"
@@ -14754,13 +14740,6 @@ json5@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.2.tgz#43ef1f0af9835dd624751a6b7fa48874fb2d608e"
   integrity sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==
-  dependencies:
-    minimist "^1.2.5"
-
-json5@^2.1.3:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
-  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
   dependencies:
     minimist "^1.2.5"
 
@@ -23949,7 +23928,7 @@ yargs@^15.4.1:
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
 
-yargs@^16.0.3, yargs@^16.2.0:
+yargs@^16.0.3:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
   integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==


### PR DESCRIPTION
## Description

Delete records from `log` after `handle-delivery-report` completes.

## Motivation and Context

There is no need to keep a log record around once it has been successfully processed. A large log
table only makes it more difficult to debug when delivery reports have _not_ been processed
correctly.

## How Has This Been Tested?

See `src/server/tasks/handle-delivery-report.spec.ts`.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
