### PR TITLE
fix: display gsform errors

### DIFF
--- a/src/components/forms/GSForm.jsx
+++ b/src/components/forms/GSForm.jsx
@@ -5,6 +5,7 @@ import Form from "react-formal";
 
 import theme from "../../styles/theme";
 import GSSubmitButton from "./GSSubmitButton";
+import SpokeFormField from "./SpokeFormField";
 
 const styles = StyleSheet.create({
   errorMessage: {
@@ -101,7 +102,7 @@ export default class GSForm extends React.Component {
       if (!React.isValidElement(child)) {
         return child;
       }
-      if (child.type === Form.Field) {
+      if (child.type === Form.Field || child.type === SpokeFormField) {
         const { name } = child.props;
         let error = this.state.formErrors ? this.state.formErrors[name] : null;
         let clonedElement = child;


### PR DESCRIPTION
## Description

Fix handling of errors in GSForm so that error messages are actually displayed.

## Motivation and Context

Closes #934.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

![Screen Shot 2021-08-06 at 11 36 18 AM](https://user-images.githubusercontent.com/2145526/128535598-7f0d928f-4482-4520-8bc8-6b43e1f2c43e.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
