### PR TITLE
fix: disambiguate deliverability stats

### DIFF
--- a/src/api/campaign.ts
+++ b/src/api/campaign.ts
@@ -22,6 +22,19 @@ export interface JobRequest {
   updatedAt: string;
 }
 
+export interface DeliverabilityErrorStat {
+  errorCode: string | null;
+  count: number;
+}
+
+export interface CampaignDeliverabilityStats {
+  deliveredCount: number;
+  sendingCount: number;
+  sentCount: number;
+  errorCount: number;
+  specificErrors: DeliverabilityErrorStat[];
+}
+
 export interface CampaignsFilter {
   isArchived?: boolean;
   organizationId?: number;
@@ -57,6 +70,7 @@ export interface Campaign {
   teams: Team[];
   externalSystem?: ExternalSystem | null;
   creator?: User | null;
+  deliverabilityStats: CampaignDeliverabilityStats;
 }
 
 export interface PaginatedCampaigns {
@@ -92,6 +106,7 @@ export const schema = `
 
   type CampaignDeliverabilityStats {
     deliveredCount: Int!
+    sendingCount: Int!
     sentCount: Int!
     errorCount: Int!
     specificErrors: [DeliverabilityErrorStat]

--- a/src/containers/AdminCampaignStats/DeliverabilityStats.tsx
+++ b/src/containers/AdminCampaignStats/DeliverabilityStats.tsx
@@ -9,27 +9,27 @@ import theme from "../../styles/theme";
 import { loadData } from "../hoc/with-operations";
 import CampaignStat from "./CampaignStat";
 
-const descriptions = {
-  40001: "Invalid destination number",
-  40002: "Blocked as spam",
-  40003: "Blocked as spam",
-  40004: "Unknown",
-  40005: "Expired",
-  40006: "Carrier outage",
-  40007: "Unknown",
-  40008: "Unknown",
-  40009: "Invalid body",
-  40011: "Too many messages",
-  40012: "Invalid destination number",
-  21610: "Recipient unsubscribed",
-  30001: "Queue overflow",
-  30002: "Account suspended",
-  30003: "Unreachable phone number",
-  30004: "Message blocked",
-  30005: "Unknown destination handset",
-  30006: "Landline or unreachable carrier",
-  30007: "Blocked as spam",
-  30008: "Unknown error"
+const descriptions: Record<string, string> = {
+  "40001": "Invalid destination number",
+  "40002": "Blocked as spam",
+  "40003": "Blocked as spam",
+  "40004": "Unknown",
+  "40005": "Expired",
+  "40006": "Carrier outage",
+  "40007": "Unknown",
+  "40008": "Unknown",
+  "40009": "Invalid body",
+  "40011": "Too many messages",
+  "40012": "Invalid destination number",
+  "21610": "Recipient unsubscribed",
+  "30001": "Queue overflow",
+  "30002": "Account suspended",
+  "30003": "Unreachable phone number",
+  "30004": "Message blocked",
+  "30005": "Unknown destination handset",
+  "30006": "Landline or unreachable carrier",
+  "30007": "Blocked as spam",
+  "30008": "Unknown error"
 };
 
 const styles = StyleSheet.create({
@@ -99,15 +99,18 @@ const DeliverabilityStats = (props: {
       <div className={css(styles.secondaryHeader)}>Top errors:</div>
       {specificErrors
         .sort((a, b) => b.count - a.count)
-        .map((e) => (
-          <div key={e.errorCode}>
-            {e.errorCode}{" "}
-            {descriptions[e.errorCode]
-              ? `(${descriptions[e.errorCode]})`
-              : "Unknown error"}
-            : {asPercentWithTotal(e.count, total)}
-          </div>
-        ))}
+        .map((e) => {
+          const errorCode = e.errorCode ? `${e.errorCode}` : "n/a";
+          return (
+            <div key={errorCode}>
+              {errorCode}{" "}
+              {descriptions[errorCode]
+                ? `(${descriptions[errorCode]})`
+                : "Unknown error"}
+              : {asPercentWithTotal(e.count, total)}
+            </div>
+          );
+        })}
     </div>
   );
 };

--- a/src/containers/AdminCampaignStats/DeliverabilityStats.tsx
+++ b/src/containers/AdminCampaignStats/DeliverabilityStats.tsx
@@ -3,6 +3,7 @@ import gql from "graphql-tag";
 import PropTypes from "prop-types";
 import React from "react";
 
+import { Campaign } from "../../api/campaign";
 import { asPercentWithTotal } from "../../lib/utils";
 import theme from "../../styles/theme";
 import { loadData } from "../hoc/with-operations";
@@ -53,18 +54,7 @@ const styles = StyleSheet.create({
 
 const DeliverabilityStats = (props: {
   data: {
-    campaign: {
-      id: string;
-      deliverabilityStats: {
-        deliveredCount: number;
-        sentCount: number;
-        errorCount: number;
-        specificErrors: {
-          errorCode: string;
-          count: number;
-        }[];
-      };
-    };
+    campaign: Pick<Campaign, "id" | "deliverabilityStats">;
   };
 }) => {
   const {
@@ -72,6 +62,7 @@ const DeliverabilityStats = (props: {
       campaign: {
         deliverabilityStats: {
           deliveredCount,
+          sendingCount,
           sentCount,
           errorCount,
           specificErrors
@@ -80,7 +71,7 @@ const DeliverabilityStats = (props: {
     }
   } = props;
 
-  const total = deliveredCount + sentCount + errorCount;
+  const total = deliveredCount + sendingCount + sentCount + errorCount;
 
   return (
     <div>
@@ -94,7 +85,7 @@ const DeliverabilityStats = (props: {
         <div className={css(styles.flexColumn, styles.spacer)}>
           <CampaignStat
             title="Sending"
-            count={asPercentWithTotal(sentCount, total)}
+            count={asPercentWithTotal(sendingCount + sentCount, total)}
           />
         </div>
         <div className={css(styles.flexColumn, styles.spacer)}>
@@ -133,6 +124,7 @@ const queries = {
           id
           deliverabilityStats {
             deliveredCount
+            sendingCount
             sentCount
             errorCount
             specificErrors {

--- a/src/containers/AdminCampaignStats/index.jsx
+++ b/src/containers/AdminCampaignStats/index.jsx
@@ -281,7 +281,7 @@ class AdminCampaignStats extends React.Component {
         <CampaignSurveyStats campaignId={campaign.id} />
 
         <br />
-        <div className={css(styles.header)}>Deliverability</div>
+        <div className={css(styles.header)}>Outbound Deliverability</div>
         <DeliverabilityStats campaignId={campaign.id} />
         <br />
 

--- a/src/server/api/lib/campaign.ts
+++ b/src/server/api/lib/campaign.ts
@@ -72,6 +72,7 @@ export const getDeliverabilityStats = async (campaignId: number) => {
 
   const result = {
     deliveredCount: rows.find((o) => o.send_status === "DELIVERED")?.count || 0,
+    sendingCount: rows.find((o) => o.send_status === "SENDING")?.count || 0,
     sentCount: rows.find((o) => o.send_status === "SENT")?.count || 0,
     errorCount:
       rows


### PR DESCRIPTION
## Description

Specify that deliverability stats only include outbound messages to avoid confusion.

This also bundles `SENDING` and `SENT` statuses for accuracy.

## Motivation and Context

The difference between the deliverability counts and full message export counts can seem like a discrepancy if you don't know that deliverability only includes outbound messages. The copy change in this PR aims to make this clear.

## How Has This Been Tested?

This has been tested locally/

## Screenshots (if appropriate):

<table><tr><td>

![Screen Shot 2021-08-03 at 9 36 27 AM](https://user-images.githubusercontent.com/2145526/128026243-28b50833-9c5b-43fb-b692-d7856480e200.png)

</td></tr></table>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

The section title has been updated here:
https://docs.spokerewired.com/article/121-campaign-metrics

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] My change requires a change to the documentation.
- [x] I have included updates for the documentation accordingly.
