### PR TITLE
feat(10dlc): add registration link to settings

### DIFF
--- a/src/api/messaging-service.ts
+++ b/src/api/messaging-service.ts
@@ -1,0 +1,45 @@
+import { RelayEdge, RelayPaginatedResponse } from "./pagination";
+
+export enum MessagingServiceType {
+  TWILIO = "TWILIO",
+  ASSEMBLE_NUMBERS = "ASSEMBLE_NUMBERS"
+}
+
+export interface MessagingService {
+  id: string;
+  messagingServiceSid: string;
+  serviceType: MessagingServiceType;
+  tcrBrandRegistrationLink: string | null;
+  updatedAt: string;
+}
+
+export type MessagingServiceEdge = RelayEdge<MessagingService>;
+
+export type MessagingServicePage = RelayPaginatedResponse<MessagingService>;
+
+export const schema = `
+  enum MessagingServiceType {
+    TWILIO
+    ASSEMBLE_NUMBERS
+  }
+
+  type MessagingService {
+    id: ID!
+    messagingServiceSid: String!
+    serviceType: MessagingServiceType!
+    updatedAt: String!
+    tcrBrandRegistrationLink: String
+  }
+
+  type MessagingServiceEdge {
+    cursor: Cursor!
+    node: MessagingService!
+  }
+
+  type MessagingServicePage {
+    edges: [MessagingServiceEdge!]!
+    pageInfo: RelayPageInfo!
+  }
+`;
+
+export default schema;

--- a/src/api/organization.ts
+++ b/src/api/organization.ts
@@ -1,6 +1,7 @@
 import { Campaign, PaginatedCampaigns } from "./campaign";
 import { ExternalSystem } from "./external-system";
 import { LinkDomain, UnhealthyLinkDomain } from "./link-domain";
+import { MessagingServicePage } from "./messaging-service";
 import { OptOut } from "./opt-out";
 import { OrganizationMembership } from "./organization-membership";
 import { OranizationSettings } from "./organization-settings";
@@ -56,6 +57,7 @@ export interface Organization {
   escalationTagList: Tag[];
   teams: Team[];
   externalSystems: RelayPaginatedResponse<ExternalSystem>;
+  messagingServices: MessagingServicePage;
 }
 
 export interface EditOrganizationInput {
@@ -110,6 +112,7 @@ export const schema = `
     escalationTagList: [Tag]
     teams: [Team]!
     externalSystems(after: Cursor, first: Int): ExternalSystemPage!
+    messagingServices(after: Cursor, first: Int): MessagingServicePage!
   }
 
   input EditOrganizationInput {

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -15,6 +15,7 @@ import { schema as interactionStepSchema } from "./interaction-step";
 import { schema as inviteSchema } from "./invite";
 import { schema as linkDomainSchema } from "./link-domain";
 import { schema as messageSchema } from "./message";
+import { schema as messagingServiceSchema } from "./messaging-service";
 import { schema as noticeSchema } from "./notice";
 import { schema as optOutSchema } from "./opt-out";
 import { schema as organizationSchema } from "./organization";
@@ -392,6 +393,7 @@ export const schema = [
   interactionStepSchema,
   optOutSchema,
   messageSchema,
+  messagingServiceSchema,
   noticeSchema,
   campaignContactSchema,
   cannedResponseSchema,

--- a/src/containers/Settings/components/General.jsx
+++ b/src/containers/Settings/components/General.jsx
@@ -23,6 +23,7 @@ import { snakeToTitleCase } from "../../../lib/attributes";
 import { DateTime } from "../../../lib/datetime";
 import { loadData } from "../../hoc/with-operations";
 import EditName from "./EditName";
+import Review10DlcInfo from "./Review10DlcInfo";
 
 const styles = StyleSheet.create({
   sectionCard: {
@@ -250,6 +251,10 @@ class Settings extends React.Component {
 
     return (
       <div>
+        <Review10DlcInfo
+          organizationId={organization.id}
+          style={{ marginBottom: 20 }}
+        />
         <EditName
           organizationId={organization.id}
           style={{ marginBottom: 20 }}

--- a/src/containers/Settings/components/Review10DlcInfo.tsx
+++ b/src/containers/Settings/components/Review10DlcInfo.tsx
@@ -1,0 +1,96 @@
+import Button from "@material-ui/core/Button";
+import Card from "@material-ui/core/Card";
+import CardActions from "@material-ui/core/CardActions";
+import CardContent from "@material-ui/core/CardContent";
+import CardHeader from "@material-ui/core/CardHeader";
+import OpenInNew from "@material-ui/icons/OpenInNew";
+import React from "react";
+import { compose } from "recompose";
+
+import { QueryMap } from "../../../network/types";
+import { loadData } from "../../hoc/with-operations";
+import {
+  GET_MESSAGING_SERVICES,
+  OrganizationMessagingServicesType
+} from "./queries";
+
+interface HocProps {
+  data: OrganizationMessagingServicesType;
+}
+
+export interface OuterProps {
+  organizationId: string;
+  style?: React.CSSProperties;
+}
+
+interface InnerProps extends OuterProps, HocProps {}
+
+const Review10DlcInfo: React.FC<InnerProps> = (props) => {
+  const {
+    data: {
+      organization: {
+        messagingServices: { edges }
+      }
+    },
+    style
+  } = props;
+
+  const link =
+    edges.length === 1
+      ? edges[0].node.tcrBrandRegistrationLink ?? undefined
+      : undefined;
+
+  return (
+    <Card style={style}>
+      <CardHeader title="10DLC Registration Information" />
+      <CardContent>
+        <p>
+          You must provide details required for us to register a 10DLC brand on
+          your behalf by September 27th, 2021! If you do not provide this
+          information by then, you may not be able to send messages starting on
+          October 1st, 2021 until 3-5 business days after you provide this
+          information.
+        </p>
+
+        <p>
+          To learn more about this change, please see our{" "}
+          <a
+            href="https://docs.spokerewired.com/article/124-10dlc"
+            target="_blank"
+            rel="noreferrer"
+          >
+            10DLC knowledge base article
+          </a>
+          .
+        </p>
+      </CardContent>
+      <CardActions disableSpacing>
+        <Button
+          href={link ?? ""}
+          target="_blank"
+          rel="noreferrer"
+          color="primary"
+          variant="contained"
+          disabled={link === undefined}
+          style={{ marginLeft: "auto" }}
+          endIcon={<OpenInNew />}
+        >
+          Register
+        </Button>
+      </CardActions>
+    </Card>
+  );
+};
+
+const queries: QueryMap<OuterProps> = {
+  data: {
+    query: GET_MESSAGING_SERVICES,
+    options: ({ organizationId }) => ({
+      variables: { organizationId }
+    })
+  }
+};
+
+export default compose<InnerProps, OuterProps>(loadData({ queries }))(
+  Review10DlcInfo
+);

--- a/src/containers/Settings/components/queries.ts
+++ b/src/containers/Settings/components/queries.ts
@@ -26,3 +26,24 @@ export const EDIT_ORGANIZATION_NAME = gql`
     }
   }
 `;
+
+export interface OrganizationMessagingServicesType {
+  organization: Pick<Organization, "id" | "messagingServices">;
+}
+
+export const GET_MESSAGING_SERVICES = gql`
+  query GetOrganizationMessagingServices($organizationId: String!) {
+    organization(id: $organizationId) {
+      id
+      messagingServices {
+        edges {
+          node {
+            id
+            serviceType
+            tcrBrandRegistrationLink
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/server/api/messaging-service.ts
+++ b/src/server/api/messaging-service.ts
@@ -1,0 +1,20 @@
+import { MessagingServiceType as GraphQLMessagingServiceType } from "../../api/messaging-service";
+import { sqlResolvers } from "./lib/utils";
+import { MessagingServiceRecord, MessagingServiceType } from "./types";
+
+export const resolvers = {
+  MessagingService: {
+    id: (service: MessagingServiceRecord) => service.messaging_service_sid,
+    ...sqlResolvers(["messagingServiceSid", "updatedAt"]),
+    serviceType: (service: MessagingServiceRecord) =>
+      service.service_type === MessagingServiceType.AssembleNumbers
+        ? GraphQLMessagingServiceType.ASSEMBLE_NUMBERS
+        : GraphQLMessagingServiceType.TWILIO,
+    tcrBrandRegistrationLink: (service: MessagingServiceRecord) =>
+      service.service_type === MessagingServiceType.AssembleNumbers
+        ? `https://portal.spokerewired.com/10dlc-registration/${service.messaging_service_sid}`
+        : null
+  }
+};
+
+export default resolvers;

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -403,6 +403,19 @@ export const resolvers = {
         .reader("external_system")
         .where({ organization_id: organizationId });
       return formatPage(query, { after, first });
+    },
+    messagingServices: async (organization, { after, first }, { user }) => {
+      const organizationId = parseInt(organization.id, 10);
+      await accessRequired(user, organizationId, "OWNER", true);
+
+      const query = r
+        .reader("messaging_service")
+        .where({ organization_id: organizationId });
+      return formatPage(query, {
+        after,
+        first,
+        primaryColumn: "messaging_service_sid"
+      });
     }
   }
 };

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -90,6 +90,7 @@ import serviceMap from "./lib/services";
 import { graphileSecretRef } from "./lib/utils";
 import { resolvers as linkDomainResolvers } from "./link-domain";
 import { resolvers as messageResolvers } from "./message";
+import { resolvers as messagingServiceResolvers } from "./messaging-service";
 import { resolvers as optOutResolvers } from "./opt-out";
 import { resolvers as organizationResolvers } from "./organization";
 import { resolvers as membershipSchema } from "./organization-membership";
@@ -4041,6 +4042,7 @@ export const resolvers = {
   ...externalActivistCodeResolvers,
   ...externalResultCodeResolvers,
   ...externalSyncConfigResolvers,
+  ...messagingServiceResolvers,
   ...{ Date: GraphQLDate },
   ...{ JSON: GraphQLJSON },
   ...{ Phone: GraphQLPhone },


### PR DESCRIPTION
## Description

Add Settings section with link to 10DLC registration form.

## Motivation and Context

Users must otherwise bookmark the registration form page in order to come back and make changes.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<table><tr><td>

![Screen Shot 2021-09-24 at 11 18 06 AM](https://user-images.githubusercontent.com/2145526/134699466-d8edacf8-7dd5-4bd6-8281-56a812fef4a4.png)

<p align="center"><i>10DLC Registration Form Section</i></p>

</td></tr></table>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
