### PR TITLE
ci: use gha cache type

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -81,7 +81,7 @@ jobs:
         run: yarn jest --forceExit --detectOpenHandles src/**/*
 
   publish-docker-image:
-    if: startsWith( github.ref, 'refs/tags/v')
+    if: true # startsWith( github.ref, 'refs/tags/v')
     needs: test
     name: Publish Docker image
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -94,15 +94,6 @@ jobs:
         with:
           version: latest
 
-      # Caching strategy from: https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#github-cache
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-switchboard-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-switchboard-
-
       - name: Get image tags
         id: image-tags
         run: |
@@ -132,13 +123,5 @@ jobs:
             us-east4-docker.pkg.dev/spoke-rewired/spoke/core:latest
             us-east4-docker.pkg.dev/spoke-rewired/spoke/core:${{ steps.image-tags.outputs.version }}
             us-east4-docker.pkg.dev/spoke-rewired/spoke/core:${{ steps.image-tags.outputs.sha }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-
-      # Temp fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -81,7 +81,7 @@ jobs:
         run: yarn jest --forceExit --detectOpenHandles src/**/*
 
   publish-docker-image:
-    if: true # startsWith( github.ref, 'refs/tags/v')
+    if: startsWith( github.ref, 'refs/tags/v')
     needs: test
     name: Publish Docker image
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Use the [new `gha` cache type](https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api).

## Motivation and Context

Using a GitHub Actions-native cache type improves build times.

## How Has This Been Tested?

The ci-cd workflow for this PR.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
