### PR TITLE
feat(script): add indicator of message type, check if attachment is image

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "autodetect-decoder-stream": "^1.0.3",
     "aws-sdk": "^2.6.3",
     "aws-serverless-express": "https://registry.npmjs.org/aws-serverless-express/-/aws-serverless-express-3.0.2.tgz",
+    "axios": "0.21.1",
     "body-parser": "^1.19.0",
     "camelcase-keys": "^4.1.0",
     "chart.js": "^2.9.4",

--- a/src/components/ScriptEditor.tsx
+++ b/src/components/ScriptEditor.tsx
@@ -12,7 +12,8 @@ import { green500, green600, grey100, red400 } from "material-ui/styles/colors";
 import React from "react";
 
 import { replaceEasyGsmWins } from "../lib/charset-utils";
-import { delimit } from "../lib/scripts";
+import { delimit, getMessageType, isAttachmentImage } from "../lib/scripts";
+import baseTheme from "../styles/theme";
 import Chip from "./Chip";
 
 type DecoratorStrategyCallBack = (start: number, end: number) => void;
@@ -94,6 +95,7 @@ interface Props {
 
 interface State {
   editorState: EditorState;
+  validAttachment: boolean;
 }
 
 class ScriptEditor extends React.Component<Props, State> {
@@ -104,15 +106,22 @@ class ScriptEditor extends React.Component<Props, State> {
 
     const editorState = this.getEditorState();
     this.state = {
-      editorState
+      editorState,
+      validAttachment: true
     };
   }
 
-  componentDidMount() {
+  async componentDidMount() {
     if (this.props.receiveFocus === true) {
       const { editorState: oldState } = this.state;
       const editorState = EditorState.moveFocusToEnd(oldState);
-      this.setState({ editorState });
+      const text = editorState.getCurrentContent().getPlainText();
+      const validAttachment = await isAttachmentImage(text);
+
+      this.setState({
+        editorState,
+        validAttachment
+      });
     }
   }
 
@@ -125,13 +134,18 @@ class ScriptEditor extends React.Component<Props, State> {
     // this.setState({ editorState: this.getEditorState() })
   }
 
-  onEditorChange = (editorState: EditorState) => {
+  onEditorChange = async (editorState: EditorState) => {
     this.setState({ editorState }, () => {
       const { onChange } = this.props;
       if (onChange) {
         onChange(this.getValue());
       }
     });
+
+    const text = editorState.getCurrentContent().getPlainText();
+    const validAttachment = await isAttachmentImage(text);
+
+    this.setState({ validAttachment });
   };
 
   getEditorState() {
@@ -209,6 +223,27 @@ class ScriptEditor extends React.Component<Props, State> {
     this.setState({ editorState: newEditorState }, this.focus);
   };
 
+  renderAttachmentWarning() {
+    const text = this.state.editorState.getCurrentContent().getPlainText();
+    const messageType = getMessageType(text);
+    if (messageType === "MMS" && !this.state.validAttachment) {
+      return (
+        <div style={{ color: baseTheme.colors.red }}>
+          WARNING! The media attachment URL is of an unsupported MMS type.
+          Please check the URL of the attachment or see{" "}
+          <a
+            href="https://docs.spokerewired.com/article/86-include-an-image-in-a-message"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Include an Image in a Message
+          </a>{" "}
+          for all supported types.
+        </div>
+      );
+    }
+  }
+
   renderCustomFields() {
     const { scriptFields } = this.props;
     return (
@@ -228,6 +263,7 @@ class ScriptEditor extends React.Component<Props, State> {
   render() {
     const text = this.state.editorState.getCurrentContent().getPlainText();
     const info = getCharCount(replaceEasyGsmWins(text));
+    const messageType = getMessageType(text);
 
     return (
       <div>
@@ -250,12 +286,14 @@ class ScriptEditor extends React.Component<Props, State> {
         )}
         {this.renderCustomFields()}
         <div>
+          {this.renderAttachmentWarning()}
           <br />
           Estimated Segments: {info.msgCount} <br />
           Characters left in current segment:{" "}
           {info.msgCount * info.charsPerSegment - info.charCount}
           <br />
           Encoding required: {info.encoding} <br />
+          Message Type: {messageType} <br />
           <br />
           Not sure what a segment is? Check out the{" "}
           <a

--- a/yarn.lock
+++ b/yarn.lock
@@ -6932,7 +6932,7 @@ axe-core@^4.3.5:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.1.tgz#7dbdc25989298f9ad006645cd396782443757413"
   integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
 
-axios@^0.21.1:
+axios@0.21.1, axios@^0.21.1:
   version "0.21.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
   integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==


### PR DESCRIPTION
Fixes #874 

## Description

Add an indicator indicating if a message is going to possibly be sent as an SMS or MMS. 
Also add a warning if the attachment is not of the content type image.

This PR also adds axios as a full dependency, it's currently installed as a sub dependency of a different library. 

## Motivation and Context

Fixes #874 

This shows the user the type of message being sent, also shows a warning about potentially sending incorrect image or other attachments. 

## How Has This Been Tested?

Tested locally using multiple image and non image URLs

## Screenshots (if appropriate):
<img width="607" alt="Screenshot 2022-02-14 at 10 37 43 PM" src="https://user-images.githubusercontent.com/367605/153912122-346dab06-234d-4696-85bf-15b8d1844068.png">
<img width="611" alt="Screenshot 2022-02-14 at 10 37 33 PM" src="https://user-images.githubusercontent.com/367605/153912141-ee05aa65-072c-4834-a561-a68f61ea4216.png">
<img width="609" alt="Screenshot 2022-02-14 at 10 38 01 PM" src="https://user-images.githubusercontent.com/367605/153912149-4b6d7275-78be-44bd-b655-8341c0d69fe9.png">

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

NA

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
