### PR TITLE
feat(trollbot): improve query perf

### DIFF
--- a/migrations/20210902145452_improve-trollbot-perf.js
+++ b/migrations/20210902145452_improve-trollbot-perf.js
@@ -1,0 +1,78 @@
+exports.up = function (knex) {
+  return knex.schema.raw(`
+		CREATE OR REPLACE FUNCTION public.get_trollbot_matches(organization_id integer, troll_interval interval)
+			RETURNS TABLE(message_id integer, trigger_token text)
+			LANGUAGE sql
+			STABLE SECURITY DEFINER
+			SET search_path TO 'public'
+		AS $function$
+					with troll_tokens as (
+						select token, mode, compiled_tsquery
+						from troll_trigger
+						where troll_trigger.organization_id = get_trollbot_matches.organization_id
+					),
+					ts_queries as (
+						select mode, to_tsquery('(' || array_to_string(array_agg(token), ') | (') || ')') as tsquery
+						from troll_trigger
+						where troll_trigger.organization_id = 1 
+						group by 1
+					),
+					bad_messages as (
+						select distinct on (message.id) message.id, mode, text, is_from_contact
+						from message
+						join campaign_contact
+							on campaign_contact.id = message.campaign_contact_id
+						join campaign
+							on campaign.id = campaign_contact.campaign_id
+						join ts_queries on to_tsvector(mode, message.text) @@ ts_queries.tsquery
+						where true
+							and message.created_at >= now() - get_trollbot_matches.troll_interval
+							and message.is_from_contact = false
+							and campaign.organization_id = get_trollbot_matches.organization_id
+						order by message.id, mode
+					),
+					messages_with_match as (
+						select bad_messages.id, bad_messages.text, token
+						from bad_messages
+						join troll_tokens on to_tsvector(troll_tokens.mode, bad_messages.text) @@ troll_tokens.compiled_tsquery
+						where troll_tokens.mode = bad_messages.mode
+					)
+					select id, token::text as trigger_token 
+					from messages_with_match 
+				$function$
+	`);
+};
+
+exports.down = function (knex) {
+  return knex.schema.raw(`
+		CREATE OR REPLACE FUNCTION public.get_trollbot_matches(organization_id integer, troll_interval interval)
+		RETURNS TABLE(message_id integer, trigger_token text)
+		LANGUAGE plpgsql
+		STABLE SECURITY DEFINER
+		SET search_path TO 'public'
+		AS $function$
+				begin
+					return query
+						with troll_tokens as (
+							select token, mode, compiled_tsquery
+							from troll_trigger
+							where troll_trigger.organization_id = get_trollbot_matches.organization_id
+						)
+						select distinct on (message.id)
+							message.id as message_id,
+							troll_tokens.token::text as trigger_token
+						from message
+						join campaign_contact
+							on campaign_contact.id = message.campaign_contact_id
+						join campaign
+							on campaign.id = campaign_contact.campaign_id
+						join troll_tokens
+							on to_tsvector(troll_tokens.mode, message.text) @@ troll_tokens.compiled_tsquery
+						where true
+							and campaign.organization_id = get_trollbot_matches.organization_id
+							and message.created_at >= now() - get_trollbot_matches.troll_interval
+							and is_from_contact = false;
+				end;
+				$function$
+	`);
+};

--- a/migrations/20210902145452_improve-trollbot-perf.js
+++ b/migrations/20210902145452_improve-trollbot-perf.js
@@ -1,78 +1,81 @@
-exports.up = function (knex) {
+exports.up = function up(knex) {
   return knex.schema.raw(`
-		CREATE OR REPLACE FUNCTION public.get_trollbot_matches(organization_id integer, troll_interval interval)
-			RETURNS TABLE(message_id integer, trigger_token text)
-			LANGUAGE sql
-			STABLE SECURITY DEFINER
-			SET search_path TO 'public'
-		AS $function$
-					with troll_tokens as (
-						select token, mode, compiled_tsquery
-						from troll_trigger
-						where troll_trigger.organization_id = get_trollbot_matches.organization_id
-					),
-					ts_queries as (
-						select mode, to_tsquery('(' || array_to_string(array_agg(token), ') | (') || ')') as tsquery
-						from troll_trigger
-						where troll_trigger.organization_id = get_trollbot_matches.organization_id
-						group by 1
-					),
-					bad_messages as (
-						select distinct on (message.id) message.id, mode, text, is_from_contact
-						from message
-						join campaign_contact
-							on campaign_contact.id = message.campaign_contact_id
-						join campaign
-							on campaign.id = campaign_contact.campaign_id
-						join ts_queries on to_tsvector(mode, message.text) @@ ts_queries.tsquery
-						where true
-							and message.created_at >= now() - get_trollbot_matches.troll_interval
-							and message.is_from_contact = false
-							and campaign.organization_id = get_trollbot_matches.organization_id
-						order by message.id, mode
-					),
-					messages_with_match as (
-						select bad_messages.id, bad_messages.text, token
-						from bad_messages
-						join troll_tokens on to_tsvector(troll_tokens.mode, bad_messages.text) @@ troll_tokens.compiled_tsquery
-						where troll_tokens.mode = bad_messages.mode
-					)
-					select id, token::text as trigger_token 
-					from messages_with_match 
-				$function$
-	`);
+  create or replace function public.get_trollbot_matches (organization_id integer, troll_interval interval)
+  returns table (
+    message_id integer,
+    trigger_token text
+  )
+  as $$
+  begin
+    return query
+      with troll_tokens as (
+        select token, mode, compiled_tsquery
+        from troll_trigger
+        where troll_trigger.organization_id = get_trollbot_matches.organization_id
+      ),
+      ts_queries as (
+        select mode, to_tsquery('(' || array_to_string(array_agg(token), ') | (') || ')') as tsquery
+        from troll_trigger
+        where troll_trigger.organization_id = get_trollbot_matches.organization_id
+        group by 1
+      ),
+      bad_messages as (
+        select distinct on (message.id) message.id, mode, text, is_from_contact
+        from message
+        join campaign_contact
+          on campaign_contact.id = message.campaign_contact_id
+        join campaign
+          on campaign.id = campaign_contact.campaign_id
+        join ts_queries on to_tsvector(mode, message.text) @@ ts_queries.tsquery
+        where true
+          and message.created_at >= now() - get_trollbot_matches.troll_interval
+          and message.is_from_contact = false
+          and campaign.organization_id = get_trollbot_matches.organization_id
+        order by message.id, mode
+      ),
+      messages_with_match as (
+        select bad_messages.id, bad_messages.text, token
+        from bad_messages
+        join troll_tokens on to_tsvector(troll_tokens.mode, bad_messages.text) @@ troll_tokens.compiled_tsquery
+        where troll_tokens.mode = bad_messages.mode
+      )
+      select id, token::text as trigger_token
+      from messages_with_match;
+  end;
+  $$ language plpgsql stable security definer set search_path = "public";
+  `);
 };
 
-exports.down = function (knex) {
+exports.down = function down(knex) {
   return knex.schema.raw(`
-		CREATE OR REPLACE FUNCTION public.get_trollbot_matches(organization_id integer, troll_interval interval)
-		RETURNS TABLE(message_id integer, trigger_token text)
-		LANGUAGE plpgsql
-		STABLE SECURITY DEFINER
-		SET search_path TO 'public'
-		AS $function$
-				begin
-					return query
-						with troll_tokens as (
-							select token, mode, compiled_tsquery
-							from troll_trigger
-							where troll_trigger.organization_id = get_trollbot_matches.organization_id
-						)
-						select distinct on (message.id)
-							message.id as message_id,
-							troll_tokens.token::text as trigger_token
-						from message
-						join campaign_contact
-							on campaign_contact.id = message.campaign_contact_id
-						join campaign
-							on campaign.id = campaign_contact.campaign_id
-						join troll_tokens
-							on to_tsvector(troll_tokens.mode, message.text) @@ troll_tokens.compiled_tsquery
-						where true
-							and campaign.organization_id = get_trollbot_matches.organization_id
-							and message.created_at >= now() - get_trollbot_matches.troll_interval
-							and is_from_contact = false;
-				end;
-				$function$
-	`);
+    create or replace function public.get_trollbot_matches (organization_id integer, troll_interval interval)
+      returns table (
+        message_id integer,
+        trigger_token text
+      )
+    as $$
+    begin
+      return query
+        with troll_tokens as (
+          select token, mode, compiled_tsquery
+          from troll_trigger
+          where troll_trigger.organization_id = get_trollbot_matches.organization_id
+        )
+        select distinct on (message.id)
+          message.id as message_id,
+          troll_tokens.token::text as trigger_token
+        from message
+        join campaign_contact
+          on campaign_contact.id = message.campaign_contact_id
+        join campaign
+          on campaign.id = campaign_contact.campaign_id
+        join troll_tokens
+          on to_tsvector(troll_tokens.mode, message.text) @@ troll_tokens.compiled_tsquery
+        where true
+          and campaign.organization_id = get_trollbot_matches.organization_id
+          and message.created_at >= now() - get_trollbot_matches.troll_interval
+          and is_from_contact = false;
+    end;
+    $$ language plpgsql stable security definer set search_path = "public";
+  `);
 };

--- a/migrations/20210902145452_improve-trollbot-perf.js
+++ b/migrations/20210902145452_improve-trollbot-perf.js
@@ -14,7 +14,7 @@ exports.up = function (knex) {
 					ts_queries as (
 						select mode, to_tsquery('(' || array_to_string(array_agg(token), ') | (') || ')') as tsquery
 						from troll_trigger
-						where troll_trigger.organization_id = 1 
+						where troll_trigger.organization_id = get_trollbot_matches.organization_id
 						group by 1
 					),
 					bad_messages as (

--- a/schema-dump.sql
+++ b/schema-dump.sql
@@ -365,29 +365,43 @@ CREATE FUNCTION public.get_trollbot_matches(organization_id integer, troll_inter
     LANGUAGE plpgsql STABLE SECURITY DEFINER
     SET search_path TO 'public'
     AS $$
-    begin
-      return query
-        with troll_tokens as (
-          select token, mode, compiled_tsquery
-          from troll_trigger
-          where troll_trigger.organization_id = get_trollbot_matches.organization_id
-        )
-        select distinct on (message.id)
-          message.id as message_id,
-          troll_tokens.token::text as trigger_token
+  begin
+    return query
+      with troll_tokens as (
+        select token, mode, compiled_tsquery
+        from troll_trigger
+        where troll_trigger.organization_id = get_trollbot_matches.organization_id
+      ),
+      ts_queries as (
+        select mode, to_tsquery('(' || array_to_string(array_agg(token), ') | (') || ')') as tsquery
+        from troll_trigger
+        where troll_trigger.organization_id = get_trollbot_matches.organization_id
+        group by 1
+      ),
+      bad_messages as (
+        select distinct on (message.id) message.id, mode, text, is_from_contact
         from message
         join campaign_contact
           on campaign_contact.id = message.campaign_contact_id
         join campaign
           on campaign.id = campaign_contact.campaign_id
-        join troll_tokens
-          on to_tsvector(troll_tokens.mode, message.text) @@ troll_tokens.compiled_tsquery
+        join ts_queries on to_tsvector(mode, message.text) @@ ts_queries.tsquery
         where true
-          and campaign.organization_id = get_trollbot_matches.organization_id
           and message.created_at >= now() - get_trollbot_matches.troll_interval
-          and is_from_contact = false;
-    end;
-    $$;
+          and message.is_from_contact = false
+          and campaign.organization_id = get_trollbot_matches.organization_id
+        order by message.id, mode
+      ),
+      messages_with_match as (
+        select bad_messages.id, bad_messages.text, token
+        from bad_messages
+        join troll_tokens on to_tsvector(troll_tokens.mode, bad_messages.text) @@ troll_tokens.compiled_tsquery
+        where troll_tokens.mode = bad_messages.mode
+      )
+      select id, token::text as trigger_token
+      from messages_with_match;
+  end;
+  $$;
 
 
 ALTER FUNCTION public.get_trollbot_matches(organization_id integer, troll_interval interval) OWNER TO postgres;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This improves the performance of `get_trollbot_matches` by only running a ts_query for each token if we have already determined that the message matches at least one token for that stemming mode.

## Motivation and Context

We think the long running query times of trollbot may have been negative impacting some other queries, particularly delivery report handling.

## How Has This Been Tested?

Running the query directly on production - just a select.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
