### PR TITLE
fix: navigate to login only on error fetching roles

### DIFF
--- a/src/components/AuthzProvider.tsx
+++ b/src/components/AuthzProvider.tsx
@@ -10,7 +10,7 @@ export const AuthzContext = React.createContext(false);
 
 export const AuthzProvider: React.FC<{ organizationId: string }> = (props) => {
   const { organizationId } = useParams<{ organizationId: string }>();
-  const { data, loading } = useCurrentUserOrganizationRolesQuery({
+  const { data, loading, error } = useCurrentUserOrganizationRolesQuery({
     variables: { organizationId: props.organizationId },
     skip: props.organizationId === undefined
   });
@@ -24,12 +24,12 @@ export const AuthzProvider: React.FC<{ organizationId: string }> = (props) => {
   }, [organizationId]);
 
   useEffect(() => {
-    if (!loading && !hasAdminPermissions) {
+    if (!loading && error !== undefined) {
       const loginUrl = `/login?nextUrl=${window.location.pathname}`;
       // We can't use replace(...) here because /login is not a react-router path
       window.location.href = loginUrl;
     }
-  }, [loading, hasAdminPermissions]);
+  }, [loading, hasAdminPermissions, error]);
 
   if (loading) return null;
 


### PR DESCRIPTION
## Description

Navigate to login page only when there is an error fetching a user's roles for an organization.

## Motivation and Context

This restores previous functionality. #1063 mistranslated [this](https://github.com/politics-rewired/Spoke/pull/1063/files#diff-8f17a437bd717cb709cda1a6bbdce2b6dc27b3a5124fbab1af2a9147f9670529L29-L46).

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
