### PR TITLE
fix: disable reassign all without target texter(s)

### DIFF
--- a/src/components/IncomingMessageActions.jsx
+++ b/src/components/IncomingMessageActions.jsx
@@ -123,7 +123,7 @@ class IncomingMessageActions extends Component {
 
     const { contactsAreSelected, conversationCount } = this.props;
     const { selectedTexters } = this.state;
-    const hasSeletedTexters = selectedTexters.length > 0;
+    const hasSelectedTexters = selectedTexters.length > 0;
     return (
       <Card>
         <CardHeader
@@ -152,14 +152,14 @@ class IncomingMessageActions extends Component {
                   <FlatButton
                     label="Reassign selected"
                     onClick={this.onReassignmentClicked}
-                    disabled={!contactsAreSelected || !hasSeletedTexters}
+                    disabled={!contactsAreSelected || !hasSelectedTexters}
                   />
                 </div>
                 <div className={css(styles.flexColumn)}>
                   <FlatButton
                     label={`Reassign all ${conversationCount} matching`}
                     onClick={this.onReassignAllMatchingClicked}
-                    disabled={conversationCount === 0 || !hasSeletedTexters}
+                    disabled={conversationCount === 0 || !hasSelectedTexters}
                   />
                 </div>
                 <Dialog

--- a/src/components/IncomingMessageActions.jsx
+++ b/src/components/IncomingMessageActions.jsx
@@ -159,7 +159,7 @@ class IncomingMessageActions extends Component {
                   <FlatButton
                     label={`Reassign all ${conversationCount} matching`}
                     onClick={this.onReassignAllMatchingClicked}
-                    disabled={conversationCount === 0}
+                    disabled={conversationCount === 0 || !hasSeletedTexters}
                   />
                 </div>
                 <Dialog


### PR DESCRIPTION
## Description

Disable the "Reassign all matching" button unless at least 1 reassignment target texter has been selected.

## Motivation and Context

Fixes #1093

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):


<table><tr><td>

![Screen Shot 2022-02-26 at 7 00 49 AM](https://user-images.githubusercontent.com/2145526/155842389-008d8166-cb8e-42bb-bd47-7e30ca0eb102.png)
</td></tr><tr><td>

![Screen Shot 2022-02-26 at 7 01 04 AM](https://user-images.githubusercontent.com/2145526/155842403-2d713107-ffe7-46f0-baa9-a53320fb0916.png)

</td></tr></table>


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
