### PR TITLE
fix: change mode column type to text

### DIFF
--- a/migrations/20211026163248_troll-mode-text.js
+++ b/migrations/20211026163248_troll-mode-text.js
@@ -13,6 +13,50 @@ exports.up = function up(knex) {
       alter column mode type text,
       alter column mode set default 'english',
       add column compiled_tsquery tsquery generated always as (to_tsquery(regconfig_mode(mode), token::text)) stored;
+
+create or replace function public.get_trollbot_matches (organization_id integer, troll_interval interval)
+  returns table (
+    message_id integer,
+    trigger_token text
+  )
+  as $$
+  begin
+    return query
+      with troll_tokens as (
+        select token, mode, compiled_tsquery
+        from troll_trigger
+        where troll_trigger.organization_id = get_trollbot_matches.organization_id
+      ),
+      ts_queries as (
+        select mode, to_tsquery('(' || array_to_string(array_agg(token), ') | (') || ')') as tsquery
+        from troll_trigger
+        where troll_trigger.organization_id = get_trollbot_matches.organization_id
+        group by 1
+      ),
+      bad_messages as (
+        select distinct on (message.id) message.id, mode, text, is_from_contact
+        from message
+        join campaign_contact
+          on campaign_contact.id = message.campaign_contact_id
+        join campaign
+          on campaign.id = campaign_contact.campaign_id
+        join ts_queries on to_tsvector(regconfig_mode(mode), message.text) @@ ts_queries.tsquery
+        where true
+          and message.created_at >= now() - get_trollbot_matches.troll_interval
+          and message.is_from_contact = false
+          and campaign.organization_id = get_trollbot_matches.organization_id
+        order by message.id, mode
+      ),
+      messages_with_match as (
+        select bad_messages.id, bad_messages.text, token
+        from bad_messages
+        join troll_tokens on to_tsvector(regconfig_mode(troll_tokens.mode), bad_messages.text) @@ troll_tokens.compiled_tsquery
+        where troll_tokens.mode = bad_messages.mode
+      )
+      select id, token::text as trigger_token
+      from messages_with_match;
+  end;
+  $$ language plpgsql stable security definer set search_path = "public";
   `);
 };
 
@@ -24,6 +68,50 @@ exports.down = function down(knex) {
       alter column mode type regconfig using regconfig_mode(mode),
       alter column mode set default 'english'::regconfig,
       add column compiled_tsquery tsquery generated always as (to_tsquery(mode, token::text)) stored;
+
+    create or replace function public.get_trollbot_matches (organization_id integer, troll_interval interval)
+      returns table (
+        message_id integer,
+        trigger_token text
+      )
+      as $$
+      begin
+        return query
+          with troll_tokens as (
+            select token, mode, compiled_tsquery
+            from troll_trigger
+            where troll_trigger.organization_id = get_trollbot_matches.organization_id
+          ),
+          ts_queries as (
+            select mode, to_tsquery('(' || array_to_string(array_agg(token), ') | (') || ')') as tsquery
+            from troll_trigger
+            where troll_trigger.organization_id = get_trollbot_matches.organization_id
+            group by 1
+          ),
+          bad_messages as (
+            select distinct on (message.id) message.id, mode, text, is_from_contact
+            from message
+            join campaign_contact
+              on campaign_contact.id = message.campaign_contact_id
+            join campaign
+              on campaign.id = campaign_contact.campaign_id
+            join ts_queries on to_tsvector(mode, message.text) @@ ts_queries.tsquery
+            where true
+              and message.created_at >= now() - get_trollbot_matches.troll_interval
+              and message.is_from_contact = false
+              and campaign.organization_id = get_trollbot_matches.organization_id
+            order by message.id, mode
+          ),
+          messages_with_match as (
+            select bad_messages.id, bad_messages.text, token
+            from bad_messages
+            join troll_tokens on to_tsvector(troll_tokens.mode, bad_messages.text) @@ troll_tokens.compiled_tsquery
+            where troll_tokens.mode = bad_messages.mode
+          )
+          select id, token::text as trigger_token
+          from messages_with_match;
+      end;
+      $$ language plpgsql stable security definer set search_path = "public";
 
     drop function regconfig_mode (text);
   `);

--- a/migrations/20211026163248_troll-mode-text.js
+++ b/migrations/20211026163248_troll-mode-text.js
@@ -1,0 +1,30 @@
+exports.up = function up(knex) {
+  return knex.schema.raw(`
+    create or replace function regconfig_mode (mode text) returns regconfig
+    as $$
+    begin
+      return cast(mode as regconfig);
+    end
+    $$
+    language plpgsql immutable;
+
+    alter table public.troll_trigger
+      drop column compiled_tsquery,
+      alter column mode type text,
+      alter column mode set default 'english',
+      add column compiled_tsquery tsquery generated always as (to_tsquery(regconfig_mode(mode), token::text)) stored;
+  `);
+};
+
+exports.down = function down(knex) {
+  return knex.schema.raw(`
+    alter table public.troll_trigger
+      drop column compiled_tsquery,
+      alter column mode drop default,
+      alter column mode type regconfig using regconfig_mode(mode),
+      alter column mode set default 'english'::regconfig,
+      add column compiled_tsquery tsquery generated always as (to_tsquery(mode, token::text)) stored;
+
+    drop function regconfig_mode (text);
+  `);
+};

--- a/migrations/20211026163248_troll-mode-text.js
+++ b/migrations/20211026163248_troll-mode-text.js
@@ -11,6 +11,7 @@ exports.up = function up(knex) {
     alter table public.troll_trigger
       drop column compiled_tsquery,
       alter column mode type text,
+      add constraint valid_regconfig check (mode = (mode::regconfig)::text),
       alter column mode set default 'english',
       add column compiled_tsquery tsquery generated always as (to_tsquery(regconfig_mode(mode), token::text)) stored;
 
@@ -64,6 +65,7 @@ exports.down = function down(knex) {
   return knex.schema.raw(`
     alter table public.troll_trigger
       drop column compiled_tsquery,
+      drop constraint valid_regconfig,
       alter column mode drop default,
       alter column mode type regconfig using regconfig_mode(mode),
       alter column mode set default 'english'::regconfig,

--- a/schema-dump.sql
+++ b/schema-dump.sql
@@ -459,7 +459,7 @@ CREATE FUNCTION public.get_trollbot_matches(organization_id integer, troll_inter
           on campaign_contact.id = message.campaign_contact_id
         join campaign
           on campaign.id = campaign_contact.campaign_id
-        join ts_queries on to_tsvector(mode, message.text) @@ ts_queries.tsquery
+        join ts_queries on to_tsvector(regconfig_mode(mode), message.text) @@ ts_queries.tsquery
         where true
           and message.created_at >= now() - get_trollbot_matches.troll_interval
           and message.is_from_contact = false
@@ -469,7 +469,7 @@ CREATE FUNCTION public.get_trollbot_matches(organization_id integer, troll_inter
       messages_with_match as (
         select bad_messages.id, bad_messages.text, token
         from bad_messages
-        join troll_tokens on to_tsvector(troll_tokens.mode, bad_messages.text) @@ troll_tokens.compiled_tsquery
+        join troll_tokens on to_tsvector(regconfig_mode(troll_tokens.mode), bad_messages.text) @@ troll_tokens.compiled_tsquery
         where troll_tokens.mode = bad_messages.mode
       )
       select id, token::text as trigger_token

--- a/schema-dump.sql
+++ b/schema-dump.sql
@@ -2854,7 +2854,8 @@ CREATE TABLE public.troll_trigger (
     token character varying(255) NOT NULL,
     organization_id integer NOT NULL,
     mode text DEFAULT 'english'::text NOT NULL,
-    compiled_tsquery tsquery GENERATED ALWAYS AS (to_tsquery(public.regconfig_mode(mode), (token)::text)) STORED
+    compiled_tsquery tsquery GENERATED ALWAYS AS (to_tsquery(public.regconfig_mode(mode), (token)::text)) STORED,
+    CONSTRAINT valid_regconfig CHECK ((mode = ((mode)::regconfig)::text))
 );
 
 

--- a/schema-dump.sql
+++ b/schema-dump.sql
@@ -1091,6 +1091,21 @@ CREATE FUNCTION public.raise_trollbot_alarms(organization_id integer, troll_inte
 ALTER FUNCTION public.raise_trollbot_alarms(organization_id integer, troll_interval interval) OWNER TO postgres;
 
 --
+-- Name: regconfig_mode(text); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.regconfig_mode(mode text) RETURNS regconfig
+    LANGUAGE plpgsql IMMUTABLE
+    AS $$
+    begin
+      return cast(mode as regconfig);
+    end
+    $$;
+
+
+ALTER FUNCTION public.regconfig_mode(mode text) OWNER TO postgres;
+
+--
 -- Name: soft_delete_tag(); Type: FUNCTION; Schema: public; Owner: postgres
 --
 
@@ -2838,8 +2853,8 @@ ALTER SEQUENCE public.team_id_seq OWNED BY public.team.id;
 CREATE TABLE public.troll_trigger (
     token character varying(255) NOT NULL,
     organization_id integer NOT NULL,
-    mode regconfig DEFAULT 'english'::regconfig NOT NULL,
-    compiled_tsquery tsquery GENERATED ALWAYS AS (to_tsquery(mode, (token)::text)) STORED
+    mode text DEFAULT 'english'::text NOT NULL,
+    compiled_tsquery tsquery GENERATED ALWAYS AS (to_tsquery(public.regconfig_mode(mode), (token)::text)) STORED
 );
 
 


### PR DESCRIPTION
## Description

Store mode as `text` instead of `regconfig`.

## Motivation and Context

`pg_upgrade` does not support upgrading of databases containing table columns using these reg* OID-
referencing system data types, including regconfig.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
