### PR TITLE
fix: preserve nextUrl through slack login flow

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -165,7 +165,7 @@ const Login: React.FC = () => {
     case "slack":
       // If Slack strategy, the server needs to initiate the redirect
       // Force reload will hit the server redirect (as opposed to client routing)
-      window.location.href = "/login";
+      window.location.href = `${window.location.href}`;
       return <div />;
 
     case "local":

--- a/src/server/auth-passport.ts
+++ b/src/server/auth-passport.ts
@@ -173,13 +173,15 @@ function setupSlackPassport() {
     return redirectPostSignIn(req, res, false);
   };
 
-  // Cast as any to allow passing Slack options
-  const passportOptions: any = {
-    scope: SLACK_SCOPES.split(",")
-  };
-
   const app = express();
-  app.get("/login", passport.authenticate("slack", passportOptions));
+  app.get("/login", (req, res, next) => {
+    // Cast as any to allow passing Slack options
+    const passportOptions: any = {
+      scope: SLACK_SCOPES.split(","),
+      state: req.query.nextUrl
+    };
+    return passport.authenticate("slack", passportOptions)(req, res, next);
+  });
 
   app.get(
     "/login-callback",


### PR DESCRIPTION
## Description

Preserve the `nextUrl` query param through the Slack OAuth flow.

## Motivation and Context

The `nextUrl` query param is very important for user experience (e.g. only needing to visit the join link once). Preserving it through the login process allows us to redirect the user to the correct location post-Slack login.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
