### PR TITLE
fix: handle overdue early return case

### DIFF
--- a/src/server/api/assignment.js
+++ b/src/server/api/assignment.js
@@ -1228,6 +1228,11 @@ export const resolvers = {
         campaign
       );
 
+      // Handle early return case in getContacts
+      if (Array.isArray(contactsQuery)) {
+        return contactsQuery;
+      }
+
       // Limit fields read from DB if possible
       const fieldNode = info.fieldNodes.find(
         ({ name: { value } }) => value === "contacts"


### PR DESCRIPTION
## Description

Handle early return from `getContacts()` that returns an empty array instead of a Knex query object.

## Motivation and Context

Otherwise this causes `contactsQuery.select is not a function` error.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
