### PR TITLE
refactor: pull up editCampaign

### DIFF
--- a/src/api/campaign-contact.ts
+++ b/src/api/campaign-contact.ts
@@ -37,6 +37,15 @@ export interface CampaignContact {
   updatedAt: Date;
 }
 
+export interface CampaignContactInput {
+  firstName: string;
+  lastName: string;
+  cell: string;
+  zip: string | null;
+  external_id: string | null;
+  customFields: string | null;
+}
+
 export const schema = `
   input ContactsFilter {
     messageStatus: String
@@ -76,5 +85,14 @@ export const schema = `
     updatedAt: Date
 
     contactTags: [Tag]
+  }
+
+  input CampaignContactInput {
+    firstName: String!
+    lastName: String!
+    cell: String!
+    zip: String
+    external_id: String
+    customFields: String
   }
 `;

--- a/src/api/campaign.ts
+++ b/src/api/campaign.ts
@@ -1,7 +1,9 @@
 /* eslint-disable no-unused-vars */
+import { CampaignContactInput } from "./campaign-contact";
 import { CampaignGroupPage } from "./campaign-group";
+import { CannedResponseInput } from "./canned-response";
 import { ExternalSystem } from "./external-system";
-import { InteractionStep } from "./interaction-step";
+import { InteractionStep, InteractionStepInput } from "./interaction-step";
 import { Team } from "./team";
 import { PageInfo } from "./types";
 import { User } from "./user";
@@ -42,12 +44,51 @@ export interface CampaignsFilter {
   campaignId?: number;
 }
 
+export interface TexterAssignmentInput {
+  userId: string;
+  contactsCount: number;
+}
+
+export interface TexterInput {
+  assignmentInputs: TexterAssignmentInput[];
+  ignoreAfterDate: string;
+}
+
+export interface CampaignInput {
+  title: string | null;
+  description: string | null;
+  dueBy: string | null;
+  logoImageUrl: string | null;
+  primaryColor: string | null;
+  introHtml: string | null;
+  externalSystemId: string | null;
+  useDynamicAssignment: boolean | null;
+  contacts: CampaignContactInput[] | null;
+  contactsFile: any | null;
+  externalListId: string | null;
+  filterOutLandlines: boolean | null;
+  excludeCampaignIds: number[] | null;
+  contactSql: string | null;
+  organizationId: string | null;
+  isAssignmentLimitedToTeams: boolean | null;
+  teamIds: string[];
+  campaignGroupIds: string[] | null;
+  texters: TexterInput;
+  interactionSteps: InteractionStepInput;
+  cannedResponses: CannedResponseInput[];
+  textingHoursStart: number | null;
+  textingHoursEnd: number | null;
+  isAutoassignEnabled: boolean | null;
+  timezone: string | null;
+  repliesStaleAfter: number | null;
+}
+
 export interface Campaign {
   id: string;
   title: string;
   description: string;
   isStarted: boolean;
-  dueBy: string;
+  dueBy?: string | null;
   contactsCount: number;
   isArchived: boolean;
   textingHoursStart: number;
@@ -61,7 +102,6 @@ export interface Campaign {
   interactionSteps: InteractionStep[];
   customFields: string[];
   hasUnassignedContacts?: boolean | null;
-  dueBy?: string | null;
   primaryColor?: string | null;
   logoImageUrl?: string | null;
   introHtml?: string | null;
@@ -208,5 +248,44 @@ export const schema = `
   type PaginatedCampaigns {
     campaigns: [Campaign]
     pageInfo: PageInfo
+  }
+
+  input TexterAssignmentInput {
+    userId: String!
+    contactsCount: Int!
+  }
+
+  input TexterInput {
+    assignmentInputs: [TexterAssignmentInput!]!
+    ignoreAfterDate: Date!
+  }
+
+  input CampaignInput {
+    title: String
+    description: String
+    dueBy: Date
+    logoImageUrl: String
+    primaryColor: String
+    introHtml: String
+    externalSystemId: String
+    useDynamicAssignment: Boolean
+    contacts: [CampaignContactInput]
+    contactsFile: Upload
+    externalListId: String
+    filterOutLandlines: Boolean
+    excludeCampaignIds: [Int]
+    contactSql: String
+    organizationId: String
+    isAssignmentLimitedToTeams: Boolean
+    teamIds: [ID]
+    campaignGroupIds: [String!]
+    texters: TexterInput
+    interactionSteps: InteractionStepInput
+    cannedResponses: [CannedResponseInput]
+    textingHoursStart: Int
+    textingHoursEnd: Int
+    isAutoassignEnabled: Boolean
+    timezone: String
+    repliesStaleAfter: Int
   }
 `;

--- a/src/api/canned-response.ts
+++ b/src/api/canned-response.ts
@@ -1,3 +1,11 @@
+export interface CannedResponseInput {
+  id: string;
+  title: string;
+  text: string;
+  campaignId: string;
+  userId: string;
+}
+
 export interface CannedResponse {
   id: string;
   title: string;

--- a/src/api/interaction-step.ts
+++ b/src/api/interaction-step.ts
@@ -14,7 +14,19 @@ export interface InteractionStep {
   createdAt: string;
 }
 
-export interface InteractionStepWithChildren extends InteractionStep {
+export interface InteractionStepInput {
+  id: string;
+  questionText: string | null;
+  scriptOptions: string[];
+  answerOption: string | null;
+  answerActions: string | null;
+  parentInteractionId: string | null;
+  isDeleted: boolean;
+  createdAt: string;
+  interactionSteps: InteractionStepInput[];
+}
+
+export interface InteractionStepWithChildren extends InteractionStepInput {
   interactionSteps: InteractionStepWithChildren[];
 }
 
@@ -30,5 +42,17 @@ export const schema = `
     answerActions: String
     questionResponse(campaignContactId: String): QuestionResponse
     createdAt: Date!
+  }
+
+  input InteractionStepInput {
+    id: String!
+    questionText: String
+    scriptOptions: [String]!
+    answerOption: String
+    answerActions: String
+    parentInteractionId: String
+    isDeleted: Boolean
+    createdAt: Date
+    interactionSteps: [InteractionStepInput]!
   }
 `;

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -31,15 +31,6 @@ import { schema as trollbotSchema } from "./trollbot";
 import { schema as userSchema } from "./user";
 
 const rootSchema = `
-  input CampaignContactInput {
-    firstName: String!
-    lastName: String!
-    cell: String!
-    zip: String
-    external_id: String
-    customFields: String
-  }
-
   input BulkUpdateScriptInput {
     searchString: String!
     replaceString: String!
@@ -70,57 +61,6 @@ const rootSchema = `
     action: String
     value: String!
     nextInteractionStepId: String
-  }
-
-  input InteractionStepInput {
-    id: String
-    questionText: String
-    scriptOptions: [String]!
-    answerOption: String
-    answerActions: String
-    parentInteractionId: String
-    isDeleted: Boolean
-    createdAt: Date
-    interactionSteps: [InteractionStepInput]
-  }
-
-  input TexterAssignmentInput {
-    userId: String!
-    contactsCount: Int!
-  }
-
-  input TexterInput {
-    assignmentInputs: [TexterAssignmentInput!]!
-    ignoreAfterDate: Date!
-  }
-
-  input CampaignInput {
-    title: String
-    description: String
-    dueBy: Date
-    logoImageUrl: String
-    primaryColor: String
-    introHtml: String
-    externalSystemId: String
-    useDynamicAssignment: Boolean
-    contacts: [CampaignContactInput]
-    contactsFile: Upload
-    externalListId: String
-    filterOutLandlines: Boolean
-    excludeCampaignIds: [Int]
-    contactSql: String
-    organizationId: String
-    isAssignmentLimitedToTeams: Boolean
-    teamIds: [ID]
-    campaignGroupIds: [String!]
-    texters: TexterInput
-    interactionSteps: InteractionStepInput
-    cannedResponses: [CannedResponseInput]
-    textingHoursStart: Int
-    textingHoursEnd: Int
-    isAutoassignEnabled: Boolean
-    timezone: String
-    repliesStaleAfter: Int
   }
 
   input MessageInput {

--- a/src/server/api/lib/campaign.ts
+++ b/src/server/api/lib/campaign.ts
@@ -1,16 +1,28 @@
 /* eslint-disable import/prefer-default-export */
+import isEqual from "lodash/isEqual";
 import isNil from "lodash/isNil";
 import { QueryResult } from "pg";
 
 import { Campaign, CampaignsFilter } from "../../../api/campaign";
 import { RelayPaginatedResponse } from "../../../api/pagination";
-import { makeTree } from "../../../lib";
+import { config } from "../../../config";
+import { gzip, makeTree } from "../../../lib";
+import { parseIanaZone } from "../../../lib/datetime";
+import {
+  loadContactsFromDataWarehouse,
+  uploadContacts
+} from "../../../workers/jobs";
 import { SpokeDbContext } from "../../contexts";
 import { cacheOpts, memoizer } from "../../memoredis";
-import { r } from "../../models";
+import { cacheableData, datawarehouse, r } from "../../models";
+import { addAssignTexters } from "../../tasks/assign-texters";
+import { accessRequired } from "../errors";
 import { CampaignRecord, InteractionStepRecord } from "../types";
+import { processContactsFile } from "./edit-campaign";
 import { persistInteractionStepTree } from "./interaction-steps";
 import { formatPage } from "./pagination";
+
+const { JOBS_SAME_PROCESS } = config;
 
 interface GetCampaignsOptions {
   first?: number;
@@ -229,4 +241,269 @@ export const copyCampaign = async (options: CopyCampaignOptions) => {
   });
 
   return result;
+};
+
+export const editCampaign = async (
+  id: number,
+  campaign: any,
+  loaders: any,
+  user: any,
+  origCampaignRecord: any
+) => {
+  const {
+    title,
+    description,
+    dueBy,
+    useDynamicAssignment: _useDynamicAssignment,
+    logoImageUrl,
+    introHtml,
+    primaryColor,
+    textingHoursStart,
+    textingHoursEnd,
+    isAutoassignEnabled,
+    repliesStaleAfter,
+    timezone,
+    externalSystemId
+  } = campaign;
+
+  const organizationId = origCampaignRecord.organization_id;
+  const campaignUpdates: Partial<CampaignRecord> = {
+    id,
+    title,
+    description,
+    due_by: dueBy,
+    organization_id: organizationId,
+    // TODO: re-enable once dynamic assignment is fixed (#548)
+    // use_dynamic_assignment: useDynamicAssignment,
+    logo_image_url: logoImageUrl,
+    primary_color: primaryColor,
+    intro_html: introHtml,
+    texting_hours_start: textingHoursStart,
+    texting_hours_end: textingHoursEnd,
+    is_autoassign_enabled: isAutoassignEnabled,
+    replies_stale_after_minutes: repliesStaleAfter, // this is null to unset it - it must be null, not undefined
+    timezone: parseIanaZone(timezone),
+    external_system_id: externalSystemId
+  };
+
+  Object.keys(campaignUpdates).forEach((key) => {
+    if (typeof campaignUpdates[key as keyof CampaignRecord] === "undefined") {
+      delete campaignUpdates[key as keyof CampaignRecord];
+    }
+  });
+
+  if (
+    Object.prototype.hasOwnProperty.call(campaign, "externalListId") &&
+    campaign.externalListId
+  ) {
+    await r.knex("campaign_contact").where({ campaign_id: id }).del();
+    await r.knex.raw(
+      `select * from public.queue_load_list_into_campaign(?, ?)`,
+      [id, parseInt(campaign.externalListId, 10)]
+    );
+  }
+
+  let validationStats = {};
+  if (
+    Object.prototype.hasOwnProperty.call(campaign, "contactsFile") &&
+    campaign.contactsFile
+  ) {
+    const processedContacts = await processContactsFile(campaign.contactsFile);
+    campaign.contacts = processedContacts.contacts;
+    validationStats = processedContacts.validationStats;
+  }
+
+  if (
+    Object.prototype.hasOwnProperty.call(campaign, "contacts") &&
+    campaign.contacts
+  ) {
+    await accessRequired(user, organizationId, "ADMIN", /* superadmin */ true);
+
+    // Uploading contacts from a CSV invalidates external system configuration
+    await r
+      .knex("campaign")
+      .update({
+        external_system_id: null
+      })
+      .where({ id });
+
+    const contactsToSave = campaign.contacts.map((datum: any) => {
+      const modelData = {
+        campaign_id: datum.campaignId,
+        first_name: datum.firstName,
+        last_name: datum.lastName,
+        cell: datum.cell,
+        external_id: datum.external_id,
+        custom_fields: datum.customFields,
+        message_status: "needsMessage",
+        is_opted_out: false,
+        zip: datum.zip || ""
+      };
+      modelData.campaign_id = id;
+      return modelData;
+    });
+    const jobPayload = {
+      excludeCampaignIds: campaign.excludeCampaignIds || [],
+      contacts: contactsToSave,
+      filterOutLandlines: campaign.filterOutLandlines,
+      validationStats
+    };
+    const compressedString = await gzip(JSON.stringify(jobPayload));
+    const [job] = await r
+      .knex("job_request")
+      .insert({
+        queue_name: `${id}:edit_campaign`,
+        job_type: "upload_contacts",
+        locks_queue: true,
+        assigned: JOBS_SAME_PROCESS, // can get called immediately, below
+        campaign_id: id,
+        // NOTE: stringifying because compressedString is a binary buffer
+        payload: compressedString.toString("base64")
+      })
+      .returning("*");
+    if (JOBS_SAME_PROCESS) {
+      uploadContacts(job);
+    }
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(campaign, "contactSql") &&
+    datawarehouse &&
+    user.is_superadmin
+  ) {
+    await accessRequired(user, organizationId, "ADMIN", /* superadmin */ true);
+    const [job] = await r
+      .knex("job_request")
+      .insert({
+        queue_name: `${id}:edit_campaign`,
+        job_type: "upload_contacts_sql",
+        locks_queue: true,
+        assigned: JOBS_SAME_PROCESS, // can get called immediately, below
+        campaign_id: id,
+        payload: campaign.contactSql
+      })
+      .returning("*");
+    if (JOBS_SAME_PROCESS) {
+      loadContactsFromDataWarehouse(job);
+    }
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(campaign, "isAssignmentLimitedToTeams")
+  ) {
+    await r
+      .knex("campaign")
+      .update({
+        limit_assignment_to_teams: campaign.isAssignmentLimitedToTeams
+      })
+      .where({ id });
+  }
+  if (Object.prototype.hasOwnProperty.call(campaign, "teamIds")) {
+    await r.knex.transaction(async (trx) => {
+      // Remove all existing team memberships and then add everything again
+      await trx("campaign_team").where({ campaign_id: id }).del();
+      await trx("campaign_team").insert(
+        campaign.teamIds.map((team_id: number) => ({
+          team_id,
+          campaign_id: id
+        }))
+      );
+    });
+    memoizer.invalidate(cacheOpts.CampaignTeams.key, { campaignId: id });
+  }
+  if (Object.prototype.hasOwnProperty.call(campaign, "campaignGroupIds")) {
+    const { campaignGroupIds } = campaign;
+    await r.knex.transaction(async (trx) => {
+      // Remove all existing team memberships and then add everything again
+      await trx.raw(
+        `
+          delete from campaign_group_campaign
+          where
+            campaign_id = ?
+            and campaign_group_id in (
+              select id
+              from campaign_group
+              where
+                organization_id = ?
+                and id != ALL(?)
+            )
+        `,
+        [id, organizationId, campaignGroupIds]
+      );
+
+      if (campaignGroupIds.length < 1) return;
+      const valuesStr = [...Array(campaignGroupIds.length)]
+        .map(() => "(?, ?)")
+        .join(", ");
+      await trx.raw(
+        `
+          insert into campaign_group_campaign (campaign_group_id, campaign_id)
+          values ${valuesStr}
+          on conflict (campaign_group_id, campaign_id) do nothing
+        `,
+        campaignGroupIds.flatMap((groupId: number) => [groupId, id])
+      );
+    });
+  }
+  if (Object.prototype.hasOwnProperty.call(campaign, "texters")) {
+    const { assignmentInputs, ignoreAfterDate } = campaign.texters;
+    await addAssignTexters({
+      campaignId: id,
+      assignmentInputs,
+      ignoreAfterDate
+    });
+  }
+
+  if (Object.prototype.hasOwnProperty.call(campaign, "interactionSteps")) {
+    memoizer.invalidate(cacheOpts.CampaignInteractionSteps.key, {
+      campaignId: id
+    });
+    // TODO: debug why { script: '' } is even being sent from the client in the first place
+    if (!isEqual(campaign.interactionSteps, { scriptOptions: [""] })) {
+      await accessRequired(
+        user,
+        organizationId,
+        "SUPERVOLUNTEER",
+        /* superadmin */ true
+      );
+      await persistInteractionStepTree(
+        id,
+        campaign.interactionSteps,
+        origCampaignRecord
+      );
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(campaign, "cannedResponses")) {
+    memoizer.invalidate(cacheOpts.CampaignCannedResponses.key, {
+      campaignId: id
+    });
+
+    // Ignore the mocked `id` automatically created on the input by GraphQL
+    const convertedResponses = campaign.cannedResponses.map(
+      ({ id: _cannedResponseId, ...response }: { id: number } | any) => ({
+        ...response,
+        campaign_id: id
+      })
+    );
+
+    await r.knex.transaction(async (trx) => {
+      await trx("canned_response")
+        .where({ campaign_id: id })
+        .whereNull("user_id")
+        .del();
+      await trx("canned_response").insert(convertedResponses);
+    });
+
+    await cacheableData.cannedResponse.clearQuery({
+      userId: "",
+      campaignId: id
+    });
+  }
+
+  const [newCampaign] = await r
+    .knex("campaign")
+    .update(campaignUpdates)
+    .where({ id })
+    .returning("*");
+  cacheableData.campaign.reload(id);
+  return newCampaign || loaders.campaign.load(id);
 };

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -13,16 +13,10 @@ import {
 } from "../../api/organization-membership";
 import { CampaignExportType } from "../../api/types";
 import { config } from "../../config";
-import { gzip } from "../../lib";
-import { parseIanaZone } from "../../lib/datetime";
 import { hasRole } from "../../lib/permissions";
 import { applyScript } from "../../lib/scripts";
 import { replaceAll } from "../../lib/utils";
 import logger from "../../logger";
-import {
-  loadContactsFromDataWarehouse,
-  uploadContacts
-} from "../../workers/jobs";
 import { eventBus, EventType } from "../event-bus";
 import { refreshExternalSystem } from "../lib/external-systems";
 import {
@@ -31,9 +25,8 @@ import {
 } from "../lib/notices";
 import { change } from "../local-auth-helpers";
 import { cacheOpts, memoizer } from "../memoredis";
-import { cacheableData, datawarehouse, r } from "../models";
+import { cacheableData, r } from "../models";
 import { Notifications, sendUserNotification } from "../notifications";
-import { addAssignTexters } from "../tasks/assign-texters";
 import { addExportCampaign } from "../tasks/export-campaign";
 import { addExportForVan } from "../tasks/export-for-van";
 import { addFilterLandlines } from "../tasks/filter-landlines";
@@ -76,9 +69,7 @@ import { resolvers as externalSystemResolvers } from "./external-system";
 import { resolvers as interactionStepResolvers } from "./interaction-step";
 import { resolvers as inviteResolvers } from "./invite";
 import { notifyAssignmentCreated, notifyOnTagConversation } from "./lib/alerts";
-import { copyCampaign } from "./lib/campaign";
-import { processContactsFile } from "./lib/edit-campaign";
-import { persistInteractionStepTree } from "./lib/interaction-steps";
+import { copyCampaign, editCampaign } from "./lib/campaign";
 import { saveNewIncomingMessage } from "./lib/message-sending";
 import { formatPage } from "./lib/pagination";
 import { sendMessage } from "./lib/send-message";
@@ -103,264 +94,6 @@ import { resolvers as trollbotResolvers } from "./trollbot";
 import { getUsers, getUsersById, resolvers as userResolvers } from "./user";
 
 const uuidv4 = require("uuid").v4;
-
-const { JOBS_SAME_PROCESS } = config;
-
-async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
-  const {
-    title,
-    description,
-    dueBy,
-    useDynamicAssignment: _useDynamicAssignment,
-    logoImageUrl,
-    introHtml,
-    primaryColor,
-    textingHoursStart,
-    textingHoursEnd,
-    isAutoassignEnabled,
-    repliesStaleAfter,
-    timezone,
-    externalSystemId
-  } = campaign;
-
-  const organizationId = origCampaignRecord.organization_id;
-  const campaignUpdates = {
-    id,
-    title,
-    description,
-    due_by: dueBy,
-    organization_id: organizationId,
-    // TODO: re-enable once dynamic assignment is fixed (#548)
-    // use_dynamic_assignment: useDynamicAssignment,
-    logo_image_url: logoImageUrl,
-    primary_color: primaryColor,
-    intro_html: introHtml,
-    texting_hours_start: textingHoursStart,
-    texting_hours_end: textingHoursEnd,
-    is_autoassign_enabled: isAutoassignEnabled,
-    replies_stale_after_minutes: repliesStaleAfter, // this is null to unset it - it must be null, not undefined
-    timezone: parseIanaZone(timezone),
-    external_system_id: externalSystemId
-  };
-
-  Object.keys(campaignUpdates).forEach((key) => {
-    if (typeof campaignUpdates[key] === "undefined") {
-      delete campaignUpdates[key];
-    }
-  });
-
-  if (
-    Object.prototype.hasOwnProperty.call(campaign, "externalListId") &&
-    campaign.externalListId
-  ) {
-    await r.knex("campaign_contact").where({ campaign_id: id }).del();
-    await r.knex.raw(
-      `select * from public.queue_load_list_into_campaign(?, ?)`,
-      [id, parseInt(campaign.externalListId, 10)]
-    );
-  }
-
-  let validationStats = {};
-  if (
-    Object.prototype.hasOwnProperty.call(campaign, "contactsFile") &&
-    campaign.contactsFile
-  ) {
-    const processedContacts = await processContactsFile(campaign.contactsFile);
-    campaign.contacts = processedContacts.contacts;
-    validationStats = processedContacts.validationStats;
-  }
-
-  if (
-    Object.prototype.hasOwnProperty.call(campaign, "contacts") &&
-    campaign.contacts
-  ) {
-    await accessRequired(user, organizationId, "ADMIN", /* superadmin */ true);
-
-    // Uploading contacts from a CSV invalidates external system configuration
-    await r
-      .knex("campaign")
-      .update({
-        external_system_id: null
-      })
-      .where({ id });
-
-    const contactsToSave = campaign.contacts.map((datum) => {
-      const modelData = {
-        campaign_id: datum.campaignId,
-        first_name: datum.firstName,
-        last_name: datum.lastName,
-        cell: datum.cell,
-        external_id: datum.external_id,
-        custom_fields: datum.customFields,
-        message_status: "needsMessage",
-        is_opted_out: false,
-        zip: datum.zip || ""
-      };
-      modelData.campaign_id = id;
-      return modelData;
-    });
-    const jobPayload = {
-      excludeCampaignIds: campaign.excludeCampaignIds || [],
-      contacts: contactsToSave,
-      filterOutLandlines: campaign.filterOutLandlines,
-      validationStats
-    };
-    const compressedString = await gzip(JSON.stringify(jobPayload));
-    const [job] = await r
-      .knex("job_request")
-      .insert({
-        queue_name: `${id}:edit_campaign`,
-        job_type: "upload_contacts",
-        locks_queue: true,
-        assigned: JOBS_SAME_PROCESS, // can get called immediately, below
-        campaign_id: id,
-        // NOTE: stringifying because compressedString is a binary buffer
-        payload: compressedString.toString("base64")
-      })
-      .returning("*");
-    if (JOBS_SAME_PROCESS) {
-      uploadContacts(job);
-    }
-  }
-  if (
-    Object.prototype.hasOwnProperty.call(campaign, "contactSql") &&
-    datawarehouse &&
-    user.is_superadmin
-  ) {
-    await accessRequired(user, organizationId, "ADMIN", /* superadmin */ true);
-    const [job] = await r
-      .knex("job_request")
-      .insert({
-        queue_name: `${id}:edit_campaign`,
-        job_type: "upload_contacts_sql",
-        locks_queue: true,
-        assigned: JOBS_SAME_PROCESS, // can get called immediately, below
-        campaign_id: id,
-        payload: campaign.contactSql
-      })
-      .returning("*");
-    if (JOBS_SAME_PROCESS) {
-      loadContactsFromDataWarehouse(job);
-    }
-  }
-  if (
-    Object.prototype.hasOwnProperty.call(campaign, "isAssignmentLimitedToTeams")
-  ) {
-    await r
-      .knex("campaign")
-      .update({
-        limit_assignment_to_teams: campaign.isAssignmentLimitedToTeams
-      })
-      .where({ id });
-  }
-  if (Object.prototype.hasOwnProperty.call(campaign, "teamIds")) {
-    await r.knex.transaction(async (trx) => {
-      // Remove all existing team memberships and then add everything again
-      await trx("campaign_team").where({ campaign_id: id }).del();
-      await trx("campaign_team").insert(
-        campaign.teamIds.map((team_id) => ({ team_id, campaign_id: id }))
-      );
-    });
-    memoizer.invalidate(cacheOpts.CampaignTeams.key, { campaignId: id });
-  }
-  if (Object.prototype.hasOwnProperty.call(campaign, "campaignGroupIds")) {
-    const { campaignGroupIds } = campaign;
-    await r.knex.transaction(async (trx) => {
-      // Remove all existing team memberships and then add everything again
-      await trx.raw(
-        `
-          delete from campaign_group_campaign
-          where
-            campaign_id = ?
-            and campaign_group_id in (
-              select id
-              from campaign_group
-              where
-                organization_id = ?
-                and id != ALL(?)
-            )
-        `,
-        [id, organizationId, campaignGroupIds]
-      );
-
-      if (campaignGroupIds.length < 1) return;
-      const valuesStr = [...Array(campaignGroupIds.length)]
-        .map(() => "(?, ?)")
-        .join(", ");
-      await trx.raw(
-        `
-          insert into campaign_group_campaign (campaign_group_id, campaign_id)
-          values ${valuesStr}
-          on conflict (campaign_group_id, campaign_id) do nothing
-        `,
-        campaignGroupIds.flatMap((groupId) => [groupId, id])
-      );
-    });
-  }
-  if (Object.prototype.hasOwnProperty.call(campaign, "texters")) {
-    const { assignmentInputs, ignoreAfterDate } = campaign.texters;
-    await addAssignTexters({
-      campaignId: id,
-      assignmentInputs,
-      ignoreAfterDate
-    });
-  }
-
-  if (Object.prototype.hasOwnProperty.call(campaign, "interactionSteps")) {
-    memoizer.invalidate(cacheOpts.CampaignInteractionSteps.key, {
-      campaignId: id
-    });
-    // TODO: debug why { script: '' } is even being sent from the client in the first place
-    if (!_.isEqual(campaign.interactionSteps, { scriptOptions: [""] })) {
-      await accessRequired(
-        user,
-        organizationId,
-        "SUPERVOLUNTEER",
-        /* superadmin */ true
-      );
-      await persistInteractionStepTree(
-        id,
-        campaign.interactionSteps,
-        origCampaignRecord
-      );
-    }
-  }
-
-  if (Object.prototype.hasOwnProperty.call(campaign, "cannedResponses")) {
-    memoizer.invalidate(cacheOpts.CampaignCannedResponses.key, {
-      campaignId: id
-    });
-
-    // Ignore the mocked `id` automatically created on the input by GraphQL
-    const convertedResponses = campaign.cannedResponses.map(
-      ({ id: _cannedResponseId, ...response }) => ({
-        ...response,
-        campaign_id: id
-      })
-    );
-
-    await r.knex.transaction(async (trx) => {
-      await trx("canned_response")
-        .where({ campaign_id: id })
-        .whereNull("user_id")
-        .del();
-      await trx("canned_response").insert(convertedResponses);
-    });
-
-    await cacheableData.cannedResponse.clearQuery({
-      userId: "",
-      campaignId: id
-    });
-  }
-
-  const [newCampaign] = await r
-    .knex("campaign")
-    .update(campaignUpdates)
-    .where({ id })
-    .returning("*");
-  cacheableData.campaign.reload(id);
-  return newCampaign || loaders.campaign.load(id);
-}
 
 async function updateQuestionResponses(
   trx,


### PR DESCRIPTION
## Description

This pulls up the editCampaign method into a typed file.

## Motivation and Context

I thought this made sense as part of a different change. It did not, but still good to do.

Breaking up schema.js is good.
Typing things is good.

## How Has This Been Tested?

This has been tested manually by going through each section of the campaign builder, making changes, saving, and verifying the correct result.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
