### PR TITLE
fix: remove undesired bolding

### DIFF
--- a/src/containers/AdminBulkScriptEditor/index.jsx
+++ b/src/containers/AdminBulkScriptEditor/index.jsx
@@ -18,9 +18,6 @@ import CampaignPrefixSelector from "./CampaignPrefixSelector";
 const PROTECTED_CHARACTERS = ["/"];
 
 const styles = {
-  bold: {
-    fontWeight: "bold"
-  },
   paddedPaper: {
     padding: "10px",
     marginBottom: "15px"
@@ -144,7 +141,7 @@ class AdminBulkScriptEditor extends Component {
       <div>
         <h1>Bulk Script Editor</h1>
         <Paper style={styles.paddedPaper}>
-          <p style={styles.bold}>Find and replace</p>
+          <p>Find and replace</p>
           <TextField
             hintText="Replace this text..."
             value={searchString}
@@ -178,7 +175,7 @@ class AdminBulkScriptEditor extends Component {
           </p>
         </Paper>
         <Paper style={styles.paddedPaper}>
-          <p style={styles.bold}>Filter campaigns</p>
+          <p>Filter campaigns</p>
           <Toggle
             label="Include archived campaigns"
             style={{ marginBottom: "25px" }}

--- a/src/containers/AdminCampaignEdit/index.jsx
+++ b/src/containers/AdminCampaignEdit/index.jsx
@@ -605,8 +605,7 @@ class AdminCampaignEdit extends React.Component {
       <div
         {...dataTest("campaignIsStarted")}
         style={{
-          color: isOverdue ? red600 : theme.colors.green,
-          fontWeight: 800
+          color: isOverdue ? red600 : theme.colors.green
         }}
       >
         {isOverdue
@@ -627,12 +626,7 @@ class AdminCampaignEdit extends React.Component {
       >
         {title && <h1> {title} </h1>}
         {this.state.startingCampaign ? (
-          <div
-            style={{
-              color: theme.colors.gray,
-              fontWeight: 800
-            }}
-          >
+          <div style={{ color: theme.colors.gray }}>
             <CircularProgress
               size={0.5}
               style={{

--- a/src/containers/AdminCampaignEdit/sections/CampaignTextersForm/components/TexterAssignmentHeaderRow.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignTextersForm/components/TexterAssignmentHeaderRow.tsx
@@ -6,11 +6,9 @@ import rowStyles from "./rowStyles";
 const headerStyles = StyleSheet.create({
   alreadyTextedHeader: {
     textAlign: "right",
-    fontWeight: 600,
     fontSize: 16
   },
   availableHeader: {
-    fontWeight: 600,
     fontSize: 16
   }
 });

--- a/src/containers/AdminCampaignStats/CampaignStat.jsx
+++ b/src/containers/AdminCampaignStats/CampaignStat.jsx
@@ -13,8 +13,7 @@ const inlineStyles = {
   count: {
     fontSize: "60px",
     paddingTop: "10px",
-    textAlign: "center",
-    fontWeight: "bold"
+    textAlign: "center"
   },
   title: {
     textTransform: "uppercase",

--- a/src/containers/AdminCampaignStats/index.jsx
+++ b/src/containers/AdminCampaignStats/index.jsx
@@ -30,7 +30,6 @@ const styles = StyleSheet.create({
   archivedBanner: {
     backgroundColor: "#FFFBE6",
     fontSize: "16px",
-    fontWeight: "bold",
     width: "100%",
     padding: "15px",
     textAlign: "center",

--- a/src/containers/AssignmentTexterSurveyDropdown.jsx
+++ b/src/containers/AssignmentTexterSurveyDropdown.jsx
@@ -8,13 +8,6 @@ import React, { Component } from "react";
 import { loadData } from "./hoc/with-operations";
 
 const styles = {
-  previousStep: {
-    fontSize: 16,
-    verticalAlign: "middle"
-  },
-  currentStep: {
-    // fontSize: 16,
-  },
   currentStepSelect: {
     fontSize: 16,
     color: "red"
@@ -23,14 +16,6 @@ const styles = {
     fontSize: 16,
     opacity: 0.8
     // fontSize: 16
-  },
-  previousStepLabel: {
-    fontSize: 16
-  },
-  currentStepLabel: {
-    fontSize: 16,
-    color: "red",
-    fontWeight: "bold"
   }
 };
 

--- a/src/server/middleware/app-renderer.js
+++ b/src/server/middleware/app-renderer.js
@@ -95,6 +95,10 @@ const indexHtml = `
         font-size: 14px;
       }
 
+      h1,h2,h3,h4,h5,h6,h7 {
+        font-weight: 400;
+      }
+
       /**/
     </style>
     <script>


### PR DESCRIPTION
## Description

Remove bolding introduced by #1045.

## Motivation and Context

Spoke had a number of places using bold that were not actually visible because only the regular weight font was loaded. #1045 added the bold weight font and suddenly these sleeping bold segments reared their heads.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
