### PR TITLE
fix: use title case for name fields in scripts

### DIFF
--- a/src/lib/scripts.spec.ts
+++ b/src/lib/scripts.spec.ts
@@ -14,10 +14,10 @@ describe("script utilities", () => {
   it("converts uppercase words to title case", () => {
     expect(titleCase("SPOKE REWIRED")).toEqual("Spoke Rewired");
   });
-  it("converts lowercase single word to title case", () => {
+  it("converts lowercase words to title case", () => {
     expect(titleCase("spoke rewired")).toEqual("Spoke Rewired");
   });
-  it("converts mixed-case single word to title case", () => {
+  it("converts mixed-case words to title case", () => {
     expect(titleCase("sPoKe ReWirEd")).toEqual("Spoke Rewired");
   });
   it("ignores hyphens", () => {

--- a/src/lib/scripts.spec.ts
+++ b/src/lib/scripts.spec.ts
@@ -1,0 +1,26 @@
+import { titleCase } from "./scripts";
+
+describe("script utilities", () => {
+  it("converts uppercase single word to title case", () => {
+    expect(titleCase("SPOKE")).toEqual("Spoke");
+  });
+  it("converts lowercase single word to title case", () => {
+    expect(titleCase("spoke")).toEqual("Spoke");
+  });
+  it("converts mixed-case single word to title case", () => {
+    expect(titleCase("sPoKe")).toEqual("Spoke");
+  });
+
+  it("converts uppercase words to title case", () => {
+    expect(titleCase("SPOKE REWIRED")).toEqual("Spoke Rewired");
+  });
+  it("converts lowercase single word to title case", () => {
+    expect(titleCase("spoke rewired")).toEqual("Spoke Rewired");
+  });
+  it("converts mixed-case single word to title case", () => {
+    expect(titleCase("sPoKe ReWirEd")).toEqual("Spoke Rewired");
+  });
+  it("ignores hyphens", () => {
+    expect(titleCase("spoke-rewired")).toEqual("Spoke-rewired");
+  });
+});

--- a/src/lib/scripts.ts
+++ b/src/lib/scripts.ts
@@ -24,7 +24,7 @@ const TOP_LEVEL_UPLOAD_FIELDS = [
 const TEXTER_SCRIPT_FIELDS = ["texterFirstName", "texterLastName"];
 
 // Fields that should be capitalized when a script is applied
-const CAPITALIZE_FIELDS = [
+const TITLE_CASE_FIELDS = [
   "firstName",
   "lastName",
   "texterFirstName",
@@ -38,10 +38,12 @@ const LOWERCASE_FIRST_NAMES = ["friend", "there"];
 export const allScriptFields = (customFields: string[]) =>
   TOP_LEVEL_UPLOAD_FIELDS.concat(TEXTER_SCRIPT_FIELDS).concat(customFields);
 
-const capitalize = (str: string) => {
-  const strTrimmed = str.trim();
-  return strTrimmed.charAt(0).toUpperCase() + strTrimmed.slice(1).toLowerCase();
-};
+export const titleCase = (str: string) =>
+  str
+    .trim()
+    .split(" ")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(" ");
 
 const getScriptFieldValue = (
   contact: CampaignContact,
@@ -60,12 +62,12 @@ const getScriptFieldValue = (
     result = customFieldNames[fieldName];
   }
 
-  const isCapitalizedField = CAPITALIZE_FIELDS.includes(fieldName);
+  const isTitleCaseField = TITLE_CASE_FIELDS.includes(fieldName);
   const isSpecialFirstName =
     fieldName === "firstName" &&
     LOWERCASE_FIRST_NAMES.includes(result.toLowerCase());
-  if (isCapitalizedField && !isSpecialFirstName) {
-    result = capitalize(result);
+  if (isTitleCaseField && !isSpecialFirstName) {
+    result = titleCase(result);
   }
 
   return result;


### PR DESCRIPTION
## Description

Use title case instead of uppercase for name fields.

## Motivation and Context

Names like 'Anne Marie' should be title cased not uppercase (e.g. 'Anne marie').

Closes #1038

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

See `scripts.spec.ts`.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201668494519507