### PR TITLE
feat: add superadmin approval for campaigns

### DIFF
--- a/__test__/testbed-preparation/core.ts
+++ b/__test__/testbed-preparation/core.ts
@@ -123,6 +123,7 @@ export type CreateCampaignOptions = Partial<
     Campaign,
     | "title"
     | "description"
+    | "isApproved"
     | "isStarted"
     | "isArchived"
     | "textingHoursStart"
@@ -151,6 +152,7 @@ export const createCampaign = async (
         organization_id,
         title,
         description,
+        is_approved,
         is_started,
         is_archived,
         use_dynamic_assignment,
@@ -166,13 +168,14 @@ export const createCampaign = async (
         replies_stale_after_minutes,
         landlines_filtered,
         external_system_id
-      ) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
+      ) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
       returning *
     `,
       [
         options.organizationId,
         options.title ?? faker.company.companyName(),
         options.description ?? faker.lorem.sentence(),
+        options.isApproved ?? false,
         options.isStarted ?? true,
         options.isArchived ?? false,
         false,

--- a/libs/spoke-codegen/src/graphql/campaign-builder.graphql
+++ b/libs/spoke-codegen/src/graphql/campaign-builder.graphql
@@ -1,0 +1,23 @@
+query GetCampaignStatus($campaignId: String!) {
+  campaign(id: $campaignId) {
+    id
+    isStarted
+    isApproved
+  }
+}
+
+mutation SetCampaignApproved($campaignId: String!, $approved: Boolean!) {
+  setCampaignApproved(id: $campaignId, approved: $approved) {
+    id
+    isStarted
+    isApproved
+  }
+}
+
+mutation StartCampaign($campaignId: String!) {
+  startCampaign(id: $campaignId) {
+    id
+    isStarted
+    isApproved
+  }
+}

--- a/libs/spoke-codegen/src/graphql/general-settings.graphql
+++ b/libs/spoke-codegen/src/graphql/general-settings.graphql
@@ -1,0 +1,28 @@
+query GetCampaignBuilderSettings($organizationId: String!) {
+  organization(id: $organizationId) {
+    id
+    settings {
+      id
+      confirmationClickForScriptLinks
+      startCampaignRequiresApproval
+    }
+  }
+}
+
+mutation UpdateCampaignBuilderSettings(
+  $organizationId: String!
+  $confirmationClicks: Boolean
+  $requiresApproval: Boolean
+) {
+  editOrganizationSettings(
+    id: $organizationId
+    input: {
+      confirmationClickForScriptLinks: $confirmationClicks
+      startCampaignRequiresApproval: $requiresApproval
+    }
+  ) {
+    id
+    confirmationClickForScriptLinks
+    startCampaignRequiresApproval
+  }
+}

--- a/libs/spoke-codegen/src/graphql/spoke-context.graphql
+++ b/libs/spoke-codegen/src/graphql/spoke-context.graphql
@@ -16,4 +16,5 @@ fragment OrganizationSettingsInfo on OrganizationSettings {
   showContactLastName
   showContactCell
   confirmationClickForScriptLinks
+  startCampaignRequiresApproval
 }

--- a/migrations/20220115111920_support-superadmin-campaign-approval.js
+++ b/migrations/20220115111920_support-superadmin-campaign-approval.js
@@ -1,0 +1,13 @@
+exports.up = function up(knex) {
+  return knex.schema.raw(`
+    alter table campaign
+      add column is_approved boolean default false;
+  `);
+};
+
+exports.down = function down(knex) {
+  return knex.schema.raw(`
+    alter table campaign
+      drop column is_approved;
+  `);
+};

--- a/schema-dump.sql
+++ b/schema-dump.sql
@@ -217,7 +217,8 @@ CREATE TABLE public.campaign (
     updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
     replies_stale_after_minutes integer,
     landlines_filtered boolean DEFAULT false,
-    external_system_id uuid
+    external_system_id uuid,
+    is_approved boolean DEFAULT false
 );
 
 

--- a/src/api/campaign.ts
+++ b/src/api/campaign.ts
@@ -93,6 +93,7 @@ export interface Campaign {
   isStarted: boolean;
   dueBy?: string | null;
   contactsCount: number;
+  isApproved: boolean;
   isArchived: boolean;
   textingHoursStart: number;
   textingHoursEnd: number;
@@ -194,6 +195,7 @@ export const schema = `
     description: String
     dueBy: Date
     readiness: CampaignReadiness!
+    isApproved: Boolean!
     isStarted: Boolean
     isArchived: Boolean
     creator: User

--- a/src/api/organization-settings.ts
+++ b/src/api/organization-settings.ts
@@ -9,6 +9,9 @@ export interface OrganizationSettingsInput {
   defaulTexterApprovalStatus: RequestAutoApproveType | null;
   numbersApiKey: string | null;
   trollbotWebhookUrl: string | null;
+
+  // Superadmin
+  startCampaignRequiresApproval: boolean | null;
 }
 
 export interface OrganizationSettings {
@@ -19,6 +22,9 @@ export interface OrganizationSettings {
   showContactLastName: boolean;
   showContactCell: boolean;
   confirmationClickForScriptLinks: boolean;
+
+  // Supervolunteer
+  startCampaignRequiresApproval: boolean | null;
 
   // Owner
   defaulTexterApprovalStatus: RequestAutoApproveType | null;
@@ -36,6 +42,9 @@ export const schema = `
     defaulTexterApprovalStatus: RequestAutoApprove
     numbersApiKey: String
     trollbotWebhookUrl: String
+
+    # Superadmin
+    startCampaignRequiresApproval: Boolean
   }
 
   type OrganizationSettings {
@@ -46,6 +55,9 @@ export const schema = `
     showContactLastName: Boolean!
     showContactCell: Boolean!
     confirmationClickForScriptLinks: Boolean!
+
+    # Supervolunteer
+    startCampaignRequiresApproval: Boolean
 
     # Owner
     defaulTexterApprovalStatus: RequestAutoApprove

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -272,6 +272,7 @@ const rootSchema = `
       optOut: ContactActionInput,
       closeConversation: Boolean
     ): CampaignContact,
+    setCampaignApproved(id: String!, approved: Boolean!): Campaign!,
     startCampaign(id:String!): Campaign,
     archiveCampaign(id:String!): Campaign,
     unarchiveCampaign(id:String!): Campaign,

--- a/src/components/AuthzProvider.tsx
+++ b/src/components/AuthzProvider.tsx
@@ -1,6 +1,5 @@
 import { useCurrentUserOrganizationRolesQuery } from "@spoke/spoke-codegen";
 import React, { useContext, useEffect } from "react";
-import { useParams } from "react-router-dom";
 
 import { UserRoleType } from "../api/organization-membership";
 import { useSpokeContext } from "../client/spoke-context";
@@ -25,19 +24,20 @@ export const AuthzContext = React.createContext<AuthzContextType>({
 });
 
 export const AuthzProvider: React.FC<{ organizationId: string }> = (props) => {
-  const { organizationId } = useParams<{ organizationId: string }>();
   const { data, loading, error } = useCurrentUserOrganizationRolesQuery({
     variables: { organizationId: props.organizationId },
     skip: props.organizationId === undefined
   });
   const roles = (data?.currentUser?.roles ?? []) as UserRoleType[];
-  const hasAdminPermissions = hasRole(UserRoleType.ADMIN, roles);
+  const isSuperadmin = data?.currentUser?.isSuperadmin ?? false;
+  const hasAdminPermissions =
+    isSuperadmin || hasRole(UserRoleType.ADMIN, roles);
 
   const { setOrganizationId } = useSpokeContext();
 
   useEffect(() => {
-    setOrganizationId(organizationId);
-  }, [organizationId]);
+    setOrganizationId(props.organizationId);
+  }, [props.organizationId]);
 
   useEffect(() => {
     if (!loading && error !== undefined) {
@@ -51,7 +51,7 @@ export const AuthzProvider: React.FC<{ organizationId: string }> = (props) => {
     () => ({
       roles,
       hasRole: (role: UserRoleType) => hasRole(role, roles),
-      isSuperadmin: hasRole(UserRoleType.SUPERADMIN, roles),
+      isSuperadmin,
       isOwner: hasRole(UserRoleType.OWNER, roles),
       isAdmin: hasRole(UserRoleType.ADMIN, roles),
       isSupervol: hasRole(UserRoleType.SUPERVOLUNTEER, roles)

--- a/src/containers/AdminCampaignEdit/components/ApproveCampaignButton.tsx
+++ b/src/containers/AdminCampaignEdit/components/ApproveCampaignButton.tsx
@@ -1,0 +1,66 @@
+import Button from "@material-ui/core/Button";
+import Tooltip from "@material-ui/core/Tooltip";
+import React, { useCallback } from "react";
+
+import {
+  useGetCampaignStatusQuery,
+  useSetCampaignApprovedMutation
+} from "../../../../libs/spoke-codegen/src";
+import { useSpokeContext } from "../../../client/spoke-context";
+import { useAuthzContext } from "../../../components/AuthzProvider";
+
+export interface ApproveCampaignButtonProps {
+  campaignId: string;
+}
+
+export const ApproveCampaignButton: React.FC<ApproveCampaignButtonProps> = (
+  props
+) => {
+  const { campaignId } = props;
+  const { isSuperadmin } = useAuthzContext();
+  const { orgSettings } = useSpokeContext();
+  const { data, loading } = useGetCampaignStatusQuery({
+    variables: { campaignId }
+  });
+  const isApproved = data?.campaign?.isApproved ?? false;
+  const [
+    setCampaignApproved,
+    { loading: approving }
+  ] = useSetCampaignApprovedMutation();
+
+  const working = loading || approving;
+
+  const tooltipText =
+    !isSuperadmin && orgSettings?.startCampaignRequiresApproval
+      ? "Superadmin approval required"
+      : "";
+
+  const handleClick = useCallback(() => {
+    if (!isSuperadmin || working) return;
+
+    setCampaignApproved({
+      variables: { campaignId, approved: !isApproved }
+    });
+  }, [campaignId, isSuperadmin, working, isApproved, setCampaignApproved]);
+
+  if (!isSuperadmin) {
+    return null;
+  }
+
+  return (
+    <Tooltip title={tooltipText} placement="top">
+      <span>
+        <Button
+          variant="contained"
+          style={{ width: 120 }}
+          disabled={working || !data}
+          onClick={handleClick}
+        >
+          {isApproved ? "Unapprove" : "Approve"}
+        </Button>
+      </span>
+    </Tooltip>
+  );
+};
+
+export default ApproveCampaignButton;

--- a/src/containers/AdminCampaignEdit/components/ApproveCampaignButton.tsx
+++ b/src/containers/AdminCampaignEdit/components/ApproveCampaignButton.tsx
@@ -43,7 +43,7 @@ export const ApproveCampaignButton: React.FC<ApproveCampaignButtonProps> = (
     });
   }, [campaignId, isSuperadmin, working, isApproved, setCampaignApproved]);
 
-  if (!isSuperadmin) {
+  if (!isSuperadmin || !orgSettings?.startCampaignRequiresApproval) {
     return null;
   }
 

--- a/src/containers/AdminCampaignEdit/components/SectionWrapper.tsx
+++ b/src/containers/AdminCampaignEdit/components/SectionWrapper.tsx
@@ -225,6 +225,7 @@ const makeQueries = (jobTypes: string[]) => ({
         campaign(id: $campaignId) {
           id
           isStarted
+          isApproved
           readiness {
             id
             basics

--- a/src/containers/AdminCampaignEdit/components/StartCampaignButton.tsx
+++ b/src/containers/AdminCampaignEdit/components/StartCampaignButton.tsx
@@ -46,7 +46,9 @@ export const StartCampaignButton: React.FC<StartCampaignButtonProps> = (
 
   const startText = data?.campaign?.isStarted
     ? "Already started"
-    : authz.isSuperadmin && !data?.campaign?.isApproved
+    : authz.isSuperadmin &&
+      !data?.campaign?.isApproved &&
+      orgSettings?.startCampaignRequiresApproval
     ? "Approve and start"
     : "Start this campaign";
 

--- a/src/containers/AdminCampaignEdit/components/StartCampaignButton.tsx
+++ b/src/containers/AdminCampaignEdit/components/StartCampaignButton.tsx
@@ -1,0 +1,70 @@
+import Button from "@material-ui/core/Button";
+import Tooltip from "@material-ui/core/Tooltip";
+import React, { useCallback } from "react";
+
+import {
+  useGetCampaignStatusQuery,
+  useStartCampaignMutation
+} from "../../../../libs/spoke-codegen/src";
+import { useSpokeContext } from "../../../client/spoke-context";
+import { useAuthzContext } from "../../../components/AuthzProvider";
+
+export interface StartCampaignButtonProps {
+  campaignId: string;
+  isCompleted: boolean;
+}
+
+export const StartCampaignButton: React.FC<StartCampaignButtonProps> = (
+  props
+) => {
+  const { campaignId, isCompleted } = props;
+  const authz = useAuthzContext();
+  const { orgSettings } = useSpokeContext();
+  const { data, loading } = useGetCampaignStatusQuery({
+    variables: { campaignId }
+  });
+  const [startCampaign] = useStartCampaignMutation();
+
+  const requiresApproval =
+    !authz.isSuperadmin &&
+    (orgSettings?.startCampaignRequiresApproval ?? true) &&
+    !(data?.campaign?.isApproved ?? false);
+
+  const disabled =
+    !isCompleted ||
+    loading ||
+    (data?.campaign?.isStarted ?? false) ||
+    requiresApproval;
+
+  const tooltipText = requiresApproval ? "Superadmin approval required" : "";
+
+  const handleClick = useCallback(() => {
+    if (disabled) return;
+
+    startCampaign({ variables: { campaignId } });
+  }, [startCampaign, campaignId]);
+
+  const startText = data?.campaign?.isStarted
+    ? "Already started"
+    : authz.isSuperadmin && !data?.campaign?.isApproved
+    ? "Approve and start"
+    : "Start this campaign";
+
+  return (
+    <Tooltip title={tooltipText} placement="top">
+      <span>
+        <Button
+          variant="contained"
+          color="primary"
+          style={{ width: 210 }}
+          disabled={disabled}
+          onClick={handleClick}
+        >
+          {startText}
+        </Button>
+      </span>
+    </Tooltip>
+  );
+};
+
+export default StartCampaignButton;

--- a/src/containers/AdminCampaignEdit/index.jsx
+++ b/src/containers/AdminCampaignEdit/index.jsx
@@ -26,6 +26,8 @@ import { camelCase, dataTest } from "../../lib/attributes";
 import { DateTime } from "../../lib/datetime";
 import theme from "../../styles/theme";
 import { loadData } from "../hoc/with-operations";
+import ApproveCampaignButton from "./components/ApproveCampaignButton";
+import StartCampaignButton from "./components/StartCampaignButton";
 import {
   ARCHIVE_CAMPAIGN,
   DELETE_JOB,
@@ -697,22 +699,12 @@ class AdminCampaignEdit extends React.Component {
               }
             />
           )}
-          <RaisedButton
-            {...dataTest("startCampaign")}
-            primary
-            label="Start This Campaign!"
-            disabled={!isCompleted}
-            onClick={async () => {
-              this.setState({
-                startingCampaign: true
-              });
-              await this.props.mutations.startCampaign(
-                this.props.campaignData.campaign.id
-              );
-              this.setState({
-                startingCampaign: false
-              });
-            }}
+          <ApproveCampaignButton
+            campaignId={this.props.campaignData.campaign.id}
+          />
+          <StartCampaignButton
+            campaignId={this.props.campaignData.campaign.id}
+            isCompleted={isCompleted}
           />
         </div>
       </div>

--- a/src/containers/AdminCampaignEdit/queries.ts
+++ b/src/containers/AdminCampaignEdit/queries.ts
@@ -68,6 +68,7 @@ export const EditCampaignFragment = gql`
     description
     dueBy
     isStarted
+    isApproved
     isArchived
     contactsCount
     datawarehouseAvailable

--- a/src/containers/AdminCampaignEdit/sections/CampaignBasicsForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignBasicsForm.tsx
@@ -210,6 +210,7 @@ const queries = {
           logoImageUrl
           primaryColor
           isStarted
+          isApproved
         }
       }
     `,
@@ -237,6 +238,7 @@ const mutations = {
           logoImageUrl
           primaryColor
           isStarted
+          isApproved
           readiness {
             id
             basics

--- a/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/index.tsx
@@ -253,6 +253,7 @@ const queries: QueryMap<InnerProps> = {
             text
           }
           isStarted
+          isApproved
           customFields
           externalSystem {
             id
@@ -283,6 +284,7 @@ const mutations: MutationMap<InnerProps> = {
             text
           }
           isStarted
+          isApproved
           customFields
           readiness {
             id

--- a/src/containers/AdminCampaignEdit/sections/CampaignGroupsForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignGroupsForm.tsx
@@ -125,6 +125,7 @@ const queries: QueryMap<InnerProps> = {
             }
           }
           isStarted
+          isApproved
         }
       }
     `,
@@ -175,6 +176,7 @@ const mutations: MutationMap<InnerProps> = {
             }
           }
           isStarted
+          isApproved
           readiness {
             id
             campaignGroups

--- a/src/containers/AdminCampaignEdit/sections/CampaignIntegrationForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignIntegrationForm.tsx
@@ -149,6 +149,7 @@ const queries: QueryMap<InnerProps> = {
             id
           }
           isStarted
+          isApproved
         }
       }
     `,
@@ -196,6 +197,7 @@ const mutations: MutationMap<InnerProps> = {
             id
           }
           isStarted
+          isApproved
           syncReadiness
           readiness {
             id

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
@@ -399,6 +399,7 @@ const mutations: MutationMap<FullComponentProps> = {
             ...EditInteractionStep
           }
           isStarted
+          isApproved
           customFields
           readiness {
             id

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/resolvers.ts
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/resolvers.ts
@@ -28,6 +28,7 @@ export const GET_CAMPAIGN_INTERACTIONS = gql`
     campaign(id: $campaignId) {
       id
       isStarted
+      isApproved
       interactionSteps {
         ...EditInteractionStep
       }

--- a/src/containers/AdminCampaignEdit/sections/CampaignTextersForm/queries.ts
+++ b/src/containers/AdminCampaignEdit/sections/CampaignTextersForm/queries.ts
@@ -19,6 +19,7 @@ export const GET_CAMPAIGN_TEXTERS = gql`
       }
       contactsCount
       isStarted
+      isApproved
       dueBy
       readiness {
         id

--- a/src/containers/CampaignList/CampaignListLoader.tsx
+++ b/src/containers/CampaignList/CampaignListLoader.tsx
@@ -27,6 +27,7 @@ const query = gql`
             id
             title
             isStarted
+            isApproved
             isArchived
             isAutoassignEnabled
             hasUnassignedContacts

--- a/src/containers/CampaignList/index.jsx
+++ b/src/containers/CampaignList/index.jsx
@@ -96,6 +96,7 @@ const campaignInfoFragment = `
   id
   title
   isStarted
+  isApproved
   isArchived
   hasUnassignedContacts
   hasUnsentInitialMessages

--- a/src/containers/Settings/components/CampaignBuilderSettingsCard.tsx
+++ b/src/containers/Settings/components/CampaignBuilderSettingsCard.tsx
@@ -1,64 +1,68 @@
-import { ApolloQueryResult } from "@apollo/client";
 import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
 import CardHeader from "@material-ui/core/CardHeader";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import FormGroup from "@material-ui/core/FormGroup";
 import Switch from "@material-ui/core/Switch";
-import React, { useState } from "react";
-import { compose } from "recompose";
+import React from "react";
 
-import { MutationMap, QueryMap } from "../../../network/types";
-import { loadData } from "../../hoc/with-operations";
 import {
-  ConfirmationClickForScriptLinksType,
-  EDIT_CONFIRMATION_CLICK_FOR_SCRIPT_LINKS,
-  GET_CONFIRMATION_CLICK_FOR_SCRIPT_LINKS
-} from "./queries";
+  useGetCampaignBuilderSettingsQuery,
+  useUpdateCampaignBuilderSettingsMutation
+} from "../../../../libs/spoke-codegen/src";
+import { useAuthzContext } from "../../../components/AuthzProvider";
 
-interface HocProps {
-  data: ConfirmationClickForScriptLinksType;
-  mutations: {
-    editConfirmationClickForScriptLinks(value: boolean): ApolloQueryResult<any>;
-  };
-}
-
-export interface OuterProps {
+export interface CampaignBuilderSettingsCardProps {
   organizationId: string;
   style?: React.CSSProperties;
 }
 
-interface InnerProps extends OuterProps, HocProps {}
+export const CampaignBuilderSettingsCard: React.FC<CampaignBuilderSettingsCardProps> = (
+  props
+) => {
+  const { organizationId, style } = props;
+  const authz = useAuthzContext();
 
-const CampaignBuilderSettingsCard: React.FC<InnerProps> = (props) => {
-  const {
-    data: {
-      organization: {
-        settings: { confirmationClickForScriptLinks }
-      }
-    },
-    style
-  } = props;
-  const [working, setWorking] = useState<boolean>(false);
-  const [errorMsg, setErrorMsg] = useState<string | undefined>(undefined);
+  const getSettingsState = useGetCampaignBuilderSettingsQuery({
+    variables: { organizationId }
+  });
+  const settings = getSettingsState?.data?.organization?.settings;
 
-  const saveConfirmationClickForLinks = async (
+  const [
+    setRequiresApproval,
+    updateState
+  ] = useUpdateCampaignBuilderSettingsMutation();
+
+  const working = getSettingsState.loading || updateState.loading;
+  const errorMsg =
+    getSettingsState.error?.message ?? updateState.error?.message;
+
+  const handleToggleConfirmationClick = async (
     _event: React.ChangeEvent<HTMLInputElement>,
-    checked: boolean
+    confirmationClicks: boolean
   ) => {
-    setErrorMsg(undefined);
-    setWorking(true);
-    try {
-      const result = await props.mutations.editConfirmationClickForScriptLinks(
-        checked
-      );
-      if (result.errors) throw new Error(result.errors[0].message);
-    } catch (err: any) {
-      console.log("setting error message", err.message);
-      setErrorMsg(err.message);
-    } finally {
-      setWorking(false);
-    }
+    if (working) return;
+
+    await setRequiresApproval({
+      variables: {
+        organizationId,
+        confirmationClicks
+      }
+    });
+  };
+
+  const handleToggleRequiresApproval = async (
+    _event: React.ChangeEvent<HTMLInputElement>,
+    requiresApproval: boolean
+  ) => {
+    if (working || !authz.isSuperadmin) return;
+
+    await setRequiresApproval({
+      variables: {
+        organizationId,
+        requiresApproval
+      }
+    });
   };
 
   return (
@@ -70,12 +74,25 @@ const CampaignBuilderSettingsCard: React.FC<InnerProps> = (props) => {
           <FormControlLabel
             control={
               <Switch
-                checked={confirmationClickForScriptLinks}
-                disabled={working}
-                onChange={saveConfirmationClickForLinks}
+                checked={settings?.confirmationClickForScriptLinks ?? true}
+                onChange={handleToggleConfirmationClick}
               />
             }
             label="Require confirmation click for links in scripts?"
+          />
+        </FormGroup>
+        <FormGroup row>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={settings?.startCampaignRequiresApproval ?? false}
+                disabled={!authz.isSuperadmin}
+                onChange={handleToggleRequiresApproval}
+              />
+            }
+            label={`Require superadmin approval before starting campaigns? ${
+              authz.isSuperadmin ? "" : "(superadmin-only)"
+            }`}
           />
         </FormGroup>
       </CardContent>
@@ -83,29 +100,4 @@ const CampaignBuilderSettingsCard: React.FC<InnerProps> = (props) => {
   );
 };
 
-const queries: QueryMap<OuterProps> = {
-  data: {
-    query: GET_CONFIRMATION_CLICK_FOR_SCRIPT_LINKS,
-    options: ({ organizationId }) => ({
-      variables: { organizationId }
-    })
-  }
-};
-
-const mutations: MutationMap<OuterProps> = {
-  editConfirmationClickForScriptLinks: ({ organizationId }) => (
-    confirmationClickForScriptLinks: boolean
-  ) => ({
-    mutation: EDIT_CONFIRMATION_CLICK_FOR_SCRIPT_LINKS,
-    variables: {
-      organizationId,
-      input: {
-        confirmationClickForScriptLinks
-      }
-    }
-  })
-};
-
-export default compose<InnerProps, OuterProps>(
-  loadData({ queries, mutations })
-)(CampaignBuilderSettingsCard);
+export default CampaignBuilderSettingsCard;

--- a/src/containers/Settings/components/queries.ts
+++ b/src/containers/Settings/components/queries.ts
@@ -1,7 +1,6 @@
 import { gql } from "@apollo/client";
 
 import { Organization } from "../../../api/organization";
-import { OrganizationSettings } from "../../../api/organization-settings";
 
 export interface OrganizationNameType {
   organization: Pick<Organization, "id" | "name">;
@@ -24,39 +23,6 @@ export const EDIT_ORGANIZATION_NAME = gql`
     editOrganization(id: $organizationId, input: $input) {
       id
       name
-    }
-  }
-`;
-
-export interface ConfirmationClickForScriptLinksType {
-  organization: Pick<Organization, "id"> & {
-    settings: Pick<
-      OrganizationSettings,
-      "id" | "confirmationClickForScriptLinks"
-    >;
-  };
-}
-
-export const GET_CONFIRMATION_CLICK_FOR_SCRIPT_LINKS = gql`
-  query GetConfirmationClickForScriptLinks($organizationId: String!) {
-    organization(id: $organizationId) {
-      id
-      settings {
-        id
-        confirmationClickForScriptLinks
-      }
-    }
-  }
-`;
-
-export const EDIT_CONFIRMATION_CLICK_FOR_SCRIPT_LINKS = gql`
-  mutation EditConfirmationClickForScriptLinks(
-    $organizationId: String!
-    $input: OrganizationSettingsInput!
-  ) {
-    editOrganizationSettings(id: $organizationId, input: $input) {
-      id
-      confirmationClickForScriptLinks
     }
   }
 `;

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -240,6 +240,7 @@ type RootMutation {
     optOut: ContactActionInput,
     closeConversation: Boolean
   ): CampaignContact,
+  setCampaignApproved(id: String!, approved: Boolean!): Campaign!,
   startCampaign(id:String!): Campaign,
   archiveCampaign(id:String!): Campaign,
   unarchiveCampaign(id:String!): Campaign,

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -409,6 +409,9 @@ input OrganizationSettingsInput {
   defaulTexterApprovalStatus: RequestAutoApprove
   numbersApiKey: String
   trollbotWebhookUrl: String
+
+  # Superadmin
+  startCampaignRequiresApproval: Boolean
 }
 
 type OrganizationSettings {
@@ -419,6 +422,9 @@ type OrganizationSettings {
   showContactLastName: Boolean!
   showContactCell: Boolean!
   confirmationClickForScriptLinks: Boolean!
+
+  # Supervolunteer
+  startCampaignRequiresApproval: Boolean
 
   # Owner
   defaulTexterApprovalStatus: RequestAutoApprove
@@ -532,6 +538,7 @@ type Campaign {
   description: String
   dueBy: Date
   readiness: CampaignReadiness!
+  isApproved: Boolean!
   isStarted: Boolean
   isArchived: Boolean
   creator: User

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -260,6 +260,7 @@ export const resolvers = {
       "id",
       "title",
       "description",
+      "isApproved",
       "isStarted",
       "isArchived",
       // TODO: re-enable once dynamic assignment is fixed (#548)

--- a/src/server/api/lib/campaign.ts
+++ b/src/server/api/lib/campaign.ts
@@ -252,8 +252,18 @@ export const editCampaign = async (
   campaign: CampaignInput,
   loaders: any,
   user: UserRecord,
-  origCampaignRecord: CampaignRecord
+  origCampaignRecord: CampaignRecord,
+  requiresApproval = false
 ) => {
+  const unstartIfNecessary = async () => {
+    if (!user.is_superadmin && requiresApproval) {
+      await r
+        .knex("campaign")
+        .update({ is_started: false, is_approved: false })
+        .where({ id });
+    }
+  };
+
   const {
     title,
     description,
@@ -457,6 +467,7 @@ export const editCampaign = async (
   }
 
   if (Object.prototype.hasOwnProperty.call(campaign, "interactionSteps")) {
+    await unstartIfNecessary();
     memoizer.invalidate(cacheOpts.CampaignInteractionSteps.key, {
       campaignId: id
     });
@@ -477,6 +488,7 @@ export const editCampaign = async (
   }
 
   if (Object.prototype.hasOwnProperty.call(campaign, "cannedResponses")) {
+    await unstartIfNecessary();
     memoizer.invalidate(cacheOpts.CampaignCannedResponses.key, {
       campaignId: id
     });

--- a/src/server/api/lib/campaign.ts
+++ b/src/server/api/lib/campaign.ts
@@ -150,6 +150,7 @@ export const copyCampaign = async (options: CopyCampaignOptions) => {
           organization_id,
           'COPY - ' || title,
           description,
+          false as is_approved,
           false as is_started,
           false as is_archived,
           due_by,

--- a/src/server/api/organization-settings.ts
+++ b/src/server/api/organization-settings.ts
@@ -16,6 +16,7 @@ interface IOrganizationSettings {
   showContactLastName: boolean;
   showContactCell: boolean;
   confirmationClickForScriptLinks: boolean;
+  startCampaignRequiresApproval: boolean;
 }
 
 const SETTINGS_PERMISSIONS: {
@@ -25,6 +26,7 @@ const SETTINGS_PERMISSIONS: {
   showContactLastName: UserRoleType.TEXTER,
   showContactCell: UserRoleType.TEXTER,
   confirmationClickForScriptLinks: UserRoleType.TEXTER,
+  startCampaignRequiresApproval: UserRoleType.SUPERVOLUNTEER,
   defaulTexterApprovalStatus: UserRoleType.OWNER,
   numbersApiKey: UserRoleType.OWNER,
   trollbotWebhookUrl: UserRoleType.OWNER
@@ -39,7 +41,8 @@ const SETTINGS_WRITE_PERMISSIONS: {
   confirmationClickForScriptLinks: UserRoleType.OWNER,
   defaulTexterApprovalStatus: UserRoleType.OWNER,
   numbersApiKey: UserRoleType.OWNER,
-  trollbotWebhookUrl: UserRoleType.OWNER
+  trollbotWebhookUrl: UserRoleType.OWNER,
+  startCampaignRequiresApproval: UserRoleType.SUPERADMIN
 };
 
 const SETTINGS_NAMES: Partial<
@@ -55,7 +58,8 @@ const SETTINGS_DEFAULTS: IOrganizationSettings = {
     "I'm opting you out of texts immediately. Have a great day.",
   showContactLastName: false,
   showContactCell: false,
-  confirmationClickForScriptLinks: true
+  confirmationClickForScriptLinks: true,
+  startCampaignRequiresApproval: false
 };
 
 const SETTINGS_TRANSFORMERS: Partial<
@@ -136,7 +140,8 @@ export const resolvers = {
       "trollbotWebhookUrl",
       "showContactLastName",
       "showContactCell",
-      "confirmationClickForScriptLinks"
+      "confirmationClickForScriptLinks",
+      "startCampaignRequiresApproval"
     ])
   }
 };

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1,3 +1,4 @@
+import { ForbiddenError } from "apollo-server-errors";
 import camelCaseKeys from "camelcase-keys";
 import GraphQLDate from "graphql-date";
 import GraphQLJSON from "graphql-type-json";
@@ -83,6 +84,7 @@ import { resolvers as optOutResolvers } from "./opt-out";
 import { resolvers as organizationResolvers } from "./organization";
 import { resolvers as membershipSchema } from "./organization-membership";
 import {
+  getOrgFeature,
   resolvers as settingsSchema,
   updateOrganizationSettings,
   writePermissionRequired
@@ -761,7 +763,8 @@ const rootMutations = {
         campaign,
         loaders,
         user,
-        origCampaignRecord
+        origCampaignRecord,
+        false
       );
     },
 
@@ -818,16 +821,33 @@ const rootMutations = {
     },
 
     startCampaign: async (_root, { id }, { user, loaders }) => {
-      const { organization_id } = await loaders.campaign.load(id);
-      await accessRequired(user, organization_id, "ADMIN");
+      const { organization_id, is_approved } = await loaders.campaign.load(id);
+      const { features } = await loaders.organization.load(organization_id);
+      const requiresApproval = getOrgFeature(
+        "startCampaignRequiresApproval",
+        features
+      );
+
+      if (!user.is_superadmin && requiresApproval && !is_approved) {
+        throw new ForbiddenError(
+          "Campaign must be approved by superadmin before starting."
+        );
+      }
+
+      await accessRequired(user, organization_id, "ADMIN", true);
 
       await memoizer.invalidate(cacheOpts.CampaignsList.key, {
         organizationId: organization_id
       });
 
+      const payload = {
+        is_started: true,
+        ...(user.is_superadmin ? { is_approved: true } : {})
+      };
+
       const [campaign] = await r
         .knex("campaign")
-        .update({ is_started: true })
+        .update(payload)
         .where({ id })
         .returning("*");
 
@@ -845,6 +865,13 @@ const rootMutations = {
       { user, loaders }
     ) => {
       const origCampaign = await r.knex("campaign").where({ id }).first();
+      const { features } = await loaders.organization.load(
+        origCampaign.organization_id
+      );
+      const requiresApproval = getOrgFeature(
+        "startCampaignRequiresApproval",
+        features
+      );
 
       // Sometimes, campaign was coming through as having
       // a "null prototype", which caused .hasOwnProperty calls
@@ -870,7 +897,15 @@ const rootMutations = {
           "Not allowed to add contacts after the campaign starts"
         );
       }
-      return editCampaign(id, campaign, loaders, user, origCampaign);
+
+      return editCampaign(
+        id,
+        campaign,
+        loaders,
+        user,
+        origCampaign,
+        requiresApproval
+      );
     },
 
     filterLandlines: async (_root, { id }, { user, loaders }) => {

--- a/src/server/api/types.ts
+++ b/src/server/api/types.ts
@@ -83,6 +83,7 @@ export interface CampaignRecord {
   organization_id: number;
   title: string;
   description: string;
+  is_approved: boolean;
   is_started: boolean | null;
   due_by: string | null;
   created_at: string;

--- a/src/server/organization-settings.spec.ts
+++ b/src/server/organization-settings.spec.ts
@@ -31,6 +31,7 @@ describe("get organization settings", () => {
     showContactLastName: false,
     showContactCell: false,
     confirmationClickForScriptLinks: true,
+    startCampaignRequiresApproval: false,
     defaulTexterApprovalStatus: RequestAutoApproveType.APPROVAL_REQUIRED,
     numbersApiKey: "SomethingSecret",
     trollbotWebhookUrl: "https://rewired.coop/trolls"
@@ -58,6 +59,7 @@ describe("get organization settings", () => {
                 showContactLastName
                 showContactCell
                 confirmationClickForScriptLinks
+                startCampaignRequiresApproval
                 defaulTexterApprovalStatus
                 numbersApiKey
                 trollbotWebhookUrl
@@ -114,6 +116,9 @@ describe("get organization settings", () => {
     expect(settings.confirmationClickForScriptLinks).toEqual(
       features.confirmationClickForScriptLinks
     );
+    expect(settings.startCampaignRequiresApproval).toEqual(
+      features.startCampaignRequiresApproval
+    );
     expect(settings.defaulTexterApprovalStatus).toEqual(
       features.defaulTexterApprovalStatus
     );
@@ -126,6 +131,12 @@ describe("get organization settings", () => {
       optOutMessage: "See ya"
     });
     expect(ownerRole).toEqual(UserRoleType.OWNER);
+
+    const superAdminRole = writePermissionRequired({
+      optOutMessage: "See ya",
+      startCampaignRequiresApproval: true
+    });
+    expect(superAdminRole).toEqual(UserRoleType.SUPERADMIN);
   });
 
   const makeSettingsUpdateRequest = async (
@@ -167,6 +178,16 @@ describe("get organization settings", () => {
       { optOutMessage: "Something new" }
     );
     expect(validResponse.ok).toBe(true);
+
+    const invalidResponse = await makeSettingsUpdateRequest(
+      organization.id,
+      cookies,
+      { startCampaignRequiresApproval: true }
+    );
+    expect(invalidResponse.ok).toBe(true);
+    expect(invalidResponse.body).toHaveProperty("errors");
+    expect(invalidResponse.body.errors.length).toBeGreaterThan(0);
+    expect(invalidResponse.body.data).toBeNull();
   });
 
   it("allows superadmin to update appropriately permissioned settings", async () => {
@@ -185,5 +206,10 @@ describe("get organization settings", () => {
       { optOutMessage: "Something new" }
     );
     expect(validResponse.ok).toBe(true);
+
+    const response = await makeSettingsUpdateRequest(organization.id, cookies, {
+      startCampaignRequiresApproval: true
+    });
+    expect(response.ok).toBe(true);
   });
 });


### PR DESCRIPTION
## Description

This adds an organization-level setting that, when enabled, requires a superadmin to approve a campaign before it can be started. Future edits to interaction steps or canned responses pause the campaign and require re-approval.

## Motivation and Context

Customers have expressed interest in this feature, particularly large chapter-based organizations where each organization may have very different styles of building campaigns and running their programs.

One question that remains is how to handle campaigns started before the setting was enabled. Current behavior is to do nothing. An alternative would be to pause (e.g. `set is_started = false`) all unapproved campaigns.

Closes #1050

## How Has This Been Tested?

See test suite changes.

## Screenshots (if appropriate):

<table>

<tr>
<th></th>
<th>Normal User</th>
<th>Superadmin</th>
</tr>

<tr>
<td>Organization Settings</td>

<td>

![Politics_Rewired_-_Settings_and__5591_Re__Feature_request_-_Rebecca_Ruechel-1](https://user-images.githubusercontent.com/2145526/156083172-bebd3e8f-6fef-4f27-a1ed-729b150d6812.png)

</td>
<td>

![Politics_Rewired_-_Settings_and__5591_Re__Feature_request_-_Rebecca_Ruechel](https://user-images.githubusercontent.com/2145526/156083174-164223f4-e9ea-4597-acd0-fadc3011e0ff.png)

</td>
</tr>

<tr>
<td>Campaign Builder</td>

<td>

![Politics_Rewired_-_Campaigns_-_4__Campaign_Builder_Refactorr_and__5591_Re__Feature_request_-_Rebecca_Ruechel](https://user-images.githubusercontent.com/2145526/156083171-b5a8c02a-8619-42fb-a056-2475b6e45430.png)

</td>
<td>

![Politics_Rewired_-_Campaigns_-_4__Campaign_Builder_Refactorr_and__5591_Re__Feature_request_-_Rebecca_Ruechel-1](https://user-images.githubusercontent.com/2145526/156083170-f95b6c87-2dbc-4547-9ad4-e99d65d1224d.png)

</td>
</tr>

</table>

## Documentation Changes

Proposed new knowledge base page, "Requiring Pre-launch Approval for Campaigns"

> # Requiring Pre-launch Approval for Campaigns
>
> Superadmin users may require that campaigns created by organization Owners and Admins be approved by a Superadmin before they are launched.
> 
> A Superadmin can turn this on from the "Campaign Builder Settings" section of the Settings page:
> [Image]
>
> Once enabled, all future campaigns will need to be approved by a Superadmin:
> [Image]
>
> Owners and Admins will not be able to start the campaign until it has been approved:
> [Image]
>
> Any future edits to the Interactions or Canned Responses sections of the campaigns by an Owner or Admin will pause the campaign and require re-approval.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have included updates for the documentation accordingly.
