### PR TITLE
fix: convert client-side id args from int to string

### DIFF
--- a/src/api/campaign.ts
+++ b/src/api/campaign.ts
@@ -276,7 +276,7 @@ export const schema = `
     contactsFile: Upload
     externalListId: String
     filterOutLandlines: Boolean
-    excludeCampaignIds: [Int]
+    excludeCampaignIds: [String!]
     contactSql: String
     organizationId: String
     isAssignmentLimitedToTeams: Boolean

--- a/src/api/external-system.ts
+++ b/src/api/external-system.ts
@@ -78,7 +78,7 @@ export const schema = `
     type: ExternalSystemType!
     username: String!
     apiKey: String!
-    organizationId: Int!
+    organizationId: String!
     createdAt: Date!
     updatedAt: Date!
     syncedAt: Date

--- a/src/api/organization.ts
+++ b/src/api/organization.ts
@@ -15,11 +15,11 @@ import { User } from "./user";
 export interface AssignmentTarget {
   type: string;
   campaign: Campaign;
-  countLeft: number;
+  countLeft?: number | null;
   teamTitle: string;
-  teamId: number;
+  teamId: string;
   enabled: boolean;
-  maxRequestCount: number;
+  maxRequestCount?: number | null;
 }
 
 export interface Organization {
@@ -73,7 +73,7 @@ export const schema = `
     campaign: Campaign
     countLeft: Int
     teamTitle: String
-    teamId: Int
+    teamId: String
     enabled: Boolean
     maxRequestCount: Int
   }

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -250,13 +250,13 @@ const rootSchema = `
     editOrganizationMembership(id: String!, level: RequestAutoApprove, role: String): OrganizationMembership!
     editOrganizationSettings(id: String!, input: OrganizationSettingsInput!): OrganizationSettings!
     purgeOrganizationUsers(organizationId: String!): Int!
-    editUser(organizationId: String!, userId: Int!, userData:UserInput): User
-    resetUserPassword(organizationId: String!, userId: Int!): String!
-    changeUserPassword(userId: Int!, formData: UserPasswordChange): User
+    editUser(organizationId: String!, userId: String!, userData:UserInput): User
+    resetUserPassword(organizationId: String!, userId: String!): String!
+    changeUserPassword(userId: String!, formData: UserPasswordChange): User
     updateTextingHours( organizationId: String!, textingHoursStart: Int!, textingHoursEnd: Int!): Organization
     updateTextingHoursEnforcement( organizationId: String!, textingHoursEnforced: Boolean!): Organization
     updateTextRequestFormSettings(organizationId: String!, textRequestFormEnabled: Boolean!, textRequestType: String!, textRequestMaxCount: Int!): Organization
-    bulkSendMessages(assignmentId: Int!): [CampaignContact]
+    bulkSendMessages(assignmentId: String!): [CampaignContact]
     sendMessage(message:MessageInput!, campaignContactId:String!): CampaignContact,
     tagConversation(campaignContactId: String!, tag: ContactTagActionInput!): CampaignContact
     createOptOut(optOut:ContactActionInput!, campaignContactId:String!):CampaignContact,
@@ -282,7 +282,7 @@ const rootSchema = `
     userAgreeTerms(userId: String!): User
     megaReassignCampaignContacts(organizationId:String!, campaignIdsContactIds:[CampaignIdContactId]!, newTexterUserIds:[String]): Boolean!
     megaBulkReassignCampaignContacts(organizationId:String!, campaignsFilter:CampaignsFilter, assignmentsFilter:AssignmentsFilter, tagsFilter: TagsFilter, contactsFilter:ContactsFilter, contactNameFilter: ContactNameFilter, newTexterUserIds:[String]): Boolean!
-    requestTexts(count: Int!, email: String!, organizationId: String!, preferredTeamId: Int!): String!
+    requestTexts(count: Int!, email: String!, organizationId: String!, preferredTeamId: String!): String!
     releaseMessages(campaignId: String!, target: ReleaseActionTarget!, ageInHours: Float): String!
     releaseAllUnhandledReplies(organizationId: String!, ageInHours: Float, releaseOnRestricted: Boolean, limitToCurrentlyTextableContacts: Boolean): ReleaseAllUnhandledRepliesResult!
     markForSecondPass(campaignId: String!, input: SecondPassInput!): String!

--- a/src/components/AssignmentTexter.jsx
+++ b/src/components/AssignmentTexter.jsx
@@ -663,7 +663,7 @@ const mutations = {
 
   bulkSendMessages: () => (assignmentId) => ({
     mutation: gql`
-      mutation bulkSendMessages($assignmentId: Int!) {
+      mutation bulkSendMessages($assignmentId: String!) {
         bulkSendMessages(assignmentId: $assignmentId) {
           id
         }

--- a/src/components/TexterRequest.jsx
+++ b/src/components/TexterRequest.jsx
@@ -162,7 +162,7 @@ class TexterRequest extends React.Component {
     }
 
     const makeOptionText = (at) =>
-      `${at.teamTitle}: ${at.maxRequestCount} ${
+      `${at.teamTitle}: ${at.maxRequestCount ?? ""} ${
         at.type === "UNSENT" ? "Initials" : "Replies"
       }`;
 

--- a/src/components/TexterRequest.jsx
+++ b/src/components/TexterRequest.jsx
@@ -275,7 +275,7 @@ const mutations = {
         $count: Int!
         $email: String!
         $organizationId: String!
-        $preferredTeamId: Int!
+        $preferredTeamId: String!
       ) {
         requestTexts(
           count: $count

--- a/src/containers/AdminPeople/AdminPeople.tsx
+++ b/src/containers/AdminPeople/AdminPeople.tsx
@@ -502,7 +502,7 @@ const mutations: MutationMap<AdminPeopleExtendedProps> = {
   ) => {
     return {
       mutation: gql`
-        mutation resetUserPassword($organizationId: String!, $userId: Int!) {
+        mutation resetUserPassword($organizationId: String!, $userId: String!) {
           resetUserPassword(organizationId: $organizationId, userId: $userId)
         }
       `,

--- a/src/containers/AdminPeople/AdminPeople.tsx
+++ b/src/containers/AdminPeople/AdminPeople.tsx
@@ -93,7 +93,7 @@ export interface AdminPeopleMutations {
   >;
   resetUserPassword: (
     organizationId: string,
-    userId: number
+    userId: string
   ) => Promise<
     ApolloQueryResult<{
       resetUserPassword: string;
@@ -276,7 +276,7 @@ class AdminPeople extends React.Component<
     if (currentUser.id !== userId) {
       const res = await this.props.mutations.resetUserPassword(
         organizationId,
-        parseInt(userId, 10)
+        userId
       );
       const { resetUserPassword: hash } = res.data;
       this.setState({ password: { open: true, hash } });
@@ -498,7 +498,7 @@ const mutations: MutationMap<AdminPeopleExtendedProps> = {
   }),
   resetUserPassword: (_ownProps) => (
     organizationId: string,
-    userId: number
+    userId: string
   ) => {
     return {
       mutation: gql`

--- a/src/containers/UserEdit.jsx
+++ b/src/containers/UserEdit.jsx
@@ -396,7 +396,7 @@ const mutations = {
     mutation: gql`
       mutation editUser(
         $organizationId: String!
-        $userId: Int!
+        $userId: String!
         $userData: UserInput
       ) {
         editUser(
@@ -421,7 +421,7 @@ const mutations = {
   changeUserPassword: (ownProps) => (formData) => ({
     mutation: gql`
       mutation changeUserPassword(
-        $userId: Int!
+        $userId: String!
         $formData: UserPasswordChange
       ) {
         changeUserPassword(userId: $userId, formData: $formData) {

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -218,13 +218,13 @@ type RootMutation {
   editOrganizationMembership(id: String!, level: RequestAutoApprove, role: String): OrganizationMembership!
   editOrganizationSettings(id: String!, input: OrganizationSettingsInput!): OrganizationSettings!
   purgeOrganizationUsers(organizationId: String!): Int!
-  editUser(organizationId: String!, userId: Int!, userData:UserInput): User
-  resetUserPassword(organizationId: String!, userId: Int!): String!
-  changeUserPassword(userId: Int!, formData: UserPasswordChange): User
+  editUser(organizationId: String!, userId: String!, userData:UserInput): User
+  resetUserPassword(organizationId: String!, userId: String!): String!
+  changeUserPassword(userId: String!, formData: UserPasswordChange): User
   updateTextingHours( organizationId: String!, textingHoursStart: Int!, textingHoursEnd: Int!): Organization
   updateTextingHoursEnforcement( organizationId: String!, textingHoursEnforced: Boolean!): Organization
   updateTextRequestFormSettings(organizationId: String!, textRequestFormEnabled: Boolean!, textRequestType: String!, textRequestMaxCount: Int!): Organization
-  bulkSendMessages(assignmentId: Int!): [CampaignContact]
+  bulkSendMessages(assignmentId: String!): [CampaignContact]
   sendMessage(message:MessageInput!, campaignContactId:String!): CampaignContact,
   tagConversation(campaignContactId: String!, tag: ContactTagActionInput!): CampaignContact
   createOptOut(optOut:ContactActionInput!, campaignContactId:String!):CampaignContact,
@@ -250,7 +250,7 @@ type RootMutation {
   userAgreeTerms(userId: String!): User
   megaReassignCampaignContacts(organizationId:String!, campaignIdsContactIds:[CampaignIdContactId]!, newTexterUserIds:[String]): Boolean!
   megaBulkReassignCampaignContacts(organizationId:String!, campaignsFilter:CampaignsFilter, assignmentsFilter:AssignmentsFilter, tagsFilter: TagsFilter, contactsFilter:ContactsFilter, contactNameFilter: ContactNameFilter, newTexterUserIds:[String]): Boolean!
-  requestTexts(count: Int!, email: String!, organizationId: String!, preferredTeamId: Int!): String!
+  requestTexts(count: Int!, email: String!, organizationId: String!, preferredTeamId: String!): String!
   releaseMessages(campaignId: String!, target: ReleaseActionTarget!, ageInHours: Float): String!
   releaseAllUnhandledReplies(organizationId: String!, ageInHours: Float, releaseOnRestricted: Boolean, limitToCurrentlyTextableContacts: Boolean): ReleaseAllUnhandledRepliesResult!
   markForSecondPass(campaignId: String!, input: SecondPassInput!): String!
@@ -1068,7 +1068,7 @@ type ExternalSystem {
   type: ExternalSystemType!
   username: String!
   apiKey: String!
-  organizationId: Int!
+  organizationId: String!
   createdAt: Date!
   updatedAt: Date!
   syncedAt: Date

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -608,7 +608,7 @@ input CampaignInput {
   contactsFile: Upload
   externalListId: String
   filterOutLandlines: Boolean
-  excludeCampaignIds: [Int]
+  excludeCampaignIds: [String!]
   contactSql: String
   organizationId: String
   isAssignmentLimitedToTeams: Boolean

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -332,7 +332,7 @@ type AssignmentTarget {
   campaign: Campaign
   countLeft: Int
   teamTitle: String
-  teamId: Int
+  teamId: String
   enabled: Boolean
   maxRequestCount: Int
 }

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -219,7 +219,7 @@ export const resolvers = {
       const cats = await allCurrentAssignmentTargets(organization.id);
       const formatted = cats.map((cat) => ({
         type: cat.assignment_type,
-        countLeft: parseInt(cat.count_left, 10),
+        countLeft: cat.count_left ? parseInt(cat.count_left, 10) : null,
         campaign: {
           id: cat.id,
           title: cat.title
@@ -235,14 +235,23 @@ export const resolvers = {
         organization.id
       );
 
-      return assignmentTarget
-        ? {
-            type: assignmentTarget.type,
-            countLeft: parseInt(assignmentTarget.count_left, 10),
-            maxRequestCount: parseInt(assignmentTarget.max_request_count, 10),
-            teamTitle: assignmentTarget.team_title
-          }
-        : null;
+      if (assignmentTarget) {
+        const {
+          type: assignmentType,
+          count_left,
+          max_request_count,
+          team_title
+        } = assignmentTarget;
+        return {
+          type: assignmentType,
+          countLeft: count_left ? parseInt(count_left, 10) : null,
+          maxRequestCount: max_request_count
+            ? parseInt(max_request_count, 10)
+            : null,
+          teamTitle: team_title
+        };
+      }
+      return null;
     },
     myCurrentAssignmentTargets: async (organization, _, context) => {
       await accessRequired(
@@ -259,8 +268,10 @@ export const resolvers = {
 
         return assignmentTargets.map((at) => ({
           type: at.type,
-          countLeft: parseInt(at.count_left, 10),
-          maxRequestCount: parseInt(at.max_request_count, 10),
+          countLeft: at.count_left ? parseInt(at.count_left, 10) : null,
+          maxRequestCount: at.max_request_count
+            ? parseInt(at.max_request_count, 10)
+            : null,
           teamTitle: at.team_title,
           teamId: at.team_id
         }));

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -527,7 +527,11 @@ const rootMutations = {
       return passwordResetHash;
     },
 
-    changeUserPassword: async (_root, { formData, ...stringIds }, { user }) => {
+    changeUserPassword: async (
+      _root,
+      { formData, ...stringIds },
+      { user, db }
+    ) => {
       const userId = parseInt(stringIds.userId, 10);
 
       if (user.id !== userId) {
@@ -537,6 +541,7 @@ const rootMutations = {
       const { password, newPassword, passwordConfirm } = formData;
 
       const updatedUser = await change({
+        db,
         user,
         password,
         newPassword,

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -459,7 +459,9 @@ const rootMutations = {
       return updatedOrganization;
     },
 
-    editUser: async (_root, { organizationId, userId, userData }, { user }) => {
+    editUser: async (_root, { userData, ...stringIds }, { user }) => {
+      const organizationId = parseInt(stringIds.organizationId, 10);
+      const userId = parseInt(stringIds.userId, 10);
       if (user.id !== userId) {
         // User can edit themselves
         await accessRequired(user, organizationId, "ADMIN", true);
@@ -501,11 +503,15 @@ const rootMutations = {
       return userData;
     },
 
-    resetUserPassword: async (_root, { organizationId, userId }, { user }) => {
+    resetUserPassword: async (_root, args, { user }) => {
       if (config.PASSPORT_STRATEGY !== "local")
         throw new Error(
           "Password reset may only be used with the 'local' login strategy."
         );
+
+      const organizationId = parseInt(args.organizationId, 10);
+      const userId = parseInt(args.userId, 10);
+
       if (user.id === userId) {
         throw new Error("You can't reset your own password.");
       }
@@ -521,7 +527,9 @@ const rootMutations = {
       return passwordResetHash;
     },
 
-    changeUserPassword: async (_root, { userId, formData }, { user }) => {
+    changeUserPassword: async (_root, { formData, ...stringIds }, { user }) => {
+      const userId = parseInt(stringIds.userId, 10);
+
       if (user.id !== userId) {
         throw new Error("You can only change your own password.");
       }
@@ -1447,11 +1455,13 @@ const rootMutations = {
       }));
     },
 
-    bulkSendMessages: async (_root, { assignmentId }, loaders) => {
+    bulkSendMessages: async (_root, args, loaders) => {
       if (!config.ALLOW_SEND_ALL || !config.NOT_IN_USA) {
         logger.error("Not allowed to send all messages at once");
         throw new GraphQLError("Not allowed to send all messages at once");
       }
+
+      const assignmentId = parseInt(args.assignmentId, 10);
 
       const assignment = await r
         .knex("assignment")
@@ -1999,11 +2009,9 @@ const rootMutations = {
       return true;
     },
 
-    requestTexts: async (
-      _root,
-      { count, organizationId, preferredTeamId },
-      { user }
-    ) => {
+    requestTexts: async (_root, { count, ...stringIds }, { user }) => {
+      const organizationId = parseInt(stringIds.organizationId, 10);
+      const preferredTeamId = parseInt(stringIds.preferredTeamId, 10);
       const myAssignmentTarget = await myCurrentAssignmentTarget(
         user.id,
         organizationId


### PR DESCRIPTION
## Description

Use string type for all client-side IDs.

This also fixes a separate bug in changeUserPassword where `db` context was not passed to helper.

This also fixes a separate bug where assignment team dropdown did not render correctly if the team did not have a maxRequestCount set.

## Motivation and Context

GraphQL uses string-type IDs. All handling of IDs on the client side and over the networks should be strings.

## How Has This Been Tested?

Manual testing of:

- [x] excludeCampaignIds in contact upload
- [x] editUser
- [x] resetUserPassword
- [x] changeUserPassword
- [x] ~~bulkSendMessages~~ N/A
- [x] requestTexts

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
