### PR TITLE
feat: add campaign groups

### DIFF
--- a/migrations/20211013104509_campaign_groups.js
+++ b/migrations/20211013104509_campaign_groups.js
@@ -1,0 +1,41 @@
+exports.up = function up(knex) {
+  return knex.schema.raw(`
+    create table campaign_group (
+      id serial primary key,
+      organization_id integer not null references organization (id),
+      name text not null,
+      description text not null,
+      created_at timestamptz not null default CURRENT_TIMESTAMP,
+      updated_at timestamptz not null default CURRENT_TIMESTAMP,
+      unique (organization_id, name)
+    );
+
+    create trigger _500_universal_updated_at
+      before update
+      on public.campaign_group
+      for each row
+      execute procedure universal_updated_at();
+
+    create table campaign_group_campaign (
+      id serial primary key,
+      campaign_group_id integer not null references campaign_group (id),
+      campaign_id integer not null references campaign (id),
+      created_at timestamptz not null default CURRENT_TIMESTAMP,
+      updated_at timestamptz not null default CURRENT_TIMESTAMP,
+      unique (campaign_group_id, campaign_id)
+    );
+
+    create trigger _500_universal_updated_at
+      before update
+      on public.campaign_group_campaign
+      for each row
+      execute procedure universal_updated_at();
+  `);
+};
+
+exports.down = function down(knex) {
+  return knex.schema.raw(`
+    drop table campaign_group_campaign;
+    drop table campaign_group;
+  `);
+};

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "iconv-lite": "^0.5.1",
     "immer": "^8.0.1",
     "isomorphic-fetch": "^2.2.1",
-    "knex": "^0.95.4",
+    "knex": "^0.95.11",
     "lightship": "^6.6.1",
     "lodash": "^4.17.20",
     "luxon": "^1.25.0",

--- a/schema-dump.sql
+++ b/schema-dump.sql
@@ -1615,6 +1615,81 @@ ALTER SEQUENCE public.campaign_contact_id_seq OWNED BY public.campaign_contact.i
 
 
 --
+-- Name: campaign_group; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.campaign_group (
+    id integer NOT NULL,
+    organization_id integer NOT NULL,
+    name text NOT NULL,
+    description text NOT NULL,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.campaign_group OWNER TO postgres;
+
+--
+-- Name: campaign_group_campaign; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.campaign_group_campaign (
+    id integer NOT NULL,
+    campaign_group_id integer NOT NULL,
+    campaign_id integer NOT NULL,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.campaign_group_campaign OWNER TO postgres;
+
+--
+-- Name: campaign_group_campaign_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.campaign_group_campaign_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.campaign_group_campaign_id_seq OWNER TO postgres;
+
+--
+-- Name: campaign_group_campaign_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.campaign_group_campaign_id_seq OWNED BY public.campaign_group_campaign.id;
+
+
+--
+-- Name: campaign_group_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.campaign_group_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.campaign_group_id_seq OWNER TO postgres;
+
+--
+-- Name: campaign_group_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.campaign_group_id_seq OWNED BY public.campaign_group.id;
+
+
+--
 -- Name: campaign_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
 --
 
@@ -3025,6 +3100,20 @@ ALTER TABLE ONLY public.campaign_contact ALTER COLUMN id SET DEFAULT nextval('pu
 
 
 --
+-- Name: campaign_group id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.campaign_group ALTER COLUMN id SET DEFAULT nextval('public.campaign_group_id_seq'::regclass);
+
+
+--
+-- Name: campaign_group_campaign id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.campaign_group_campaign ALTER COLUMN id SET DEFAULT nextval('public.campaign_group_campaign_id_seq'::regclass);
+
+
+--
 -- Name: campaign_team id; Type: DEFAULT; Schema: public; Owner: postgres
 --
 
@@ -3247,6 +3336,38 @@ ALTER TABLE ONLY public.campaign_contact
 
 ALTER TABLE ONLY public.campaign_contact_tag
     ADD CONSTRAINT campaign_contact_tag_pkey PRIMARY KEY (campaign_contact_id, tag_id);
+
+
+--
+-- Name: campaign_group_campaign campaign_group_campaign_campaign_group_id_campaign_id_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.campaign_group_campaign
+    ADD CONSTRAINT campaign_group_campaign_campaign_group_id_campaign_id_key UNIQUE (campaign_group_id, campaign_id);
+
+
+--
+-- Name: campaign_group_campaign campaign_group_campaign_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.campaign_group_campaign
+    ADD CONSTRAINT campaign_group_campaign_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: campaign_group campaign_group_organization_id_name_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.campaign_group
+    ADD CONSTRAINT campaign_group_organization_id_name_key UNIQUE (organization_id, name);
+
+
+--
+-- Name: campaign_group campaign_group_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.campaign_group
+    ADD CONSTRAINT campaign_group_pkey PRIMARY KEY (id);
 
 
 --
@@ -4442,6 +4563,20 @@ CREATE TRIGGER _500_unhealthy_link_domain_updated_at BEFORE UPDATE ON public.unh
 
 
 --
+-- Name: campaign_group _500_universal_updated_at; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER _500_universal_updated_at BEFORE UPDATE ON public.campaign_group FOR EACH ROW EXECUTE FUNCTION public.universal_updated_at();
+
+
+--
+-- Name: campaign_group_campaign _500_universal_updated_at; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER _500_universal_updated_at BEFORE UPDATE ON public.campaign_group_campaign FOR EACH ROW EXECUTE FUNCTION public.universal_updated_at();
+
+
+--
 -- Name: user_organization _500_user_organization_updated_at; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
@@ -4556,6 +4691,30 @@ ALTER TABLE ONLY public.campaign
 
 ALTER TABLE ONLY public.campaign
     ADD CONSTRAINT campaign_external_system_id_fkey FOREIGN KEY (external_system_id) REFERENCES public.external_system(id);
+
+
+--
+-- Name: campaign_group_campaign campaign_group_campaign_campaign_group_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.campaign_group_campaign
+    ADD CONSTRAINT campaign_group_campaign_campaign_group_id_fkey FOREIGN KEY (campaign_group_id) REFERENCES public.campaign_group(id);
+
+
+--
+-- Name: campaign_group_campaign campaign_group_campaign_campaign_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.campaign_group_campaign
+    ADD CONSTRAINT campaign_group_campaign_campaign_id_fkey FOREIGN KEY (campaign_id) REFERENCES public.campaign(id);
+
+
+--
+-- Name: campaign_group campaign_group_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.campaign_group
+    ADD CONSTRAINT campaign_group_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id);
 
 
 --

--- a/src/api/campaign-group.ts
+++ b/src/api/campaign-group.ts
@@ -1,0 +1,52 @@
+import { Campaign } from "./campaign";
+import { RelayEdge, RelayPaginatedResponse } from "./pagination";
+
+export interface CampaignGroupInput {
+  id?: string | null;
+  name: string;
+  description: string;
+}
+
+export interface CampaignGroup {
+  id: string;
+  organization_id: string;
+  name: string;
+  description: string;
+  campaignGroups: RelayPaginatedResponse<Campaign>;
+  created_at: string;
+  updated_at: string;
+}
+
+export type CampaignGroupEdge = RelayEdge<CampaignGroup>;
+
+export type CampaignGroupPage = RelayPaginatedResponse<CampaignGroup>;
+
+export const schema = `
+  input CampaignGroupInput {
+    id: String
+    name: String!
+    description: String!
+  }
+
+  type CampaignGroup {
+    id: ID!
+    organizationId: String!
+    name: String!
+    description: String!
+    campaigns: CampaignPage!
+    createdAt: String!
+    updatedAt: String!
+  }
+
+  type CampaignGroupEdge {
+    cursor: Cursor!
+    node: CampaignGroup!
+  }
+
+  type CampaignGroupPage {
+    edges: [CampaignGroupEdge!]!
+    pageInfo: RelayPageInfo!
+  }
+`;
+
+export default schema;

--- a/src/api/campaign.ts
+++ b/src/api/campaign.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-unused-vars */
+import { CampaignGroupPage } from "./campaign-group";
 import { ExternalSystem } from "./external-system";
 import { InteractionStep } from "./interaction-step";
 import { Team } from "./team";
@@ -68,6 +69,7 @@ export interface Campaign {
   hasUnsentInitialMessages?: boolean | null;
   hasUnhandledMessages?: boolean | null;
   teams: Team[];
+  campaignGroups: CampaignGroupPage;
   externalSystem?: ExternalSystem | null;
   creator?: User | null;
   deliverabilityStats: CampaignDeliverabilityStats;
@@ -130,6 +132,7 @@ export const schema = `
     contacts: Boolean!
     autoassign: Boolean!
     cannedResponses: Boolean!
+    campaignGroups: Boolean!
     interactions: Boolean!
     texters: Boolean!
   }
@@ -170,6 +173,7 @@ export const schema = `
     logoImageUrl: String
     editors: String
     teams: [Team]!
+    campaignGroups: CampaignGroupPage!
     textingHoursStart: Int
     textingHoursEnd: Int
     isAutoassignEnabled: Boolean!

--- a/src/api/organization.ts
+++ b/src/api/organization.ts
@@ -1,4 +1,5 @@
 import { Campaign, PaginatedCampaigns } from "./campaign";
+import { CampaignGroupPage } from "./campaign-group";
 import { ExternalSystem } from "./external-system";
 import { LinkDomain, UnhealthyLinkDomain } from "./link-domain";
 import { MessagingServicePage } from "./messaging-service";
@@ -58,6 +59,7 @@ export interface Organization {
   teams: Team[];
   externalSystems: RelayPaginatedResponse<ExternalSystem>;
   messagingServices: MessagingServicePage;
+  campaignGroups: CampaignGroupPage;
 }
 
 export interface EditOrganizationInput {
@@ -113,6 +115,7 @@ export const schema = `
     teams: [Team]!
     externalSystems(after: Cursor, first: Int): ExternalSystemPage!
     messagingServices(after: Cursor, first: Int): MessagingServicePage!
+    campaignGroups(after: Cursor, first: Int): CampaignGroupPage!
   }
 
   input EditOrganizationInput {

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -2,6 +2,7 @@ import { schema as assignmentSchema } from "./assignment";
 import { schema as assignmentRequestSchema } from "./assignment-request";
 import { schema as campaignSchema } from "./campaign";
 import { schema as campaignContactSchema } from "./campaign-contact";
+import { schema as campaignGroupSchema } from "./campaign-group";
 import { schema as cannedResponseSchema } from "./canned-response";
 import { schema as conversationSchema } from "./conversations";
 import { schema as externalActivistCodeSchema } from "./external-activist-code";
@@ -111,6 +112,7 @@ const rootSchema = `
     organizationId: String
     isAssignmentLimitedToTeams: Boolean
     teamIds: [ID]
+    campaignGroupIds: [String!]
     texters: TexterInput
     interactionSteps: InteractionStepInput
     cannedResponses: [CannedResponseInput]
@@ -282,6 +284,7 @@ const rootSchema = `
     externalSystems(organizationId: String!, after: Cursor, first: Int): ExternalSystemPage!
     externalLists(organizationId: String!, systemId: String!, after: Cursor, first: Int): ExternalListPage!
     notices(organizationId: String): NoticePage!
+    campaignGroups(organizationId: String! after: Cursor, first: Int): CampaignGroupPage!
   }
 
   input SecondPassInput {
@@ -293,6 +296,8 @@ const rootSchema = `
     createInvite(invite:InviteInput!): Invite
     createCampaign(campaign:CampaignInput!): Campaign
     editCampaign(id:String!, campaign:CampaignInput!): Campaign
+    saveCampaignGroups(organizationId: String!, campaignGroups: [CampaignGroupInput!]!): [CampaignGroup!]!
+    deleteCampaignGroup(organizationId: String!, campaignGroupId: String!): Boolean!
     filterLandlines(id:String!): Campaign
     bulkUpdateScript(organizationId:String!, findAndReplace: BulkUpdateScriptInput!): [ScriptUpdateResult]
     deleteJob(campaignId:String!, id:String!): JobRequest
@@ -396,6 +401,7 @@ export const schema = [
   messagingServiceSchema,
   noticeSchema,
   campaignContactSchema,
+  campaignGroupSchema,
   cannedResponseSchema,
   questionResponseSchema,
   questionSchema,

--- a/src/components/AdminDashboard.jsx
+++ b/src/components/AdminDashboard.jsx
@@ -68,6 +68,7 @@ class AdminDashboard extends React.Component {
 
     const sections = [
       { name: "Campaigns", path: "campaigns", role: "ADMIN" },
+      { name: "Campaign Groups", path: "campaign-groups", role: "ADMIN" },
       { name: "People", path: "people", role: "ADMIN" },
       { name: "Teams", path: "teams", role: "ADMIN" },
       { name: "Assignment Control", path: "assignment-control", role: "ADMIN" },
@@ -113,6 +114,11 @@ class AdminDashboard extends React.Component {
 
     if (!window.ENABLE_SHORTLINK_DOMAINS) {
       const index = sections.findIndex((s) => s.name === "Short Link Domains");
+      sections.splice(index, 1);
+    }
+
+    if (!window.ENABLE_CAMPAIGN_GROUPS) {
+      const index = sections.findIndex((s) => s.name === "Campaign Groups");
       sections.splice(index, 1);
     }
 

--- a/src/config.js
+++ b/src/config.js
@@ -320,6 +320,11 @@ const validators = {
       "The interval length in minutes that each troll patrol sweep will examine messages within.",
     default: 6
   }),
+  ENABLE_CAMPAIGN_GROUPS: bool({
+    desc: "Whether to enable campaign groups",
+    default: false,
+    isClient: true
+  }),
   ENABLE_SHORTLINK_DOMAINS: bool({
     desc: "Whether to enable shortlink domains",
     default: false,

--- a/src/containers/AdminCampaignEdit/components/SectionWrapper.tsx
+++ b/src/containers/AdminCampaignEdit/components/SectionWrapper.tsx
@@ -232,6 +232,7 @@ const makeQueries = (jobTypes: string[]) => ({
             cannedResponses
             interactions
             texters
+            campaignGroups
           }
         }
       }

--- a/src/containers/AdminCampaignEdit/index.jsx
+++ b/src/containers/AdminCampaignEdit/index.jsx
@@ -41,6 +41,7 @@ import CampaignBasicsForm from "./sections/CampaignBasicsForm";
 import CampaignCannedResponsesForm from "./sections/CampaignCannedResponsesForm";
 import CampaignContactsForm from "./sections/CampaignContactsForm";
 import CampaignFilterLandlinesForm from "./sections/CampaignFilterLandlinesForm";
+import CampaignGroupsForm from "./sections/CampaignGroupsForm";
 import CampaignIntegrationForm from "./sections/CampaignIntegrationForm";
 import CampaignInteractionStepsForm from "./sections/CampaignInteractionStepsForm";
 import CampaignOverlapManager from "./sections/CampaignOverlapManager";
@@ -321,6 +322,18 @@ class AdminCampaignEdit extends React.Component {
           this.state.campaignFormValues.title !== "" &&
           this.state.campaignFormValues.description !== "" &&
           this.state.campaignFormValues.dueBy !== null
+      },
+      {
+        title: "Campaign Groups",
+        content: CampaignGroupsForm,
+        isStandalone: true,
+        keys: ["campaignGroups"],
+        exclude: !window.ENABLE_CAMPAIGN_GROUPS,
+        checkCompleted: () => true,
+        blocksStarting: false,
+        expandAfterCampaignStarts: true,
+        expandableBySuperVolunteers: false,
+        extraProps: {}
       },
       {
         title: "Texting Hours",

--- a/src/containers/AdminCampaignEdit/sections/CampaignGroupsForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignGroupsForm.tsx
@@ -1,0 +1,207 @@
+import Button from "@material-ui/core/Button";
+import { ApolloQueryResult } from "apollo-client";
+import gql from "graphql-tag";
+import ChipInput from "material-ui-chip-input";
+import React, { useState } from "react";
+import { compose } from "recompose";
+
+import { Campaign } from "../../../api/campaign";
+import { CampaignGroup } from "../../../api/campaign-group";
+import { Organization } from "../../../api/organization";
+import { MutationMap, QueryMap } from "../../../network/types";
+import { loadData } from "../../hoc/with-operations";
+import CampaignFormSectionHeading from "../components/CampaignFormSectionHeading";
+import {
+  asSection,
+  FullComponentProps,
+  RequiredComponentProps
+} from "../components/SectionWrapper";
+
+type GroupSelect = Pick<CampaignGroup, "id" | "name">;
+
+interface HocProps {
+  mutations: {
+    editCampaign(campaignGroupIds: string[]): ApolloQueryResult<any>;
+  };
+  data: {
+    campaign: Pick<Campaign, "id" | "campaignGroups" | "isStarted">;
+  };
+  orgCampaignGroups: {
+    organization: Pick<Organization, "id" | "campaignGroups">;
+  };
+}
+
+interface InnerProps extends FullComponentProps, HocProps {}
+
+const CampaignGroupsForm: React.FC<InnerProps> = (props) => {
+  const [isWorking, setIsWorking] = useState(false);
+  const [pendingGroups, setPendingGroups] = useState<GroupSelect[] | undefined>(
+    undefined
+  );
+
+  const orgCampaignGroupEdges =
+    props.orgCampaignGroups?.organization?.campaignGroups?.edges ?? [];
+  const campaignGroupEdges = props.data?.campaign?.campaignGroups?.edges ?? [];
+
+  const orgCampaignGroups = orgCampaignGroupEdges.map(({ node }) => node);
+
+  const campaignGroups = campaignGroupEdges.map(({ node: { id, name } }) => ({
+    id,
+    name
+  }));
+  const selectedGroups = pendingGroups ?? campaignGroups;
+
+  // Prevent user-defined teams
+  const handleBeforeRequestAdd = ({
+    id: groupId,
+    name
+  }: {
+    id: string;
+    name: string;
+  }) => !Number.isNaN(groupId) && groupId !== name;
+
+  const handleAddGroup = (group: GroupSelect) =>
+    setPendingGroups([...selectedGroups, group]);
+
+  const handleRemoveGroup = (deleteGroupId: string) =>
+    setPendingGroups(selectedGroups.filter(({ id }) => id !== deleteGroupId));
+
+  const handleSave = async () => {
+    if (pendingGroups === undefined) return;
+
+    setIsWorking(true);
+    try {
+      const campaignGroupIds = pendingGroups.map(({ id }) => id);
+      const result = await props.mutations.editCampaign(campaignGroupIds);
+      if (result.errors) throw new Error(result.errors[0].message);
+      setPendingGroups(undefined);
+    } catch (err: any) {
+      props.onError(err.message);
+    } finally {
+      setIsWorking(false);
+    }
+  };
+
+  return (
+    <>
+      <CampaignFormSectionHeading
+        title="Campaign Groups"
+        subtitle="Associate groups of campaigns together."
+      />
+      <ChipInput
+        value={selectedGroups}
+        dataSourceConfig={{ text: "name", value: "id" }}
+        dataSource={orgCampaignGroups}
+        placeholder="Select campaign groups"
+        fullWidth
+        openOnFocus
+        onBeforeRequestAdd={handleBeforeRequestAdd}
+        onRequestAdd={handleAddGroup}
+        onRequestDelete={handleRemoveGroup}
+      />
+      <Button
+        variant="contained"
+        color="primary"
+        disabled={isWorking}
+        onClick={handleSave}
+      >
+        {props.saveLabel}
+      </Button>
+    </>
+  );
+};
+
+const queries: QueryMap<InnerProps> = {
+  data: {
+    query: gql`
+      query getCampaignGroups($campaignId: String!) {
+        campaign(id: $campaignId) {
+          id
+          campaignGroups {
+            edges {
+              node {
+                id
+                name
+              }
+            }
+          }
+          isStarted
+        }
+      }
+    `,
+    options: (ownProps) => ({
+      variables: {
+        campaignId: ownProps.campaignId
+      }
+    })
+  },
+  orgCampaignGroups: {
+    query: gql`
+      query GetOrgCampaignGroups($organizationId: String!) {
+        organization(id: $organizationId) {
+          id
+          campaignGroups {
+            edges {
+              node {
+                id
+                name
+              }
+            }
+          }
+        }
+      }
+    `,
+    options: (ownProps) => ({
+      variables: {
+        organizationId: ownProps.organizationId
+      }
+    })
+  }
+};
+const mutations: MutationMap<InnerProps> = {
+  editCampaign: (ownProps) => (campaignGroupIds: string[]) => ({
+    mutation: gql`
+      mutation editCampaignBasics(
+        $campaignId: String!
+        $payload: CampaignInput!
+      ) {
+        editCampaign(id: $campaignId, campaign: $payload) {
+          id
+          campaignGroups {
+            edges {
+              node {
+                id
+                name
+              }
+            }
+          }
+          isStarted
+          readiness {
+            id
+            campaignGroups
+          }
+        }
+      }
+    `,
+    variables: {
+      campaignId: ownProps.campaignId,
+      payload: {
+        campaignGroupIds
+      }
+    }
+  })
+};
+
+export default compose<InnerProps, RequiredComponentProps>(
+  asSection({
+    title: "Campaign Groups",
+    readinessName: "cannedResponses",
+    jobQueueNames: [],
+    expandAfterCampaignStarts: true,
+    expandableBySuperVolunteers: false
+  }),
+  loadData({
+    queries,
+    mutations
+  })
+)(CampaignGroupsForm);

--- a/src/containers/AdminCampaignGroupEditor/AdminCampaignGroupList.tsx
+++ b/src/containers/AdminCampaignGroupEditor/AdminCampaignGroupList.tsx
@@ -1,0 +1,77 @@
+import IconButton from "@material-ui/core/IconButton";
+import Paper from "@material-ui/core/Paper";
+import { makeStyles } from "@material-ui/core/styles";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableContainer from "@material-ui/core/TableContainer";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import DeleteIcon from "@material-ui/icons/Delete";
+import EditIcon from "@material-ui/icons/Edit";
+import React from "react";
+
+import { CampaignGroup } from "../../api/campaign-group";
+
+const useStyles = makeStyles({
+  table: {
+    minWidth: 650
+  }
+});
+
+export interface AdminCampaignGroupListProps {
+  campaignGroups: CampaignGroup[];
+  onEditGroup: (groupId: string) => Promise<void> | void;
+  onDeleteGroup: (groupId: string) => Promise<void> | void;
+}
+
+export const AdminCampaignGroupList: React.FC<AdminCampaignGroupListProps> = (
+  props
+) => {
+  const classes = useStyles();
+
+  const handleClickEditFactory = (groupId: string) => () =>
+    props.onEditGroup(groupId);
+  const handleClickDeleteFactory = (groupId: string) => () =>
+    props.onDeleteGroup(groupId);
+
+  return (
+    <TableContainer component={Paper}>
+      <Table className={classes.table} aria-label="simple table">
+        <TableHead>
+          <TableRow>
+            <TableCell>Name</TableCell>
+            <TableCell align="right">Description</TableCell>
+            <TableCell align="right">Actions</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {props.campaignGroups.map((campaignGroup) => (
+            <TableRow key={campaignGroup.name}>
+              <TableCell component="th" scope="row">
+                {campaignGroup.name}
+              </TableCell>
+              <TableCell align="right">{campaignGroup.description}</TableCell>
+              <TableCell align="right">
+                <IconButton
+                  aria-label="edit"
+                  onClick={handleClickEditFactory(campaignGroup.id)}
+                >
+                  <EditIcon />
+                </IconButton>
+                <IconButton
+                  aria-label="delete"
+                  onClick={handleClickDeleteFactory(campaignGroup.id)}
+                >
+                  <DeleteIcon />
+                </IconButton>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
+
+export default AdminCampaignGroupList;

--- a/src/containers/AdminCampaignGroupEditor/index.tsx
+++ b/src/containers/AdminCampaignGroupEditor/index.tsx
@@ -1,0 +1,268 @@
+import Button from "@material-ui/core/Button";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import Fab from "@material-ui/core/Fab";
+import { makeStyles } from "@material-ui/core/styles";
+import TextField from "@material-ui/core/TextField";
+import AddIcon from "@material-ui/icons/Add";
+import { ApolloQueryResult } from "apollo-client";
+import gql from "graphql-tag";
+import { History } from "history";
+import React, { useState } from "react";
+import { compose } from "react-apollo";
+import { withRouter } from "react-router-dom";
+
+import {
+  CampaignGroupInput,
+  CampaignGroupPage
+} from "../../api/campaign-group";
+import { MutationMap, QueryMap } from "../../network/types";
+import { formatErrorMessage, loadData } from "../hoc/with-operations";
+import AdminCampaignGroupList from "./AdminCampaignGroupList";
+
+const useStyles = makeStyles((theme) => ({
+  fab: {
+    position: "absolute",
+    bottom: theme.spacing(2),
+    right: theme.spacing(2)
+  }
+}));
+
+interface OuterProps {
+  mutations: {
+    saveCampaignGroups: (campaignGroups: CampaignGroupInput[]) => Promise<any>;
+    deleteCampaignGroup: (campaignGroupId: string) => Promise<any>;
+  };
+  campaignGroups: Pick<ApolloQueryResult<unknown>, "loading" | "errors"> & {
+    organization: {
+      campaignGroups: CampaignGroupPage;
+    };
+  };
+}
+
+interface InnerProps extends OuterProps {
+  match: any;
+  history: History;
+}
+
+const AdminCampaignGroupEditor: React.FC<InnerProps> = (props) => {
+  const classes = useStyles();
+
+  const [editingCampaignGroup, setEditingCampaignGroup] = useState<
+    CampaignGroupInput | undefined
+  >(undefined);
+  const [isWorking, setIsWorking] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | undefined>(
+    undefined
+  );
+
+  const campaignGroups = (
+    props?.campaignGroups?.organization?.campaignGroups?.edges ?? []
+  ).map(({ node }) => node);
+
+  const getGroup = (campaignGroupId: string) => {
+    const matching = campaignGroups.find(
+      (group) => group.id === campaignGroupId
+    );
+    if (matching) return { ...matching };
+  };
+
+  const handleCancelError = () => setErrorMessage(undefined);
+
+  const handleClickAddCampaignGroup = () =>
+    setEditingCampaignGroup({ name: "", description: "" });
+
+  const handleEditCampaignGroup = (campaignGroupId: string) => {
+    const campaignGroup = getGroup(campaignGroupId);
+    if (campaignGroup) setEditingCampaignGroup(campaignGroup);
+  };
+
+  const handleCancelEditCampaignGroup = () =>
+    setEditingCampaignGroup(undefined);
+
+  const handleSaveCampaignGroup = async () => {
+    if (!editingCampaignGroup) return;
+
+    setIsWorking(true);
+    try {
+      const result = await props.mutations.saveCampaignGroups([
+        editingCampaignGroup
+      ]);
+      if (result.errors) throw new Error(result.errors[0].message);
+    } catch (err: any) {
+      setErrorMessage(err.message);
+    } finally {
+      setIsWorking(false);
+      handleCancelEditCampaignGroup();
+    }
+  };
+
+  const handleDeleteCampaignGroup = async (campaignGroupId: string) => {
+    setIsWorking(true);
+    try {
+      const result = await props.mutations.deleteCampaignGroup(campaignGroupId);
+      if (result.errors) throw new Error(result.errors[0].message);
+    } catch (error: any) {
+      setErrorMessage(formatErrorMessage(error.message));
+    } finally {
+      setIsWorking(false);
+    }
+  };
+
+  const createCampaignGroupEditorHandle = (
+    event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+  ) => {
+    if (!editingCampaignGroup) return;
+    setEditingCampaignGroup({
+      ...editingCampaignGroup,
+      [event.target.name]: event.target.value
+    });
+  };
+
+  const editorAction =
+    editingCampaignGroup?.id === undefined ? "Create" : "Edit";
+
+  return (
+    <>
+      <AdminCampaignGroupList
+        // organizationId={organizationId}
+        campaignGroups={campaignGroups}
+        onEditGroup={handleEditCampaignGroup}
+        onDeleteGroup={handleDeleteCampaignGroup}
+      />
+      <Fab
+        color="primary"
+        className={classes.fab}
+        disabled={isWorking}
+        onClick={handleClickAddCampaignGroup}
+      >
+        <AddIcon />
+      </Fab>
+      <Dialog
+        open={editingCampaignGroup !== undefined}
+        fullWidth
+        onClose={handleCancelEditCampaignGroup}
+      >
+        <DialogTitle>{editorAction} Campaign Group</DialogTitle>
+        <DialogContent>
+          <TextField
+            name="name"
+            value={editingCampaignGroup?.name}
+            label="Name"
+            autoFocus
+            fullWidth
+            onChange={createCampaignGroupEditorHandle}
+          />
+          <br />
+          <br />
+          <TextField
+            name="description"
+            label="Description"
+            value={editingCampaignGroup?.description}
+            multiline
+            fullWidth
+            onChange={createCampaignGroupEditorHandle}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCancelEditCampaignGroup} color="primary">
+            Cancel
+          </Button>
+          <Button onClick={handleSaveCampaignGroup} color="primary">
+            {editorAction}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={errorMessage !== undefined} onClose={handleCancelError}>
+        <DialogTitle>Error</DialogTitle>
+        <DialogContent>
+          <DialogContentText>{errorMessage || ""}</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCancelError}>Cancel</Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+const queries: QueryMap<InnerProps> = {
+  campaignGroups: {
+    query: gql`
+      query GetOrganizationCampaignGroups($organizationId: String!) {
+        organization(id: $organizationId) {
+          id
+          campaignGroups {
+            edges {
+              node {
+                id
+                name
+                description
+              }
+            }
+          }
+        }
+      }
+    `,
+    options: (ownProps) => ({
+      variables: {
+        organizationId: ownProps.match.params.organizationId
+      }
+    })
+  }
+};
+
+const mutations: MutationMap<InnerProps> = {
+  saveCampaignGroups: (ownProps) => (campaignGroups: CampaignGroupInput[]) => ({
+    mutation: gql`
+      mutation SaveCampaignGroups(
+        $organizationId: String!
+        $campaignGroups: [CampaignGroupInput!]!
+      ) {
+        saveCampaignGroups(
+          organizationId: $organizationId
+          campaignGroups: $campaignGroups
+        ) {
+          id
+          name
+          description
+        }
+      }
+    `,
+    variables: {
+      organizationId: ownProps.match.params.organizationId,
+      campaignGroups
+    },
+    refetchQueries: ["GetOrganizationCampaignGroups"]
+  }),
+  deleteCampaignGroup: (ownProps) => (campaignGroupId: string) => ({
+    mutation: gql`
+      mutation DeleteCampaignGroup(
+        $organizationId: String!
+        $campaignGroupId: String!
+      ) {
+        deleteCampaignGroup(
+          organizationId: $organizationId
+          campaignGroupId: $campaignGroupId
+        )
+      }
+    `,
+    variables: {
+      organizationId: ownProps.match.params.organizationId,
+      campaignGroupId
+    },
+    refetchQueries: ["GetOrganizationCampaignGroups"]
+  })
+};
+
+export default compose(
+  withRouter,
+  loadData({
+    queries,
+    mutations
+  })
+)(AdminCampaignGroupEditor);

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -11,6 +11,7 @@ import AdminAssignmentControl from "./containers/AdminAssignmentControl";
 import AdminAssignmentRequest from "./containers/AdminAssignmentRequest";
 import AdminBulkScriptEditor from "./containers/AdminBulkScriptEditor";
 import AdminCampaignEdit from "./containers/AdminCampaignEdit";
+import AdminCampaignGroupEditor from "./containers/AdminCampaignGroupEditor";
 import AdminCampaignList from "./containers/AdminCampaignList";
 import AdminCampaignStats from "./containers/AdminCampaignStats";
 import AdminExternalSystemDetail from "./containers/AdminExternalSystemDetail";
@@ -128,6 +129,10 @@ const AdminOrganizationRoutes = (props) => {
           <Route
             path={`${organizationPath}/campaigns`}
             component={AdminCampaignListRoutes}
+          />
+          <Route
+            path={`${organizationPath}/campaign-groups`}
+            component={AdminCampaignGroupEditor}
           />
           <Route path={`${organizationPath}/people`} component={AdminPeople} />
           <Route

--- a/src/server/api/campaign-group.ts
+++ b/src/server/api/campaign-group.ts
@@ -1,0 +1,46 @@
+import { r } from "../models";
+import { accessRequired } from "./errors";
+import { formatPage } from "./lib/pagination";
+import { sqlResolvers } from "./lib/utils";
+import { RelayPageArgs } from "./types";
+
+interface CampaignGroup {
+  id: string;
+  organization_id: string;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export const resolvers = {
+  CampaignGroup: {
+    ...sqlResolvers(["id", "name", "description", "createdAt", "updatedAt"]),
+    campaigns: async (
+      campaignGroup: CampaignGroup,
+      { after, first }: RelayPageArgs,
+      { user }: any
+    ) => {
+      const organizationId = parseInt(campaignGroup.id, 10);
+      await accessRequired(user, organizationId, "ADMIN");
+
+      const query = r
+        .reader("campaign")
+        .select("campaign.*")
+        .join(
+          "campaign_group_campaign",
+          "campaign_group_campaign.campaign_id",
+          "campaign.id"
+        )
+        .where({ campaign_group_id: campaignGroup.id });
+
+      const result = await formatPage(query, {
+        after,
+        first,
+        primaryColumn: "campaign.id"
+      });
+      return result;
+    }
+  }
+};
+
+export default resolvers;

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -416,6 +416,16 @@ export const resolvers = {
         first,
         primaryColumn: "messaging_service_sid"
       });
+    },
+    campaignGroups: async (organization, { after, first }, { user }) => {
+      const organizationId = parseInt(organization.id, 10);
+      await accessRequired(user, organizationId, "ADMIN");
+
+      const query = r
+        .reader("campaign_group")
+        .where({ organization_id: organizationId });
+      const result = await formatPage(query, { after, first });
+      return result;
     }
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8683,10 +8683,10 @@ debug@4, debug@4.1.1, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debug@4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
-  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+debug@4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
   dependencies:
     ms "2.1.2"
 
@@ -15024,21 +15024,21 @@ knex@^0.17.5:
     uuid "^3.3.2"
     v8flags "^3.1.3"
 
-knex@^0.95.4:
-  version "0.95.4"
-  resolved "https://registry.yarnpkg.com/knex/-/knex-0.95.4.tgz#91578e425d054e76cf0aacbc1157fa8ee5b6da4c"
-  integrity sha512-IwUcHr6AkZPL707mJCOal1P4jlgxKMy17IMjJm5W23yrkM1jO2/APBM1eyw/MhQ61w8T7NpzGD+LEkr8M46mWw==
+knex@^0.95.11:
+  version "0.95.11"
+  resolved "https://registry.yarnpkg.com/knex/-/knex-0.95.11.tgz#1526bd700cb07497252214d34c10f660aee01a3e"
+  integrity sha512-grDetD91O8VoQVCFqeWTgkzdq5406W6rggF/lK1hHuwzmjDs/0m9KxyncGdZbklTi7aUgHvw3+Cfy4x7FvpdaQ==
   dependencies:
     colorette "1.2.1"
     commander "^7.1.0"
-    debug "4.3.1"
+    debug "4.3.2"
     escalade "^3.1.1"
     esm "^3.2.25"
     getopts "2.2.5"
     interpret "^2.2.0"
     lodash "^4.17.21"
-    pg-connection-string "2.4.0"
-    rechoir "^0.7.0"
+    pg-connection-string "2.5.0"
+    rechoir "0.7.0"
     resolve-from "^5.0.0"
     tarn "^3.0.1"
     tildify "2.0.0"
@@ -17516,7 +17516,7 @@ pg-compose@^1.0.0:
     yaml "^1.10.0"
     yargs "^15.3.1"
 
-pg-connection-string@0.1.3, pg-connection-string@2.0.0, pg-connection-string@2.4.0, pg-connection-string@^2.0.0, pg-connection-string@^2.4.0, pg-connection-string@~2.4.0:
+pg-connection-string@0.1.3, pg-connection-string@2.0.0, pg-connection-string@2.5.0, pg-connection-string@^2.0.0, pg-connection-string@^2.4.0, pg-connection-string@~2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.4.0.tgz#c979922eb47832999a204da5dbe1ebf2341b6a10"
   integrity sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ==
@@ -19366,19 +19366,19 @@ realpath-native@^1.0.0:
   dependencies:
     util.promisify "^1.0.0"
 
+rechoir@0.7.0, rechoir@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.7.0.tgz#32650fd52c21ab252aa5d65b19310441c7e03aca"
+  integrity sha512-ADsDEH2bvbjltXEP+hTIAmeFekTFK0V2BTxMkok6qILyAJEXV0AFfoWcAq4yfll5VdIMd/RVXq0lR+wQi5ZU3Q==
+  dependencies:
+    resolve "^1.9.0"
+
 rechoir@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
   integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
   dependencies:
     resolve "^1.1.6"
-
-rechoir@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.7.0.tgz#32650fd52c21ab252aa5d65b19310441c7e03aca"
-  integrity sha512-ADsDEH2bvbjltXEP+hTIAmeFekTFK0V2BTxMkok6qILyAJEXV0AFfoWcAq4yfll5VdIMd/RVXq0lR+wQi5ZU3Q==
-  dependencies:
-    resolve "^1.9.0"
 
 recompose@^0.22.0:
   version "0.22.0"


### PR DESCRIPTION
## Description

Adds concept of campaign groups to Spoke.

## Motivation and Context

There are many reasons you might want to group campaigns together. This PR adds very basic support for these groupings in order to simplify analytic queries over a universe that, for performance reasons, had to be split into multiple Spoke campaigns. It lays the groundwork for future work to support batch operations on groups.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<table><tr><td>

![Spoke](https://user-images.githubusercontent.com/2145526/137233207-9d7f7981-0e0f-45b4-b2ba-fc26bbf486a8.png)

</td></tr><tr><td>

![Spoke](https://user-images.githubusercontent.com/2145526/137233272-544e0cc6-370c-4e61-95a5-a3c81cda3aab.png)

</td></tr><tr><td>

![Spoke](https://user-images.githubusercontent.com/2145526/137233155-d7b2861a-9596-4b15-8a89-d9afc3423184.png)

</td></tr></table>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

None yet. This is a beta feature that provides value only for analytic queries.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
