### PR TITLE
fix: leave autoassign disabled for copied campaigns

### DIFF
--- a/src/server/api/lib/campaign.ts
+++ b/src/server/api/lib/campaign.ts
@@ -144,7 +144,7 @@ export const copyCampaign = async (options: CopyCampaignOptions) => {
           texting_hours_end,
           timezone,
           ? as creator_id,
-          is_autoassign_enabled,
+          false as is_autoassign_enabled,
           limit_assignment_to_teams,
           replies_stale_after_minutes,
           external_system_id


### PR DESCRIPTION
## Description

Ensure autoassign is disabled for all copied campaigns.

## Motivation and Context

Like starting a campaign, enabling autoassign should be a conscious decision.

Closes #1039 

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201668628977620