### PR TITLE
feat: make due dates for campaigns optional

### DIFF
--- a/src/containers/AdminCampaignEdit/index.jsx
+++ b/src/containers/AdminCampaignEdit/index.jsx
@@ -321,8 +321,7 @@ class AdminCampaignEdit extends React.Component {
         expandableBySuperVolunteers: true,
         checkCompleted: () =>
           this.state.campaignFormValues.title !== "" &&
-          this.state.campaignFormValues.description !== "" &&
-          this.state.campaignFormValues.dueBy !== null
+          this.state.campaignFormValues.description !== ""
       },
       {
         title: "Campaign Groups",

--- a/src/containers/AdminCampaignEdit/sections/CampaignBasicsForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignBasicsForm.tsx
@@ -1,7 +1,9 @@
 import { ApolloQueryResult, gql } from "@apollo/client";
 import isEmpty from "lodash/isEmpty";
 import ColorPicker from "material-ui-color-picker";
+import IconButton from "material-ui/IconButton";
 import RaisedButton from "material-ui/RaisedButton";
+import DeleteIcon from "material-ui/svg-icons/action/delete";
 import React from "react";
 import { compose } from "recompose";
 import * as yup from "yup";
@@ -22,7 +24,7 @@ import {
 interface BasicsValues {
   title?: string;
   description?: string;
-  dueBy?: string;
+  dueBy?: string | null;
   logoImageUrl?: string;
   primaryColor?: string;
   introHtml?: string;
@@ -51,7 +53,7 @@ const schemaForIsStarted = (mustBeComplete: boolean) =>
   yup.object({
     title: mustBeComplete ? yup.string().required() : yup.string(),
     description: mustBeComplete ? yup.string().required() : yup.string(),
-    dueBy: mustBeComplete ? yup.mixed().required() : yup.mixed(),
+    dueBy: yup.mixed().nullable(),
     logoImageUrl: yup
       .string()
       .url()
@@ -98,6 +100,11 @@ class CampaignBasicsForm extends React.Component<
     }
   };
 
+  deleteDueDate = () => {
+    const pendingChanges = { dueBy: null };
+    this.setState({ pendingChanges });
+  };
+
   render() {
     const { pendingChanges, isWorking } = this.state;
     const {
@@ -137,18 +144,27 @@ class CampaignBasicsForm extends React.Component<
             hintText="Get out the vote"
             fullWidth
           />
-          <SpokeFormField
-            {...dataTest("dueBy")}
-            name="dueBy"
-            label="Due date"
-            type="date"
-            locale="en-US"
-            shouldDisableDate={(date: Date) =>
-              DateTime.fromJSDate(date) < DateTime.local()
-            }
-            autoOk
-            fullWidth
-          />
+          <div style={{ display: "inline-block", width: 256 }}>
+            <SpokeFormField
+              {...dataTest("dueBy")}
+              name="dueBy"
+              label="Due date"
+              type="date"
+              locale="en-US"
+              shouldDisableDate={(date: Date) =>
+                DateTime.fromJSDate(date) < DateTime.local()
+              }
+              autoOk
+            />
+          </div>
+          <IconButton
+            tooltip="Delete the Due Date"
+            tooltipPosition="top"
+            onClick={this.deleteDueDate}
+            style={{ width: 50 }}
+          >
+            <DeleteIcon />
+          </IconButton>
 
           <SpokeFormField
             name="introHtml"

--- a/src/server/api/assignment.js
+++ b/src/server/api/assignment.js
@@ -3,6 +3,7 @@ import _ from "lodash";
 import request from "superagent";
 
 import { config } from "../../config";
+import { DateTime } from "../../lib/datetime";
 import { isNowBetween } from "../../lib/timezones";
 import { sleep } from "../../lib/utils";
 import logger from "../../logger";
@@ -55,9 +56,11 @@ export function getContacts(
 ) {
   // 24-hours past due - why is this 24 hours offset?
   const includePastDue = contactsFilter && contactsFilter.includePastDue;
-  const pastDue =
-    campaign.due_by &&
-    Number(campaign.due_by) + 24 * 60 * 60 * 1000 < Number(new Date());
+
+  const dueBy = DateTime.fromJSDate(new Date(campaign.due_by));
+  const pastDue = campaign.due_by
+    ? dueBy.plus({ days: 1 }) < DateTime.local()
+    : false;
 
   if (
     !includePastDue &&

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -189,10 +189,7 @@ export const resolvers = {
   },
   CampaignReadiness: {
     id: ({ id }) => id,
-    basics: (campaign) =>
-      campaign.title !== "" &&
-      campaign.description !== "" &&
-      campaign.due_by !== null,
+    basics: (campaign) => campaign.title !== "" && campaign.description !== "",
     textingHours: (campaign) =>
       campaign.textingHoursStart !== null &&
       campaign.textingHoursEnd !== null &&


### PR DESCRIPTION
## Description

Make Due Dates optional, also add a button to delete the due date, the current date selector doesn't allow putting in a null value, adding the delete button makes it so that you can remove the due date during campaign edit.

## Motivation and Context

Fixes #1056 

## How Has This Been Tested?

Tested working locally. Contacts are pulled as expected.

## Screenshots (if appropriate):
![Screenshot 2022-02-21 at 8 24 19 PM](https://user-images.githubusercontent.com/367605/154979965-213b4427-08d3-42d9-bf3a-37db0b05426f.png)


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

NA

## Checklist:

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
