### PR TITLE
fix: add missing primary keys

### DIFF
--- a/migrations/20210902181911_add-missing-primary-keys.js
+++ b/migrations/20210902181911_add-missing-primary-keys.js
@@ -1,0 +1,41 @@
+exports.up = function up(knex) {
+  return knex.schema.raw(`
+    alter table public.campaign_team
+      add column id serial primary key;
+
+    alter table public.user_team
+      add column id serial primary key;
+
+    alter table public.team_escalation_tags
+      add column id serial primary key;
+
+    -- We cannot turn existing unique index into primary key index without recreating the index
+    -- Just set the replica identity instead
+    alter table public.messaging_service_stick
+      alter column organization_id set not null,
+      alter column messaging_service_sid set not null,
+      alter column cell set not null;
+    alter table public.messaging_service_stick
+      replica identity using index messaging_service_stick_cell_organization_unique_constraint;
+  `);
+};
+
+exports.down = function down(knex) {
+  return knex.schema.raw(`
+    alter table public.campaign_team
+      drop column id;
+
+    alter table public.user_team
+      drop column id;
+
+    alter table public.team_escalation_tags
+      drop column id;
+
+    alter table public.messaging_service_stick
+      replica identity default;
+    alter table public.messaging_service_stick
+      alter column organization_id drop not null,
+      alter column messaging_service_sid drop not null,
+      alter column cell drop not null;
+  `);
+};

--- a/schema-dump.sql
+++ b/schema-dump.sql
@@ -1644,11 +1644,34 @@ CREATE TABLE public.campaign_team (
     campaign_id integer,
     team_id integer,
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    id integer NOT NULL
 );
 
 
 ALTER TABLE public.campaign_team OWNER TO postgres;
+
+--
+-- Name: campaign_team_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.campaign_team_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.campaign_team_id_seq OWNER TO postgres;
+
+--
+-- Name: campaign_team_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.campaign_team_id_seq OWNED BY public.campaign_team.id;
+
 
 --
 -- Name: canned_response; Type: TABLE; Schema: public; Owner: postgres
@@ -2355,9 +2378,9 @@ ALTER SEQUENCE public.message_id_seq OWNED BY public.message.id;
 --
 
 CREATE TABLE public.messaging_service_stick (
-    cell text,
-    organization_id integer,
-    messaging_service_sid text,
+    cell text NOT NULL,
+    organization_id integer NOT NULL,
+    messaging_service_sid text NOT NULL,
     updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP
 )
 WITH (autovacuum_vacuum_scale_factor='0', autovacuum_vacuum_threshold='20000');
@@ -2640,11 +2663,34 @@ CREATE TABLE public.team_escalation_tags (
     team_id integer,
     tag_id integer,
     created_at timestamp with time zone,
-    updated_at timestamp with time zone
+    updated_at timestamp with time zone,
+    id integer NOT NULL
 );
 
 
 ALTER TABLE public.team_escalation_tags OWNER TO postgres;
+
+--
+-- Name: team_escalation_tags_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.team_escalation_tags_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.team_escalation_tags_id_seq OWNER TO postgres;
+
+--
+-- Name: team_escalation_tags_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.team_escalation_tags_id_seq OWNED BY public.team_escalation_tags.id;
+
 
 --
 -- Name: team_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
@@ -2890,11 +2936,34 @@ CREATE TABLE public.user_team (
     user_id integer,
     team_id integer,
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    id integer NOT NULL
 );
 
 
 ALTER TABLE public.user_team OWNER TO postgres;
+
+--
+-- Name: user_team_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.user_team_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.user_team_id_seq OWNER TO postgres;
+
+--
+-- Name: user_team_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.user_team_id_seq OWNED BY public.user_team.id;
+
 
 --
 -- Name: zip_code; Type: TABLE; Schema: public; Owner: postgres
@@ -2953,6 +3022,13 @@ ALTER TABLE ONLY public.campaign ALTER COLUMN id SET DEFAULT nextval('public.cam
 --
 
 ALTER TABLE ONLY public.campaign_contact ALTER COLUMN id SET DEFAULT nextval('public.campaign_contact_id_seq'::regclass);
+
+
+--
+-- Name: campaign_team id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.campaign_team ALTER COLUMN id SET DEFAULT nextval('public.campaign_team_id_seq'::regclass);
 
 
 --
@@ -3061,6 +3137,13 @@ ALTER TABLE ONLY public.team ALTER COLUMN id SET DEFAULT nextval('public.team_id
 
 
 --
+-- Name: team_escalation_tags id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.team_escalation_tags ALTER COLUMN id SET DEFAULT nextval('public.team_escalation_tags_id_seq'::regclass);
+
+
+--
 -- Name: unhealthy_link_domain id; Type: DEFAULT; Schema: public; Owner: postgres
 --
 
@@ -3093,6 +3176,13 @@ ALTER TABLE ONLY public.user_cell ALTER COLUMN id SET DEFAULT nextval('public.us
 --
 
 ALTER TABLE ONLY public.user_organization ALTER COLUMN id SET DEFAULT nextval('public.user_organization_id_seq'::regclass);
+
+
+--
+-- Name: user_team id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_team ALTER COLUMN id SET DEFAULT nextval('public.user_team_id_seq'::regclass);
 
 
 --
@@ -3173,6 +3263,14 @@ ALTER TABLE ONLY public.campaign
 
 ALTER TABLE ONLY public.campaign_team
     ADD CONSTRAINT campaign_team_campaign_id_team_id_unique UNIQUE (campaign_id, team_id);
+
+
+--
+-- Name: campaign_team campaign_team_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.campaign_team
+    ADD CONSTRAINT campaign_team_pkey PRIMARY KEY (id);
 
 
 --
@@ -3414,6 +3512,8 @@ ALTER TABLE ONLY public.messaging_service
 ALTER TABLE ONLY public.messaging_service_stick
     ADD CONSTRAINT messaging_service_stick_cell_organization_unique_constraint UNIQUE (cell, organization_id);
 
+ALTER TABLE ONLY public.messaging_service_stick REPLICA IDENTITY USING INDEX messaging_service_stick_cell_organization_unique_constraint;
+
 
 --
 -- Name: monthly_organization_message_usages monthly_organization_message_usages_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
@@ -3477,6 +3577,14 @@ ALTER TABLE ONLY public.all_tag
 
 ALTER TABLE ONLY public.all_tag
     ADD CONSTRAINT tag_title_organization_id_unique UNIQUE (title, organization_id);
+
+
+--
+-- Name: team_escalation_tags team_escalation_tags_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.team_escalation_tags
+    ADD CONSTRAINT team_escalation_tags_pkey PRIMARY KEY (id);
 
 
 --
@@ -3565,6 +3673,14 @@ ALTER TABLE ONLY public.user_organization
 
 ALTER TABLE ONLY public."user"
     ADD CONSTRAINT user_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: user_team user_team_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_team
+    ADD CONSTRAINT user_team_pkey PRIMARY KEY (id);
 
 
 --


### PR DESCRIPTION
## Description

Ensure every table has a primary key or a replica identity set.

## Motivation and Context

Clickhouse's MaterializedPostgreSQL engine requires that every synced table have a primary key or a replica identity set.

Replica identity seemed like the easiest approach for `messaging_service_stick` after attempting the following:

```sql
alter table public.messaging_service_stick
      add constraint messaging_service_stick_pkey primary key using index messaging_service_stick_cell_organization_unique_constraint;
```

but getting error:

```
   - index "messaging_service_stick_cell_organization_unique_constraint" is already associated with a constraint
```

## How Has This Been Tested?

Tables without primary keys were identified using:

```sql
select tab.table_schema,
       tab.table_name
from information_schema.tables tab
left join information_schema.table_constraints tco
          on tab.table_schema = tco.table_schema
          and tab.table_name = tco.table_name
          and tco.constraint_type = 'PRIMARY KEY'
where tab.table_type = 'BASE TABLE'
      and tab.table_schema not in ('pg_catalog', 'information_schema')
      and tab.table_schema = 'public'
      and tco.constraint_name is null
order by table_schema,
         table_name;
```

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
