### PR TITLE
fix(slack): set unknown phone number for empty string

### DIFF
--- a/src/server/auth-passport.ts
+++ b/src/server/auth-passport.ts
@@ -154,7 +154,7 @@ function setupSlackPassport() {
         auth0_id: auth0Id,
         first_name,
         last_name,
-        cell: user.phone ?? "unknown",
+        cell: user.phone || "unknown",
         email: user.email,
         is_superadmin: false
       };


### PR DESCRIPTION
## Description

Replace empty string phone numbers from Slack with `'unknown'`.

## Motivation and Context

Slack profiles without a phone number send an empty string, not null. Using the null coalescing
operator, ??, results in saving this empty string. That in turn prevents editing user records.

Related to #934.

## How Has This Been Tested?

```sh
$ node

> console.log('' ?? 'unknown');

> console.log('' || 'unknown');
unknown
```

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
