### PR TITLE
feat: add resend-message task

### DIFF
--- a/src/server/api/lib/assemble-numbers.ts
+++ b/src/server/api/lib/assemble-numbers.ts
@@ -158,7 +158,7 @@ export const deliveryReportValidator: RequestHandlerFactory = () => async (
 export const sendMessage = async (
   message: SendMessagePayload,
   organizationId: number,
-  _trx: Knex
+  _trx?: Knex
 ) => {
   const {
     id: spokeMessageId,

--- a/src/server/tasks/resend-message.ts
+++ b/src/server/tasks/resend-message.ts
@@ -1,0 +1,46 @@
+/* eslint-disable import/prefer-default-export */
+import { Task } from "pg-compose";
+
+import { sendMessage } from "../api/lib/assemble-numbers";
+import { SendMessagePayload } from "../api/lib/types";
+
+/*
+To create these jobs, run:
+
+select graphile_worker.add_job(
+	'resend-message',
+	row_to_json(jobs)
+)
+from (
+	select
+	  m.id,
+		m.user_id,
+		m.campaign_contact_id,
+		m.text,
+		m.contact_number,
+		m.assignment_id,
+		m.send_status,
+		m.service,
+		m.is_from_contact,
+		m.queued_at,
+		m.send_before, -- maybe change
+		m.script_version_hash,
+		c.organization_id
+	from message m
+	join campaign_contact cc on cc.id = m.campaign_contact_id
+	join campaign c on cc.campaign_id = c.id
+	where -- your custom requeue where clauses here
+) jobs
+
+*/
+
+type ResendMessagePayload = { organization_id: number } & SendMessagePayload;
+
+export const resendMessage: Task = async (payload, _helpers) => {
+  const {
+    organization_id,
+    ...sendMessagePayload
+  } = payload as ResendMessagePayload;
+
+  await sendMessage(sendMessagePayload, organization_id);
+};

--- a/src/server/tasks/resend-message.ts
+++ b/src/server/tasks/resend-message.ts
@@ -8,28 +8,28 @@ import { SendMessagePayload } from "../api/lib/types";
 To create these jobs, run:
 
 select graphile_worker.add_job(
-	'resend-message',
-	row_to_json(jobs)
+  'resend-message',
+  row_to_json(jobs)
 )
 from (
-	select
-	  m.id,
-		m.user_id,
-		m.campaign_contact_id,
-		m.text,
-		m.contact_number,
-		m.assignment_id,
-		m.send_status,
-		m.service,
-		m.is_from_contact,
-		m.queued_at,
-		m.send_before, -- maybe change
-		m.script_version_hash,
-		c.organization_id
-	from message m
-	join campaign_contact cc on cc.id = m.campaign_contact_id
-	join campaign c on cc.campaign_id = c.id
-	where -- your custom requeue where clauses here
+  select
+    m.id,
+    m.user_id,
+    m.campaign_contact_id,
+    m.text,
+    m.contact_number,
+    m.assignment_id,
+    m.send_status,
+    m.service,
+    m.is_from_contact,
+    m.queued_at,
+    m.send_before, -- maybe change
+    m.script_version_hash,
+    c.organization_id
+  from message m
+  join campaign_contact cc on cc.id = m.campaign_contact_id
+  join campaign c on cc.campaign_id = c.id
+  where -- your custom requeue where clauses here
 ) jobs
 
 */

--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -27,6 +27,7 @@ import {
 import handleAutoassignmentRequest from "./tasks/handle-autoassignment-request";
 import handleDeliveryReport from "./tasks/handle-delivery-report";
 import { releaseStaleReplies } from "./tasks/release-stale-replies";
+import { resendMessage } from "./tasks/resend-message";
 import {
   syncCampaignContactToVAN,
   updateVanSyncStatuses
@@ -68,6 +69,7 @@ export const getWorker = async (attempt = 0): Promise<PgComposeWorker> => {
   m.taskList!["van-sync-campaign-contact"] = syncCampaignContactToVAN;
   m.taskList!["update-van-sync-statuses"] = updateVanSyncStatuses;
   m.taskList!["update-org-message-usage"] = updateOrgMessageUsage;
+  m.taskList!["resend-message"] = resendMessage;
   m.taskList![exportCampaignIdentifier] = wrapProgressTask(exportCampaign, {
     removeOnComplete: true
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds a resend message task + inline instructions to re-queue it.

## Motivation and Context

Sometimes, we have to resend messages. This makes it possible from a running Spoke deployment, which is much easier than any alternative.

## How Has This Been Tested?

I've run this before locally.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
