### PR TITLE
fix: clarify that contact filtering is optional

### DIFF
--- a/src/containers/AdminCampaignEdit/sections/CampaignContactsForm/components/SelectExcludeCampaigns.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignContactsForm/components/SelectExcludeCampaigns.tsx
@@ -23,7 +23,7 @@ const mapOption = ({ id, title }: { id: string; title: string }) => ({
   value: id
 });
 
-export const SelectExcludeCampaigns: React.SFC<SelectExcludeCampaignsProps> = (
+export const SelectExcludeCampaigns: React.FC<SelectExcludeCampaignsProps> = (
   props
 ) => {
   const { allOtherCampaigns, selectedCampaignIds } = props;
@@ -46,9 +46,10 @@ export const SelectExcludeCampaigns: React.SFC<SelectExcludeCampaignsProps> = (
   return (
     <div>
       <p>
-        You can filter out contacts from this upload that are already uploaded
-        to an existing Spoke campaigns (regardless of whether they have been
-        texted yet in that campaign).
+        You can <span style={{ fontWeight: "bold" }}>optionally</span> filter
+        out contacts from this upload that are already uploaded to an existing
+        Spoke campaigns (regardless of whether they have been texted yet in that
+        campaign).
       </p>
       <Select
         name="Campaigns"

--- a/src/containers/AdminCampaignEdit/sections/CampaignContactsForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignContactsForm/index.tsx
@@ -242,11 +242,6 @@ class CampaignContactsForm extends React.Component<
     return (
       <div>
         <CampaignFormSectionHeading title="Who are you contacting?" />
-        <SelectExcludeCampaigns
-          allOtherCampaigns={allOtherCampaigns}
-          selectedCampaignIds={selectedCampaignIds}
-          onChangeExcludedCamapignIds={this.handleOnChangeExcludedCamapignIds}
-        />
         <SelectField
           floatingLabelText="Contact source"
           value={source}
@@ -287,6 +282,11 @@ class CampaignContactsForm extends React.Component<
             onChangeValidSql={this.handleOnChangeValidSql}
           />
         )}
+        <SelectExcludeCampaigns
+          allOtherCampaigns={allOtherCampaigns}
+          selectedCampaignIds={selectedCampaignIds}
+          onChangeExcludedCamapignIds={this.handleOnChangeExcludedCamapignIds}
+        />
         <UploadResults
           contactsCount={contactsCount}
           customFields={customFields}

--- a/src/server/middleware/app-renderer.js
+++ b/src/server/middleware/app-renderer.js
@@ -42,8 +42,10 @@ if (config.isProduction) {
 // good for doing dev offline
 const externalLinks = config.NO_EXTERNAL_LINKS
   ? ""
-  : `<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Poppins">
-  <script src="https://cdn.auth0.com/js/lock/11.0.1/lock.min.js"></script>`;
+  : `<link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap" rel="stylesheet">
+    <script src="https://cdn.auth0.com/js/lock/11.0.1/lock.min.js"></script>`;
 
 const rollbarScript = config.ROLLBAR_ACCESS_TOKEN
   ? `

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -71,7 +71,7 @@ const text: TextStyles = {
   header: {
     color: colors.darkGray,
     fontSize: "1.5em",
-    fontWeight: 600,
+    fontWeight: 400,
     fontFamily: defaultFont
   },
   secondaryHeader: {


### PR DESCRIPTION
## Description

This moves the campaign exclusion selector below the contact upload file drop and adds the word "**optionally**" to the instructions.

## Motivation and Context

It is easy to interpret the campaign exclusion feature in contact upload as required, rather than
optional. This leads to confusion and support tickets for why a campaign has zero contacts.

Closes #1044.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

![Spoke](https://user-images.githubusercontent.com/2145526/149940701-31b057e5-90df-483b-bd6d-37790143477b.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
