### PR TITLE
fix: fix create org using the wrong types

### DIFF
--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -7,12 +7,11 @@ import _ from "lodash";
 import groupBy from "lodash/groupBy";
 
 import { VanOperationMode } from "../../api/external-system";
-import { TextRequestType } from "../../api/organization";
 import {
   RequestAutoApproveType,
   UserRoleType
 } from "../../api/organization-membership";
-import { CampaignExportType } from "../../api/types";
+import { CampaignExportType, TextRequestType } from "../../api/types";
 import { config } from "../../config";
 import { hasRole } from "../../lib/permissions";
 import { applyScript } from "../../lib/scripts";


### PR DESCRIPTION
## Description

Create Organization was pulling in the incorrect types, and the server would fail trying to create a new org, this fixes it.

## How Has This Been Tested?

Created multiple new organizations to test.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

NA

## Checklist:

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
