### PR TITLE
fix(van): add warning about van-supplied fields

### DIFF
--- a/src/components/CannedResponseForm.jsx
+++ b/src/components/CannedResponseForm.jsx
@@ -17,13 +17,14 @@ class CannedResponseForm extends React.Component {
       text: yup.string().required()
     });
 
-    const { customFields } = this.props;
+    const { customFields, integrationSourced } = this.props;
     return (
       <div>
         <GSForm ref="form" schema={modelSchema} onSubmit={this.handleSave}>
           <SpokeFormField name="title" autoFocus fullWidth label="Title" />
           <SpokeFormField
             customFields={customFields}
+            integrationSourced={integrationSourced}
             name="text"
             type="script"
             label="Script"

--- a/src/components/CannedResponseMenu.jsx
+++ b/src/components/CannedResponseMenu.jsx
@@ -21,7 +21,13 @@ class CannedResponseMenu extends React.Component {
   };
 
   renderCannedResponses({ scripts, subheader, showAddScriptButton }) {
-    const { customFields, campaignId, texterId, client } = this.props;
+    const {
+      customFields,
+      integrationSourced,
+      campaignId,
+      texterId,
+      client
+    } = this.props;
 
     return (
       <ScriptList
@@ -32,6 +38,7 @@ class CannedResponseMenu extends React.Component {
         showAddScriptButton={showAddScriptButton}
         duplicateCampaignResponses
         customFields={customFields}
+        integrationSourced={integrationSourced}
         subheader={subheader}
         onSelectCannedResponse={this.handleSelectCannedResponse}
       />
@@ -79,6 +86,7 @@ CannedResponseMenu.propTypes = {
   onSelectCannedResponse: type.func,
   onRequestClose: type.func,
   customFields: type.array,
+  integrationSourced: type.bool,
   texterId: type.string,
   userCannedResponses: type.array,
   open: type.bool,

--- a/src/components/ScriptEditor.tsx
+++ b/src/components/ScriptEditor.tsx
@@ -87,6 +87,7 @@ const UnrecognizedField: React.FC = (props) => (
 interface Props {
   scriptText: string;
   scriptFields: string[];
+  integrationSourced: boolean;
   onChange: (value: string) => Promise<void> | void;
   receiveFocus?: boolean;
 }
@@ -240,6 +241,13 @@ class ScriptEditor extends React.Component<Props, State> {
             spellCheck
           />
         </div>
+        {this.props.integrationSourced && (
+          <p>
+            <span style={{ color: "black" }}>Note:</span> these fields are
+            provided by an integration and are not all guarateed to contain
+            values for all contacts.
+          </p>
+        )}
         {this.renderCustomFields()}
         <div>
           <br />

--- a/src/components/ScriptList.jsx
+++ b/src/components/ScriptList.jsx
@@ -48,6 +48,7 @@ class ScriptList extends React.Component {
       onSelectCannedResponse,
       showAddScriptButton,
       customFields,
+      integrationSourced,
       campaignId,
       texterId
     } = this.props;
@@ -120,6 +121,7 @@ class ScriptList extends React.Component {
             <CannedResponseForm
               onSaveCannedResponse={onSaveCannedResponse}
               customFields={customFields}
+              integrationSourced={integrationSourced}
               script={this.state.script}
             />
           </DialogContent>
@@ -145,6 +147,7 @@ ScriptList.propTypes = {
   onSelectCannedResponse: PropTypes.func,
   showAddScriptButton: PropTypes.bool,
   customFields: PropTypes.array,
+  integrationSourced: PropTypes.bool,
   campaignId: PropTypes.string,
   mutations: PropTypes.object,
   texterId: PropTypes.string

--- a/src/components/forms/GSScriptField.jsx
+++ b/src/components/forms/GSScriptField.jsx
@@ -82,7 +82,7 @@ class GSScriptField extends GSFormField {
   };
 
   renderDialog() {
-    const { name, customFields } = this.props;
+    const { name, customFields, integrationSourced } = this.props;
     const { open, scriptWarningOpen, script } = this.state;
     const scriptFields = allScriptFields(customFields);
     const warningContext = script && getWarningContextForScript(script);
@@ -103,6 +103,7 @@ class GSScriptField extends GSFormField {
             name={name}
             scriptText={this.state.script}
             scriptFields={scriptFields}
+            integrationSourced={integrationSourced}
             expandable
             onChange={(val) => this.setState({ script: val })}
           />

--- a/src/components/forms/GSScriptOptionsField.jsx
+++ b/src/components/forms/GSScriptOptionsField.jsx
@@ -92,7 +92,12 @@ class GSScriptOptionsField extends GSFormField {
   };
 
   renderDialog() {
-    const { name, customFields, value: scriptVersions } = this.props;
+    const {
+      name,
+      customFields,
+      value: scriptVersions,
+      integrationSourced
+    } = this.props;
     const { scriptTarget, scriptDraft, scriptWarningOpen } = this.state;
     const scriptFields = allScriptFields(customFields);
 
@@ -140,6 +145,7 @@ class GSScriptOptionsField extends GSFormField {
             name={name}
             scriptText={scriptDraft}
             scriptFields={scriptFields}
+            integrationSourced={integrationSourced}
             receiveFocus
             expandable
             onChange={(val) => this.setState({ scriptDraft: val.trim() })}

--- a/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/components/CannedResponseEditor.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/components/CannedResponseEditor.tsx
@@ -23,12 +23,19 @@ const modelSchema = yup.object({
 export interface CannedResponseEditorProps {
   editingResponse: CannedResponse;
   customFields: string[];
+  integrationSourced: boolean;
   onSave(...args: any[]): void;
   onCancel(): void;
 }
 
 const CannedResponseEditor: React.SFC<CannedResponseEditorProps> = (props) => {
-  const { customFields, editingResponse, onSave, onCancel } = props;
+  const {
+    customFields,
+    integrationSourced,
+    editingResponse,
+    onSave,
+    onCancel
+  } = props;
 
   const handleSave = (formValues: any) => {
     onSave(formValues);
@@ -49,6 +56,7 @@ const CannedResponseEditor: React.SFC<CannedResponseEditorProps> = (props) => {
       <SpokeFormField
         {...dataTest("editorResponse")}
         customFields={customFields}
+        integrationSourced={integrationSourced}
         name="text"
         context="responseEditor"
         type="script"

--- a/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/index.tsx
@@ -37,6 +37,7 @@ interface HocProps {
       cannedResponses: CannedResponse[];
       isStarted: boolean;
       customFields: string[];
+      externalSystem: { id: string } | null;
     };
   };
 }
@@ -162,7 +163,7 @@ class CampaignCannedResponsesForm extends React.Component<InnerProps, State> {
     const { shouldShowEditor, editingResponse } = this.state;
     const {
       data: {
-        campaign: { customFields }
+        campaign: { customFields, externalSystem }
       }
     } = this.props;
 
@@ -178,6 +179,7 @@ class CampaignCannedResponsesForm extends React.Component<InnerProps, State> {
         open={shouldShowEditor}
         context={context}
         customFields={customFields}
+        integrationSourced={externalSystem !== null}
         editingResponse={editingResponse!}
         onCancel={this.handleOnCancelResponseEdit}
         onSave={onSave}
@@ -253,6 +255,9 @@ const queries: QueryMap<InnerProps> = {
           }
           isStarted
           customFields
+          externalSystem {
+            id
+          }
         }
       }
     `,

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/components/InteractionStepCard.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/components/InteractionStepCard.tsx
@@ -47,6 +47,7 @@ type BlockHandlerFactory = (stepId: string) => () => Promise<void> | void;
 interface Props {
   interactionStep: InteractionStepWithChildren;
   customFields: string[];
+  integrationSourced: boolean;
   availableActions: any[];
   hasBlockCopied: boolean;
   title?: string;
@@ -64,6 +65,7 @@ export const InteractionStepCard: React.FC<Props> = (props) => {
   const {
     interactionStep,
     customFields,
+    integrationSourced,
     availableActions,
     hasBlockCopied,
     title = "Start",
@@ -195,6 +197,7 @@ export const InteractionStepCard: React.FC<Props> = (props) => {
               label="Script"
               hintText="This is what your texters will send to your contacts. E.g. Hi, {firstName}. It's {texterFirstName} here."
               customFields={customFields}
+              integrationSourced={integrationSourced}
               fullWidth
               multiLine
               disabled={disabled}
@@ -238,6 +241,7 @@ export const InteractionStepCard: React.FC<Props> = (props) => {
               title={`Question: ${questionText}`}
               interactionStep={childStep}
               customFields={customFields}
+              integrationSourced={integrationSourced}
               availableActions={availableActions}
               hasBlockCopied={hasBlockCopied}
               disabled={disabled}

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
@@ -58,7 +58,10 @@ interface HocProps {
     ): Promise<void>;
   };
   data: {
-    campaign: Pick<Campaign, "id" | "isStarted" | "customFields"> & {
+    campaign: Pick<
+      Campaign,
+      "id" | "isStarted" | "customFields" | "externalSystem"
+    > & {
       interactionSteps: InteractionStepWithLocalState[];
     };
   };
@@ -262,7 +265,12 @@ const CampaignInteractionStepsForm: React.FC<InnerProps> = (props) => {
   const {
     isNew,
     saveLabel,
-    data: { campaign: { customFields } = { customFields: [] } },
+    data: {
+      campaign: { customFields, externalSystem } = {
+        customFields: [],
+        externalSystem: null
+      }
+    },
     availableActions: { availableActions }
   } = props;
 
@@ -326,6 +334,7 @@ const CampaignInteractionStepsForm: React.FC<InnerProps> = (props) => {
       <InteractionStepCard
         interactionStep={finalFree}
         customFields={customFields}
+        integrationSourced={externalSystem !== null}
         availableActions={availableActions}
         hasBlockCopied={hasBlockCopied}
         disabled={isWorking}

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/resolvers.ts
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/resolvers.ts
@@ -33,6 +33,9 @@ export const GET_CAMPAIGN_INTERACTIONS = gql`
         ...EditInteractionStep
       }
       customFields
+      externalSystem {
+        id
+      }
     }
   }
   ${EditInteractionStepFragment}

--- a/src/containers/AdminTagEditor/index.jsx
+++ b/src/containers/AdminTagEditor/index.jsx
@@ -190,6 +190,7 @@ class AdminTagEditor extends Component {
     // Custom fields are campaign-specific and thus cannot be used in Tag scripts.
     // However, this is a required prop for GSScriptField
     const customFields = [""];
+    const integrationSourced = false;
 
     const errorActions = [
       <FlatButton
@@ -238,6 +239,7 @@ class AdminTagEditor extends Component {
                       label="Tag script"
                       context="tagEditor"
                       customFields={customFields}
+                      integrationSourced={integrationSourced}
                       value={editingTag.onApplyScript || ""}
                       onChange={this.handleEditTagScript}
                       onClick={this.handleOpenScriptEditor}

--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -739,6 +739,9 @@ export class AssignmentTexterContact extends React.Component {
     const { campaign, assignment, texter } = this.props;
     const { userCannedResponses, campaignCannedResponses } = assignment;
 
+    // We do not allow Texters to compose their own canned responses
+    const integrationSourced = false;
+
     return (
       <CannedResponseMenu
         onRequestClose={this.handleClosePopover}
@@ -747,6 +750,7 @@ export class AssignmentTexterContact extends React.Component {
         campaignCannedResponses={campaignCannedResponses}
         userCannedResponses={userCannedResponses}
         customFields={campaign.customFields}
+        integrationSourced={integrationSourced}
         campaignId={campaign.id}
         texterId={texter.id}
         onSelectCannedResponse={this.handleCannedResponseChange}


### PR DESCRIPTION
## Description

Add warning about van-supplied contact fields.

## Motivation and Context

Anecdotally, many VAN exports contain blank columns for many fields. Once we expose all of these fields, we'll want users to be sure _their VAN_ includes the fields they want to use.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

![Spoke](https://user-images.githubusercontent.com/2145526/139849488-9ed93d42-06da-452b-86f4-5b6ebea46a31.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

See "Write script with VAN-provided fields" section of new [VAN Integration & List Loading draft](https://secure.helpscout.net/docs/5d65589b04286350aeeb1576/article/5ee923fc2c7d3a10cba9045e/).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] My change requires a change to the documentation.
- [x] I have included updates for the documentation accordingly.
