### PR TITLE
fix: fix read permissions for organization settings

### DIFF
--- a/src/api/organization-settings.ts
+++ b/src/api/organization-settings.ts
@@ -12,7 +12,7 @@ export interface OrganizationSettingsInput {
   confirmationClickForScriptLinks: boolean | null;
 }
 
-export interface OranizationSettings {
+export interface OrganizationSettings {
   id: string;
   defaulTexterApprovalStatus: RequestAutoApproveType;
   optOutMessage: string | null;
@@ -34,7 +34,7 @@ export const schema = `
     confirmationClickForScriptLinks: Boolean
   }
 
-  type OranizationSettings {
+  type OrganizationSettings {
     id: ID!
     defaulTexterApprovalStatus: RequestAutoApprove!
     optOutMessage: String
@@ -47,7 +47,7 @@ export const schema = `
 `;
 
 export const AllOrganizationSettingsFragment = gql`
-  fragment AllOrganizationSettingsFragment on OranizationSettings {
+  fragment AllOrganizationSettingsFragment on OrganizationSettings {
     id
     defaulTexterApprovalStatus
     optOutMessage

--- a/src/api/organization-settings.ts
+++ b/src/api/organization-settings.ts
@@ -58,3 +58,12 @@ export const AllOrganizationSettingsFragment = gql`
     confirmationClickForScriptLinks
   }
 `;
+
+export const TexterOrganizationSettingsFragment = gql`
+  fragment TexterOrganizationSettingsFragment on OrganizationSettings {
+    id
+    showContactLastName
+    showContactCell
+    confirmationClickForScriptLinks
+  }
+`;

--- a/src/api/organization.ts
+++ b/src/api/organization.ts
@@ -5,7 +5,7 @@ import { LinkDomain, UnhealthyLinkDomain } from "./link-domain";
 import { MessagingServicePage } from "./messaging-service";
 import { OptOut } from "./opt-out";
 import { OrganizationMembership } from "./organization-membership";
-import { OranizationSettings } from "./organization-settings";
+import { OrganizationSettings } from "./organization-settings";
 import { RelayPaginatedResponse } from "./pagination";
 import { Tag } from "./tag";
 import { Team } from "./team";
@@ -53,7 +53,7 @@ export interface Organization {
   linkDomains: LinkDomain[];
   unhealthyLinkDomains: UnhealthyLinkDomain[];
   numbersApiKey: string;
-  settings: OranizationSettings;
+  settings: OrganizationSettings;
   tagList: Tag[];
   escalationTagList: Tag[];
   teams: Team[];
@@ -109,7 +109,7 @@ export const schema = `
     linkDomains: [LinkDomain]!
     unhealthyLinkDomains: [UnhealthyLinkDomain]!
     numbersApiKey: String
-    settings: OranizationSettings!
+    settings: OrganizationSettings!
     tagList: [Tag]
     escalationTagList: [Tag]
     teams: [Team]!

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -248,7 +248,7 @@ const rootSchema = `
     editOrganization(id: String! input: EditOrganizationInput!): Organization!
     joinOrganization(organizationUuid: String!): Organization!
     editOrganizationMembership(id: String!, level: RequestAutoApprove, role: String): OrganizationMembership!
-    editOrganizationSettings(id: String!, input: OrganizationSettingsInput!): OranizationSettings!
+    editOrganizationSettings(id: String!, input: OrganizationSettingsInput!): OrganizationSettings!
     purgeOrganizationUsers(organizationId: String!): Int!
     editUser(organizationId: String!, userId: Int!, userData:UserInput): User
     resetUserPassword(organizationId: String!, userId: Int!): String!

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -7,7 +7,7 @@ import { BrowserRouter as Router, Route } from "react-router-dom";
 import request from "superagent";
 import { QueryParamProvider } from "use-query-params";
 
-import { OranizationSettings } from "../api/organization-settings";
+import { OrganizationSettings } from "../api/organization-settings";
 import ApolloClientSingleton from "../network/apollo-client-singleton";
 import AppRoutes from "../routes";
 import { createMuiThemev0, createMuiThemev1 } from "../styles/mui-theme";
@@ -26,7 +26,7 @@ const styles = StyleSheet.create({
 const App: React.FC = () => {
   const [customTheme, setTheme] = useState<CustomTheme>({});
   const [orgSettings, setOrgSettings] = useState<
-    OranizationSettings | undefined
+    OrganizationSettings | undefined
   >(undefined);
 
   useEffect(() => {

--- a/src/client/spoke-context.tsx
+++ b/src/client/spoke-context.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { OranizationSettings } from "../api/organization-settings";
+import { OrganizationSettings } from "../api/organization-settings";
 import { CustomTheme } from "../styles/types";
 
 export interface InstanceSettings {
@@ -12,8 +12,8 @@ export interface InstanceSettings {
 
 export interface SpokeContextType {
   settings?: InstanceSettings;
-  orgSettings?: OranizationSettings;
-  setOrgSettings?: (settings?: OranizationSettings) => void;
+  orgSettings?: OrganizationSettings;
+  setOrgSettings?: (settings?: OrganizationSettings) => void;
   theme?: CustomTheme;
 }
 

--- a/src/components/OrgSettingsFetcher.tsx
+++ b/src/components/OrgSettingsFetcher.tsx
@@ -3,7 +3,10 @@ import gql from "graphql-tag";
 import React, { useContext, useEffect } from "react";
 
 import { Organization } from "../api/organization";
-import { AllOrganizationSettingsFragment } from "../api/organization-settings";
+import {
+  OrganizationSettings,
+  TexterOrganizationSettingsFragment
+} from "../api/organization-settings";
 import SpokeContext from "../client/spoke-context";
 import { loadData } from "../containers/hoc/with-operations";
 import { QueryMap } from "../network/types";
@@ -15,7 +18,15 @@ interface OuterProps {
 interface InnerProps
   extends OuterProps,
     ApolloQueryResult<{
-      organization: Pick<Organization, "id" | "settings">;
+      organization: Pick<Organization, "id" | "settings"> & {
+        settings: Pick<
+          OrganizationSettings,
+          | "id"
+          | "showContactCell"
+          | "showContactLastName"
+          | "confirmationClickForScriptLinks"
+        >;
+      };
     }> {}
 
 export const OrgSettingsFetcher: React.FC<InnerProps> = (props) => {
@@ -38,11 +49,11 @@ const queries: QueryMap<OuterProps> = {
         organization(id: $organizationId) {
           id
           settings {
-            ...AllOrganizationSettingsFragment
+            ...TexterOrganizationSettingsFragment
           }
         }
       }
-      ${AllOrganizationSettingsFragment}
+      ${TexterOrganizationSettingsFragment}
     `,
     skip: (props) => !props.organizationId,
     options: ({ organizationId }) => ({

--- a/src/containers/Settings/components/queries.ts
+++ b/src/containers/Settings/components/queries.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
 
 import { Organization } from "../../../api/organization";
-import { OranizationSettings } from "../../../api/organization-settings";
+import { OrganizationSettings } from "../../../api/organization-settings";
 
 export interface OrganizationNameType {
   organization: Pick<Organization, "id" | "name">;
@@ -31,7 +31,7 @@ export const EDIT_ORGANIZATION_NAME = gql`
 export interface ConfirmationClickForScriptLinksType {
   organization: Pick<Organization, "id"> & {
     settings: Pick<
-      OranizationSettings,
+      OrganizationSettings,
       "id" | "confirmationClickForScriptLinks"
     >;
   };

--- a/src/server/api/organization-settings.ts
+++ b/src/server/api/organization-settings.ts
@@ -1,4 +1,7 @@
-import { RequestAutoApproveType } from "../../api/organization-membership";
+import {
+  RequestAutoApproveType,
+  UserRoleType
+} from "../../api/organization-membership";
 import { config } from "../../config";
 import { stringIsAValidUrl } from "../../lib/utils";
 import { r } from "../models";
@@ -15,14 +18,16 @@ interface IOrganizationSettings {
   confirmationClickForScriptLinks: boolean;
 }
 
-const SETTINGS_PERMISSIONS: { [key in keyof IOrganizationSettings]: string } = {
-  defaulTexterApprovalStatus: "OWNER",
-  optOutMessage: "OWNER",
-  numbersApiKey: "OWNER",
-  trollbotWebhookUrl: "OWNER",
-  showContactLastName: "TEXTER",
-  showContactCell: "TEXTER",
-  confirmationClickForScriptLinks: "OWNER"
+const SETTINGS_PERMISSIONS: {
+  [key in keyof IOrganizationSettings]: UserRoleType;
+} = {
+  defaulTexterApprovalStatus: UserRoleType.OWNER,
+  optOutMessage: UserRoleType.OWNER,
+  numbersApiKey: UserRoleType.OWNER,
+  trollbotWebhookUrl: UserRoleType.OWNER,
+  showContactLastName: UserRoleType.TEXTER,
+  showContactCell: UserRoleType.TEXTER,
+  confirmationClickForScriptLinks: UserRoleType.OWNER
 };
 
 const SETTINGS_NAMES: { [key: string]: string } = {

--- a/src/server/api/organization-settings.ts
+++ b/src/server/api/organization-settings.ts
@@ -27,7 +27,7 @@ const SETTINGS_PERMISSIONS: {
   trollbotWebhookUrl: UserRoleType.OWNER,
   showContactLastName: UserRoleType.TEXTER,
   showContactCell: UserRoleType.TEXTER,
-  confirmationClickForScriptLinks: UserRoleType.OWNER
+  confirmationClickForScriptLinks: UserRoleType.TEXTER
 };
 
 const SETTINGS_NAMES: { [key: string]: string } = {

--- a/src/server/api/organization-settings.ts
+++ b/src/server/api/organization-settings.ts
@@ -101,7 +101,7 @@ const settingResolvers = (settingNames: (keyof IOrganizationSettings)[]) =>
   }, {});
 
 export const resolvers = {
-  OranizationSettings: {
+  OrganizationSettings: {
     id: (organization: { id: number }) => organization.id,
     ...settingResolvers([
       "defaulTexterApprovalStatus",

--- a/src/server/organization-settings.spec.ts
+++ b/src/server/organization-settings.spec.ts
@@ -1,0 +1,115 @@
+import { Pool } from "pg";
+import supertest from "supertest";
+
+import { createOrgAndSession } from "../../__test__/lib/session";
+import { UserRoleType } from "../api/organization-membership";
+import { config } from "../config";
+import app from "./app";
+import { withClient } from "./utils";
+
+describe("get organization settings", () => {
+  let pool: Pool;
+  let agent: supertest.SuperAgentTest;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: config.TEST_DATABASE_URL });
+    agent = supertest.agent(app);
+  });
+
+  afterAll(async () => {
+    if (pool) await pool.end();
+  });
+
+  it("can read TexterOrganizationSettingsFragment as texter", async () => {
+    const features = {
+      showContactLastName: false,
+      showContactCell: false,
+      confirmationClickForScriptLinks: true
+    };
+    const { organization, cookies } = await withClient(pool, async (client) => {
+      const result = await createOrgAndSession(client, {
+        agent,
+        role: UserRoleType.TEXTER,
+        orgOptions: { features }
+      });
+      return result;
+    });
+
+    const response = await agent
+      .post(`/graphql`)
+      .set(cookies)
+      .send({
+        operationName: "GetOrganizationSettings",
+        variables: {
+          organizationId: `${organization.id}`
+        },
+        query: `
+          query GetOrganizationSettings($organizationId: String!) {
+            organization(id: $organizationId) {
+              id
+              settings {
+                id
+                showContactLastName
+                showContactCell
+                confirmationClickForScriptLinks
+              }
+            }
+          }
+        `
+      });
+
+    expect(response.ok).toBeTruthy();
+    expect(response.body.data.organization.settings).toHaveProperty(
+      "confirmationClickForScriptLinks"
+    );
+    expect(
+      response.body.data.organization.settings.confirmationClickForScriptLinks
+    ).toEqual(features.confirmationClickForScriptLinks);
+  });
+
+  it("cannot read protected settings as texter", async () => {
+    const features = {
+      numbersApiKey: "WhoahSomethingReallySecret",
+      trollbotWebhookUrl: "https://domain.com/path/to/webhook"
+    };
+    const { organization, cookies } = await withClient(pool, async (client) => {
+      const result = await createOrgAndSession(client, {
+        agent,
+        role: UserRoleType.TEXTER,
+        orgOptions: { features }
+      });
+      return result;
+    });
+
+    const response = await agent
+      .post(`/graphql`)
+      .set(cookies)
+      .send({
+        operationName: "GetOrganizationSettings",
+        variables: {
+          organizationId: `${organization.id}`
+        },
+        query: `
+          query GetOrganizationSettings($organizationId: String!) {
+            organization(id: $organizationId) {
+              id
+              settings {
+                id
+                numbersApiKey
+                trollbotWebhookUrl
+              }
+            }
+          }
+        `
+      });
+
+    expect(response.ok).toBe(true);
+    expect(response.body).toHaveProperty("errors");
+    expect(response.body.errors.length).toBeGreaterThan(0);
+    expect(response.body.data.organization.settings.id).not.toBeNull();
+    expect(response.body.data.organization.settings.numbersApiKey).toBeNull();
+    expect(
+      response.body.data.organization.settings.trollbotWebhookUrl
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Description

This is a bandaid fix to allow organization settings request to succeed for texters.

## Motivation and Context

A full fix depends on #1027 in order to better support partial success responses. Current `apollo-client` tooling is all-or-nothing. We want to attempt to fetch all organization settings fields knowing that we may not have permission for all of them and handling that as it comes.

## How Has This Been Tested?

`organization-settings.spec.ts` and local testing.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
