### PR TITLE
fix: enable link replacement only if envvar is enabled

### DIFF
--- a/src/server/api/lib/send-message.ts
+++ b/src/server/api/lib/send-message.ts
@@ -250,10 +250,9 @@ export const sendMessage = async (
   }
 
   const escapedApostrophes = replaceCurlyApostrophes(text!);
-  const replacedDomainsText = await replaceShortLinkDomains(
-    record.organization_id,
-    escapedApostrophes
-  );
+  const replacedDomainsText = config.ENABLE_SHORTLINK_DOMAINS
+    ? await replaceShortLinkDomains(record.organization_id, escapedApostrophes)
+    : escapedApostrophes;
 
   const { service_type } = await getContactMessagingService(
     campaignContactId,


### PR DESCRIPTION
## Description

Only replace short links in messages if environment variable is set.

## Motivation and Context

If the short link rotation feature is disabled after a period of use, there may be stale records in `link_domain` table. Once the feature is disabled, these domains are still being swapped but the user has no access to the link domain records to control this.

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
