### PR TITLE
feat: add 10dlc registration notice

### DIFF
--- a/src/api/notice.ts
+++ b/src/api/notice.ts
@@ -3,7 +3,7 @@ import { GraphQLType } from "./types";
 
 export interface Register10DlcBrandNotice {
   id: string;
-  tcrBrandRegistrationUrl: string;
+  tcrBrandRegistrationUrl: string | null;
 }
 
 export type Notice = Register10DlcBrandNotice;
@@ -24,7 +24,7 @@ export type NoticePage = RelayPaginatedResponse<Notice>;
 export const schema = `
   type Register10DlcBrandNotice {
     id: ID!
-    tcrBrandRegistrationUrl: String!
+    tcrBrandRegistrationUrl: String
   }
 
   union Notice = Register10DlcBrandNotice

--- a/src/api/notice.ts
+++ b/src/api/notice.ts
@@ -1,0 +1,43 @@
+import { RelayEdge, RelayPaginatedResponse } from "./pagination";
+import { GraphQLType } from "./types";
+
+export interface Register10DlcBrandNotice {
+  id: string;
+  tcrBrandRegistrationUrl: string;
+}
+
+export type Notice = Register10DlcBrandNotice;
+
+export function isRegister10DlcBrandNotice(
+  obj: Notice
+): obj is Register10DlcBrandNotice {
+  return (
+    (obj as Register10DlcBrandNotice & GraphQLType).__typename ===
+    "Register10DlcBrandNotice"
+  );
+}
+
+export type NoticeEdge = RelayEdge<Notice>;
+
+export type NoticePage = RelayPaginatedResponse<Notice>;
+
+export const schema = `
+  type Register10DlcBrandNotice {
+    id: ID!
+    tcrBrandRegistrationUrl: String!
+  }
+
+  union Notice = Register10DlcBrandNotice
+
+  type NoticeEdge {
+    cursor: Cursor!
+    node: Notice!
+  }
+
+  type NoticePage {
+    edges: [NoticeEdge!]!
+    pageInfo: RelayPageInfo!
+  }
+`;
+
+export default schema;

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -15,6 +15,7 @@ import { schema as interactionStepSchema } from "./interaction-step";
 import { schema as inviteSchema } from "./invite";
 import { schema as linkDomainSchema } from "./link-domain";
 import { schema as messageSchema } from "./message";
+import { schema as noticeSchema } from "./notice";
 import { schema as optOutSchema } from "./opt-out";
 import { schema as organizationSchema } from "./organization";
 import { schema as membershipSchema } from "./organization-membership";
@@ -279,6 +280,7 @@ const rootSchema = `
     externalSystem(systemId: String!): ExternalSystem!
     externalSystems(organizationId: String!, after: Cursor, first: Int): ExternalSystemPage!
     externalLists(organizationId: String!, systemId: String!, after: Cursor, first: Int): ExternalListPage!
+    notices(organizationId: String): NoticePage!
   }
 
   input SecondPassInput {
@@ -390,6 +392,7 @@ export const schema = [
   interactionStepSchema,
   optOutSchema,
   messageSchema,
+  noticeSchema,
   campaignContactSchema,
   cannedResponseSchema,
   questionResponseSchema,

--- a/src/components/AdminDashboard.jsx
+++ b/src/components/AdminDashboard.jsx
@@ -9,6 +9,7 @@ import AdminNavigation from "../containers/AdminNavigation";
 import { loadData } from "../containers/hoc/with-operations";
 import { hasRole } from "../lib/permissions";
 import theme from "../styles/theme";
+import NotificationCard from "./NotificationCard";
 import TopNav from "./TopNav";
 
 const styles = StyleSheet.create({
@@ -138,7 +139,10 @@ class AdminDashboard extends React.Component {
           {this.renderNavigation(
             sections.filter((s) => hasRole(s.role, roles))
           )}
-          <div className={css(styles.content)}>{children}</div>
+          <div className={css(styles.content)}>
+            <NotificationCard organizationId={match.params.organizationId} />
+            {children}
+          </div>
         </div>
       </div>
     );

--- a/src/components/NotificationCard.tsx
+++ b/src/components/NotificationCard.tsx
@@ -36,7 +36,7 @@ const Register10DlcBrandNoticeCard: React.FC<Register10DlcBrandNotice> = (
       <CardContent>
         <p>
           You must provide details required for us to register a 10DLC brand on
-          your behalf by September 24th! If you do not provide this information
+          your behalf by September 27th! If you do not provide this information
           by then, you may not be able to send messages starting on October 1st
           until 3-5 business days after you provide this information.
         </p>

--- a/src/components/NotificationCard.tsx
+++ b/src/components/NotificationCard.tsx
@@ -1,0 +1,115 @@
+import Button from "@material-ui/core/Button";
+import Card from "@material-ui/core/Card";
+import CardActions from "@material-ui/core/CardActions";
+import CardContent from "@material-ui/core/CardContent";
+import CardHeader from "@material-ui/core/CardHeader";
+import Divider from "@material-ui/core/Divider";
+import OpenInNew from "@material-ui/icons/OpenInNew";
+import Warning from "@material-ui/icons/Warning";
+import gql from "graphql-tag";
+import React from "react";
+
+import {
+  isRegister10DlcBrandNotice,
+  NoticePage,
+  Register10DlcBrandNotice
+} from "../api/notice";
+import { loadData } from "../containers/hoc/with-operations";
+import { QueryMap } from "../network/types";
+
+interface InnerProps {
+  organizationId: string;
+  data: {
+    notices: NoticePage;
+  };
+}
+
+const Register10DlcBrandNoticeCard: React.FC<Register10DlcBrandNotice> = (
+  props
+) => {
+  return (
+    <Card variant="outlined" style={{ marginBottom: "2em" }}>
+      <CardHeader
+        title="10DLC Brand Information Required"
+        avatar={<Warning color="error" />}
+      />
+      <CardContent>
+        <p>
+          You must provide details required for us to register a 10DLC brand on
+          your behalf by September 24th!
+        </p>
+
+        <p>
+          To learn more about this change please see our{" "}
+          <a
+            href="https://docs.spokerewired.com/article/124-10dlc"
+            target="_blank"
+            rel="noreferrer"
+          >
+            10DLC knowledge base article
+          </a>
+          .
+        </p>
+      </CardContent>
+      <CardActions disableSpacing>
+        <Button
+          href={props.tcrBrandRegistrationUrl}
+          target="_blank"
+          rel="noreferrer"
+          color="primary"
+          variant="contained"
+          style={{ marginLeft: "auto" }}
+          endIcon={<OpenInNew />}
+        >
+          Register
+        </Button>
+      </CardActions>
+    </Card>
+  );
+};
+
+export const NotificationCard: React.FC<InnerProps> = (props) => {
+  return (
+    <div>
+      {props.data.notices.edges.map(({ node }) => {
+        if (isRegister10DlcBrandNotice(node)) {
+          return <Register10DlcBrandNoticeCard key={node.id} {...node} />;
+        }
+        return null;
+      })}
+      {props.data.notices.pageInfo.totalCount > 0 && <Divider />}
+    </div>
+  );
+};
+
+const queries: QueryMap<InnerProps> = {
+  data: {
+    query: gql`
+      query getOrganizationNotifications($organizationId: String!) {
+        notices(organizationId: $organizationId) {
+          pageInfo {
+            totalCount
+          }
+          edges {
+            node {
+              ... on Register10DlcBrandNotice {
+                id
+                tcrBrandRegistrationUrl
+              }
+            }
+          }
+        }
+      }
+    `,
+    options: (ownProps) => ({
+      variables: {
+        organizationId: ownProps.organizationId
+      },
+      fetchPolicy: "network-only"
+    })
+  }
+};
+
+export default loadData({
+  queries
+})(NotificationCard);

--- a/src/components/NotificationCard.tsx
+++ b/src/components/NotificationCard.tsx
@@ -52,20 +52,28 @@ const Register10DlcBrandNoticeCard: React.FC<Register10DlcBrandNotice> = (
           </a>
           .
         </p>
+
+        {props.tcrBrandRegistrationUrl === null && (
+          <p style={{ fontWeight: "bold" }}>
+            Please contact your Spoke organization owner to resolve this!
+          </p>
+        )}
       </CardContent>
-      <CardActions disableSpacing>
-        <Button
-          href={props.tcrBrandRegistrationUrl}
-          target="_blank"
-          rel="noreferrer"
-          color="primary"
-          variant="contained"
-          style={{ marginLeft: "auto" }}
-          endIcon={<OpenInNew />}
-        >
-          Register
-        </Button>
-      </CardActions>
+      {props.tcrBrandRegistrationUrl && (
+        <CardActions disableSpacing>
+          <Button
+            href={props.tcrBrandRegistrationUrl}
+            target="_blank"
+            rel="noreferrer"
+            color="primary"
+            variant="contained"
+            style={{ marginLeft: "auto" }}
+            endIcon={<OpenInNew />}
+          >
+            Register
+          </Button>
+        </CardActions>
+      )}
     </Card>
   );
 };

--- a/src/components/NotificationCard.tsx
+++ b/src/components/NotificationCard.tsx
@@ -36,11 +36,13 @@ const Register10DlcBrandNoticeCard: React.FC<Register10DlcBrandNotice> = (
       <CardContent>
         <p>
           You must provide details required for us to register a 10DLC brand on
-          your behalf by September 24th!
+          your behalf by September 24th! If you do not provide this information
+          by then, you may not be able to send messages starting on October 1st
+          until 3-5 business days after you provide this information.
         </p>
 
         <p>
-          To learn more about this change please see our{" "}
+          To learn more about this change, please see our{" "}
           <a
             href="https://docs.spokerewired.com/article/124-10dlc"
             target="_blank"

--- a/src/server/lib/notices.ts
+++ b/src/server/lib/notices.ts
@@ -1,0 +1,113 @@
+import request from "superagent";
+
+import { Notice, Register10DlcBrandNotice } from "../../api/notice";
+import { r } from "../models";
+
+const graphqlQuery = `
+  query AnonGetTcr10DlcBrand($switchboardProfileId: String!) {
+    billingAccountId: billingAccountIdBySwitchboardProfileId(
+      switchboardProfileId: $switchboardProfileId
+    )
+    billingAccountName: billingAccountNameBySwitchboardProfileId(
+      switchboardProfileId: $switchboardProfileId
+    )
+    brand: tcr10DlcBrandBySwitchboardProfileId(
+      switchboardProfileId: $switchboardProfileId
+    ) {
+      ...Tcr10DlcBrandInfo
+      __typename
+    }
+  }
+
+  fragment Tcr10DlcBrandInfo on Tcr10DlcBrand {
+    id
+    nodeId
+    legalCompannyName
+    dba
+    entityForm
+    industry
+    website
+    usFein
+    address
+    city
+    state
+    postalCode
+    email
+    phoneNumber
+    __typename
+  }
+`;
+
+export const getInstanceNotifications = (_userId: string): Notice[] => [];
+
+type OrgLevelNotificationGetter = (
+  userId: string,
+  organizationId?: string
+) => Promise<Notice[]> | Notice[];
+
+const get10DlcBrandNotices: OrgLevelNotificationGetter = async (
+  userId,
+  organizationId
+) => {
+  const query = r
+    .knex("messaging_service")
+    .select("messaging_service_sid")
+    .where({ service_type: "assemble-numbers" })
+    .whereIn("organization_id", function whereIn(this: any) {
+      this.select("organization_id")
+        .from("user_organization")
+        .where({ user_id: userId, role: "OWNER" });
+    });
+  if (organizationId !== undefined) {
+    query.where({ organization_id: organizationId });
+  }
+
+  const profileIds: string[] = (await query).map(
+    ({ messaging_service_sid }: { messaging_service_sid: string }) =>
+      messaging_service_sid
+  );
+  const notifications: (
+    | Register10DlcBrandNotice
+    | undefined
+  )[] = await Promise.all(
+    profileIds.map(async (profileId: string) => {
+      const payload = {
+        operationName: "AnonGetTcr10DlcBrand",
+        query: graphqlQuery,
+        variables: {
+          switchboardProfileId: profileId
+        }
+      };
+      const response = await request
+        .post(`https://api.portal.spokerewired.com/graphql`)
+        .send(payload);
+
+      if (!response.body.data.brand) {
+        return {
+          __typename: "Register10DlcBrandNotice",
+          id: profileId,
+          tcrBrandRegistrationUrl: `https://portal.spokerewired.com/10dlc-registration/${profileId}`
+        };
+      }
+      return undefined;
+    })
+  );
+
+  const result = notifications.reduce<Register10DlcBrandNotice[]>(
+    (acc, notification) =>
+      notification !== undefined ? [...acc, notification] : acc,
+    []
+  );
+
+  return result;
+};
+
+export const getOrgLevelNotifications: OrgLevelNotificationGetter = async (
+  userId,
+  organizationId
+) => {
+  const notices: Notice[] = await Promise.all([
+    get10DlcBrandNotices(userId, organizationId)
+  ]).then((noticeSets) => noticeSets.flat());
+  return notices;
+};

--- a/src/server/lib/notices/index.ts
+++ b/src/server/lib/notices/index.ts
@@ -1,0 +1,15 @@
+import { Notice } from "../../../api/notice";
+import { get10DlcBrandNotices } from "./register-10dlc-brand";
+import { OrgLevelNotificationGetter } from "./types";
+
+export const getInstanceNotifications = (_userId: string): Notice[] => [];
+
+export const getOrgLevelNotifications: OrgLevelNotificationGetter = async (
+  userId,
+  organizationId
+) => {
+  const notices: Notice[] = await Promise.all([
+    get10DlcBrandNotices(userId, organizationId)
+  ]).then((noticeSets) => noticeSets.flat());
+  return notices;
+};

--- a/src/server/lib/notices/register-10dlc-brand.ts
+++ b/src/server/lib/notices/register-10dlc-brand.ts
@@ -1,7 +1,8 @@
 import request from "superagent";
 
-import { Notice, Register10DlcBrandNotice } from "../../api/notice";
-import { r } from "../models";
+import { Register10DlcBrandNotice } from "../../../api/notice";
+import { r } from "../../models";
+import { OrgLevelNotificationGetter } from "./types";
 
 const graphqlQuery = `
   query AnonGetTcr10DlcBrand($switchboardProfileId: String!) {
@@ -38,14 +39,7 @@ const graphqlQuery = `
   }
 `;
 
-export const getInstanceNotifications = (_userId: string): Notice[] => [];
-
-type OrgLevelNotificationGetter = (
-  userId: string,
-  organizationId?: string
-) => Promise<Notice[]> | Notice[];
-
-const get10DlcBrandNotices: OrgLevelNotificationGetter = async (
+export const get10DlcBrandNotices: OrgLevelNotificationGetter = async (
   userId,
   organizationId
 ) => {
@@ -102,12 +96,4 @@ const get10DlcBrandNotices: OrgLevelNotificationGetter = async (
   return result;
 };
 
-export const getOrgLevelNotifications: OrgLevelNotificationGetter = async (
-  userId,
-  organizationId
-) => {
-  const notices: Notice[] = await Promise.all([
-    get10DlcBrandNotices(userId, organizationId)
-  ]).then((noticeSets) => noticeSets.flat());
-  return notices;
-};
+export default get10DlcBrandNotices;

--- a/src/server/lib/notices/types.ts
+++ b/src/server/lib/notices/types.ts
@@ -1,0 +1,6 @@
+import { Notice } from "../../../api/notice";
+
+export type OrgLevelNotificationGetter = (
+  userId: string,
+  organizationId?: string
+) => Promise<Notice[]> | Notice[];


### PR DESCRIPTION
## Description

Add a notice prompting organization owners to provide their 10DLC registration information.

ToDo:

- [x] Show notice for Admins, without registration link

## Motivation and Context

10DLC registration needs to happen.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<table><tr><td>

<img width="1022" alt="Fullscreen_9_8_21__2_07_PM" src="https://user-images.githubusercontent.com/2145526/132564923-5412867d-96cb-46c8-b77f-de33a9e9c7d1.png">

<p align="center"><i>Owner notification</i></p>

</td></tr>
<tr><td>

<img width="1139" alt="Screen Shot 2021-09-22 at 10 50 09 AM" src="https://user-images.githubusercontent.com/2145526/134366899-40736ab3-58ac-432c-bbc4-d7f14456339e.png">

<p align="center"><i>Admin notification</i></p>

</td></tr></table>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

The 10DLC page needs to be updated with latest updates, cost, etc.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
