### PR TITLE
fix(10dlc): handle graphql errors

### DIFF
--- a/src/components/NotificationCard.tsx
+++ b/src/components/NotificationCard.tsx
@@ -14,12 +14,13 @@ import {
   NoticePage,
   Register10DlcBrandNotice
 } from "../api/notice";
-import { loadData } from "../containers/hoc/with-operations";
+import { withOperations } from "../containers/hoc/with-operations";
 import { QueryMap } from "../network/types";
 
 interface InnerProps {
   organizationId: string;
   data: {
+    error?: any;
     notices: NoticePage;
   };
 }
@@ -79,6 +80,13 @@ const Register10DlcBrandNoticeCard: React.FC<Register10DlcBrandNotice> = (
 };
 
 export const NotificationCard: React.FC<InnerProps> = (props) => {
+  if (props.data.error || !props.data.notices) {
+    return (
+      <Card style={{ marginBottom: "2em" }}>
+        <CardContent>There was an error fetching notifications.</CardContent>
+      </Card>
+    );
+  }
   return (
     <div>
       {props.data.notices.edges.map(({ node }) => {
@@ -120,6 +128,6 @@ const queries: QueryMap<InnerProps> = {
   }
 };
 
-export default loadData({
+export default withOperations({
   queries
 })(NotificationCard);

--- a/src/server/lib/notices/register-10dlc-brand.ts
+++ b/src/server/lib/notices/register-10dlc-brand.ts
@@ -5,22 +5,22 @@ import { r } from "../../models";
 import { OrgLevelNotificationGetter } from "./types";
 
 const graphqlQuery = `
-  query AnonGetTcr10DlcBrand($switchboardProfileId: String!) {
+  query AnonGetTcr10DlcSurvey($switchboardProfileId: String!) {
     billingAccountId: billingAccountIdBySwitchboardProfileId(
       switchboardProfileId: $switchboardProfileId
     )
     billingAccountName: billingAccountNameBySwitchboardProfileId(
       switchboardProfileId: $switchboardProfileId
     )
-    brand: tcr10DlcBrandBySwitchboardProfileId(
+    survey: tcr10DlcSurveyBySwitchboardProfileId(
       switchboardProfileId: $switchboardProfileId
     ) {
-      ...Tcr10DlcBrandInfo
+      ...Tcr10DlcSurveyInfo
       __typename
     }
   }
 
-  fragment Tcr10DlcBrandInfo on Tcr10DlcBrand {
+  fragment Tcr10DlcSurveyInfo on Tcr10DlcSurvey {
     id
     nodeId
     legalCompanyName
@@ -82,7 +82,7 @@ export const get10DlcBrandNotices: OrgLevelNotificationGetter = async (
           .post(`https://api.portal.spokerewired.com/graphql`)
           .send(payload);
 
-        if (!response.body.data.brand) {
+        if (!response.body.data.survey) {
           return {
             __typename: "Register10DlcBrandNotice",
             id: messaging_service_sid,

--- a/src/server/lib/notices/register-10dlc-brand.ts
+++ b/src/server/lib/notices/register-10dlc-brand.ts
@@ -71,30 +71,26 @@ export const get10DlcBrandNotices: OrgLevelNotificationGetter = async (
   )[] = await Promise.all(
     profiles.map(async ({ messaging_service_sid, roles }) => {
       const payload = {
-        operationName: "AnonGetTcr10DlcBrand",
+        operationName: "AnonGetTcr10DlcSurvey",
         query: graphqlQuery,
         variables: {
           switchboardProfileId: messaging_service_sid
         }
       };
-      try {
-        const response = await request
-          .post(`https://api.portal.spokerewired.com/graphql`)
-          .send(payload);
+      const response = await request
+        .post(`https://api.portal.spokerewired.com/graphql`)
+        .send(payload);
 
-        if (!response.body.data.survey) {
-          return {
-            __typename: "Register10DlcBrandNotice",
-            id: messaging_service_sid,
-            tcrBrandRegistrationUrl: roles.includes("OWNER")
-              ? `https://portal.spokerewired.com/10dlc-registration/${messaging_service_sid}`
-              : null
-          };
-        }
-        return undefined;
-      } catch (err) {
-        return undefined;
+      if (!response.body.data.survey) {
+        return {
+          __typename: "Register10DlcBrandNotice",
+          id: messaging_service_sid,
+          tcrBrandRegistrationUrl: roles.includes("OWNER")
+            ? `https://portal.spokerewired.com/10dlc-registration/${messaging_service_sid}`
+            : null
+        };
       }
+      return undefined;
     })
   );
 

--- a/src/server/lib/notices/register-10dlc-brand.ts
+++ b/src/server/lib/notices/register-10dlc-brand.ts
@@ -77,20 +77,24 @@ export const get10DlcBrandNotices: OrgLevelNotificationGetter = async (
           switchboardProfileId: messaging_service_sid
         }
       };
-      const response = await request
-        .post(`https://api.portal.spokerewired.com/graphql`)
-        .send(payload);
+      try {
+        const response = await request
+          .post(`https://api.portal.spokerewired.com/graphql`)
+          .send(payload);
 
-      if (!response.body.data.brand) {
-        return {
-          __typename: "Register10DlcBrandNotice",
-          id: messaging_service_sid,
-          tcrBrandRegistrationUrl: roles.includes("OWNER")
-            ? `https://portal.spokerewired.com/10dlc-registration/${messaging_service_sid}`
-            : null
-        };
+        if (!response.body.data.brand) {
+          return {
+            __typename: "Register10DlcBrandNotice",
+            id: messaging_service_sid,
+            tcrBrandRegistrationUrl: roles.includes("OWNER")
+              ? `https://portal.spokerewired.com/10dlc-registration/${messaging_service_sid}`
+              : null
+          };
+        }
+        return undefined;
+      } catch (err) {
+        return undefined;
       }
-      return undefined;
     })
   );
 


### PR DESCRIPTION
## Description

Handle errors when fetching 10DLC registrations.

## Motivation and Context

Spoke Portal schema is fluid and errors in the GraphQL request should not break Spoke.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
