### PR TITLE
feat: allowing suspending users

### DIFF
--- a/migrations/20220223123406_add_suspended_user_type.js
+++ b/migrations/20220223123406_add_suspended_user_type.js
@@ -1,4 +1,4 @@
-exports.up = function (knex) {
+exports.up = function up(knex) {
   return knex.schema.raw(`
 ALTER TABLE "user_organization"
 DROP CONSTRAINT "user_organization_role_check";
@@ -7,7 +7,7 @@ CHECK (role IN ('OWNER', 'ADMIN', 'SUPERVOLUNTEER', 'TEXTER', 'SUSPENDED'))
 `);
 };
 
-exports.down = function (knex) {
+exports.down = function down(knex) {
   return knex.schema.raw(`
 ALTER TABLE "user_organization"
 DROP CONSTRAINT "user_organization_role_check";

--- a/migrations/20220223123406_add_suspended_user_type.js
+++ b/migrations/20220223123406_add_suspended_user_type.js
@@ -1,0 +1,17 @@
+exports.up = function (knex) {
+  return knex.schema.raw(`
+ALTER TABLE "user_organization"
+DROP CONSTRAINT "user_organization_role_check";
+ALTER TABLE "user_organization" ADD CONSTRAINT "user_organization_role_check"
+CHECK (role IN ('OWNER', 'ADMIN', 'SUPERVOLUNTEER', 'TEXTER', 'SUSPENDED'))
+`);
+};
+
+exports.down = function (knex) {
+  return knex.schema.raw(`
+ALTER TABLE "user_organization"
+DROP CONSTRAINT "user_organization_role_check";
+ALTER TABLE "user_organization" ADD CONSTRAINT "user_organization_role_check"
+CHECK (role IN ('OWNER', 'ADMIN', 'SUPERVOLUNTEER', 'TEXTER'))
+`);
+};

--- a/src/api/organization-membership.ts
+++ b/src/api/organization-membership.ts
@@ -4,6 +4,7 @@ import type { RelayPageInfo } from "./pagination";
 import type { User } from "./user";
 
 export enum UserRoleType {
+  SUSPENDED = "SUSPENDED",
   TEXTER = "TEXTER",
   SUPERVOLUNTEER = "SUPERVOLUNTEER",
   ADMIN = "ADMIN",
@@ -21,6 +22,7 @@ export interface MembershipFilter {
   nameSearch?: string;
   campaignId?: string;
   campaignArchived?: boolean;
+  roles?: string[];
 }
 
 export interface OrganizationMembership {
@@ -42,6 +44,7 @@ export interface OrganizationMembershipPage {
 
 export const schema = `
   enum UserRole {
+    SUSPENDED
     TEXTER
     SUPERVOLUNTEER
     ADMIN
@@ -59,6 +62,7 @@ export const schema = `
     nameSearch: String
     campaignId: Int
     campaignArchived: Boolean
+    roles: [String]
   }
 
   type OrganizationMembership {

--- a/src/api/organization-membership.ts
+++ b/src/api/organization-membership.ts
@@ -62,7 +62,7 @@ export const schema = `
     nameSearch: String
     campaignId: Int
     campaignArchived: Boolean
-    roles: [String]
+    roles: [String!]
   }
 
   type OrganizationMembership {

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -315,6 +315,7 @@ const rootSchema = `
     deleteQuestionResponseSyncTarget(targetId: String!): String!
     syncCampaignToSystem(input: SyncCampaignToSystemInput!): Boolean!
     editExternalOptOutSyncConfig(systemId: String!, targetId: String): ExternalSystem!
+    unassignTextsFromUser(membershipId: String!): Boolean!
   }
 
   schema {

--- a/src/containers/AdminCampaignEdit/sections/CampaignTextersForm/components/TexterAssignmentRow.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignTextersForm/components/TexterAssignmentRow.tsx
@@ -4,6 +4,7 @@ import DeleteIcon from "@material-ui/icons/Delete";
 import { css } from "aphrodite";
 import React from "react";
 
+import { UserRoleType } from "../../../../../api/organization-membership";
 import Slider from "../../../../../components/Slider";
 import { dataTest } from "../../../../../lib/attributes";
 import theme from "../../../../../styles/theme";
@@ -30,6 +31,7 @@ const TexterAssignmentRow: React.FC<Props> = (props) => {
 
   const {
     displayName,
+    roles,
     assignment: { contactsCount, needsMessageCount }
   } = texter;
   const messagedCount = contactsCount - needsMessageCount;
@@ -66,7 +68,9 @@ const TexterAssignmentRow: React.FC<Props> = (props) => {
       </div>
       <div className={css(rowStyles.assignedCount)}>{messagedCount}</div>
       <div {...dataTest("texterName")} className={css(rowStyles.nameColumn)}>
-        {displayName}
+        {roles?.includes(UserRoleType.SUSPENDED)
+          ? `${displayName} (SUSPENDED)`
+          : displayName}
       </div>
       <div className={css(rowStyles.input)}>
         <TextField

--- a/src/containers/AdminCampaignEdit/sections/CampaignTextersForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignTextersForm/index.tsx
@@ -282,7 +282,8 @@ const queries: QueryMap<InnerProps> = {
     query: GET_CAMPAIGN_TEXTERS,
     options: (ownProps) => ({
       variables: {
-        campaignId: ownProps.campaignId
+        campaignId: ownProps.campaignId,
+        organizationId: ownProps.organizationId
       },
       fetchPolicy: "network-only"
     })

--- a/src/containers/AdminCampaignEdit/sections/CampaignTextersForm/queries.ts
+++ b/src/containers/AdminCampaignEdit/sections/CampaignTextersForm/queries.ts
@@ -1,7 +1,7 @@
 import { gql } from "@apollo/client";
 
 export const GET_CAMPAIGN_TEXTERS = gql`
-  query GetCampaignTexters($campaignId: String!) {
+  query GetCampaignTexters($campaignId: String!, $organizationId: String!) {
     campaign(id: $campaignId) {
       id
       texters {
@@ -16,6 +16,7 @@ export const GET_CAMPAIGN_TEXTERS = gql`
           )
           maxContacts
         }
+        roles(organizationId: $organizationId)
       }
       contactsCount
       isStarted
@@ -38,6 +39,7 @@ export const GET_ORGANIZATION_TEXTERS = gql`
         firstName
         lastName
         displayName
+        roles(organizationId: $organizationId)
       }
     }
   }

--- a/src/containers/AdminCampaignEdit/sections/CampaignTextersForm/types.ts
+++ b/src/containers/AdminCampaignEdit/sections/CampaignTextersForm/types.ts
@@ -13,4 +13,5 @@ export type OrgTexter = Pick<User, "id" | "firstName" | "displayName">;
 
 export type Texter = OrgTexter & {
   assignment: TexterAssignment;
+  roles: string[];
 };

--- a/src/containers/AdminIncomingMessageList/index.jsx
+++ b/src/containers/AdminIncomingMessageList/index.jsx
@@ -464,6 +464,7 @@ export class AdminIncomingMessageList extends Component {
           organizationId={organizationId}
           onUsersReceived={this.handleReassignmentTextersReceived}
           pageSize={1000}
+          filterSuspended
         />
         <PaginatedUsersRetriever
           organizationId={organizationId}

--- a/src/containers/AdminPeople/Dialogs.tsx
+++ b/src/containers/AdminPeople/Dialogs.tsx
@@ -136,6 +136,44 @@ const ConfirmSuperAdmin: React.StatelessComponent<ConfirmSuperAdminProps> = ({
   </div>
 );
 
+interface ConfirmUnassignTextsProps {
+  open: boolean;
+  onClose: () => void;
+  handleConfirmUnassignTexts: (unassignTexts: boolean) => void;
+}
+
+const ConfirmUnassignTexts: React.StatelessComponent<ConfirmUnassignTextsProps> = ({
+  open,
+  onClose,
+  handleConfirmUnassignTexts
+}) => (
+  <div>
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>Unassign Texts for User?</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          You've just suspended a user's account, do you want to unassign their
+          texts? Unassigned texts will be able to be picked up by other texters.
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <FlatButton
+          key="no"
+          label="No"
+          primary
+          onClick={() => handleConfirmUnassignTexts(false)}
+        />
+        <FlatButton
+          key="yes"
+          label="Yes"
+          primary
+          onClick={() => handleConfirmUnassignTexts(true)}
+        />
+      </DialogActions>
+    </Dialog>
+  </div>
+);
+
 interface ConfirmRemoveUsersProps {
   open: boolean;
   onClose: () => Promise<void> | void;
@@ -175,6 +213,7 @@ const Dialogs = {
   EditPerson,
   ResetPassword,
   ConfirmSuperAdmin,
+  ConfirmUnassignTexts,
   ConfirmRemoveUsers
 };
 export default Dialogs;

--- a/src/containers/AdminPeople/PeopleRow.tsx
+++ b/src/containers/AdminPeople/PeopleRow.tsx
@@ -56,6 +56,7 @@ const RoleSelect: React.StatelessComponent<RoleSelectProps> = ({
       onChange={(_, __, newRole: UserRoleType) => onSelect(newRole)}
     >
       {[
+        UserRoleType.SUSPENDED,
         UserRoleType.TEXTER,
         UserRoleType.SUPERVOLUNTEER,
         UserRoleType.ADMIN,

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -1,6 +1,7 @@
 import { UserRoleType } from "../api/organization-membership";
 
 export const ROLE_HIERARCHY = [
+  UserRoleType.SUSPENDED,
   UserRoleType.TEXTER,
   UserRoleType.SUPERVOLUNTEER,
   UserRoleType.ADMIN,

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -455,7 +455,7 @@ input MembershipFilter {
   nameSearch: String
   campaignId: Int
   campaignArchived: Boolean
-  roles: [String]
+  roles: [String!]
 }
 
 type OrganizationMembership {

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -283,6 +283,7 @@ type RootMutation {
   deleteQuestionResponseSyncTarget(targetId: String!): String!
   syncCampaignToSystem(input: SyncCampaignToSystemInput!): Boolean!
   editExternalOptOutSyncConfig(systemId: String!, targetId: String): ExternalSystem!
+  unassignTextsFromUser(membershipId: String!): Boolean!
 }
 
 schema {
@@ -436,6 +437,7 @@ type OrganizationSettings {
 
 
 enum UserRole {
+  SUSPENDED
   TEXTER
   SUPERVOLUNTEER
   ADMIN
@@ -453,6 +455,7 @@ input MembershipFilter {
   nameSearch: String
   campaignId: Int
   campaignArchived: Boolean
+  roles: [String]
 }
 
 type OrganizationMembership {

--- a/src/server/api/lib/send-message.ts
+++ b/src/server/api/lib/send-message.ts
@@ -157,6 +157,18 @@ export const sendMessage = async (
     )
   );
 
+  const { role } = await r
+    .knex("user_organization")
+    .where({
+      user_id: user.id,
+      organization_id: record.organization_id
+    })
+    .first(["role"]);
+
+  if (role === UserRoleType.SUSPENDED) {
+    throw new GraphQLError("You don't have the permission to send messages");
+  }
+
   if (
     record.monthly_message_limit !== undefined &&
     record.sent_message_count !== undefined &&

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -77,10 +77,14 @@ export const resolvers = {
         primaryColumn: "user_organization.id"
       };
 
-      const { nameSearch, campaignId, campaignArchived } = filter || {};
+      const { nameSearch, campaignId, campaignArchived, roles } = filter || {};
 
       const userQueryPath = "memberships.edges.node.user";
       const wantsUserInfo = infoHasQueryPath(info, userQueryPath);
+
+      if (roles) {
+        query.whereIn("role", roles);
+      }
 
       if (!!nameSearch || wantsUserInfo) {
         query.join("user", "user.id", "user_organization.user_id");

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -556,6 +556,24 @@ const rootMutations = {
       return updatedUser;
     },
 
+    unassignTextsFromUser: async (_root, { membershipId }, { user }) => {
+      const userOrg = await r
+        .knex("user_organization")
+        .where({ id: membershipId })
+        .first();
+      await accessRequired(user, userOrg.organization_id, "OWNER");
+
+      const assignment_ids = await r
+        .knex("assignment")
+        .where({ user_id: userOrg.user_id })
+        .pluck("id");
+
+      return r
+        .knex("campaign_contact")
+        .whereIn("assignment_id", assignment_ids)
+        .update({ assignment_id: null });
+    },
+
     joinOrganization: async (_root, { organizationUuid }, { user }) => {
       const organization = await r
         .knex("organization")

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -2103,6 +2103,18 @@ const rootMutations = {
         organizationId
       );
 
+      const { role } = await r
+        .knex("user_organization")
+        .where({
+          user_id: user.id,
+          organization_id: organizationId
+        })
+        .first(["role"]);
+
+      if (role === UserRoleType.SUSPENDED) {
+        return "You don't have the permission to request texts";
+      }
+
       if (!myAssignmentTarget) {
         return "No texts available at the moment";
       }

--- a/src/server/api/user.js
+++ b/src/server/api/user.js
@@ -16,10 +16,10 @@ export function buildUserOrganizationQuery(
   campaignId,
   offset
 ) {
-  if (role !== UserRoleType.SUSPENDED) {
-    queryParam.whereNot({ role: UserRoleType.SUSPENDED });
-  } else if (role) {
+  if (role) {
     queryParam.where({ role });
+  } else {
+    queryParam.whereNot({ role: UserRoleType.SUSPENDED });
   }
 
   queryParam


### PR DESCRIPTION
Allow users to be marked as suspended, not giving them access to the organization anymore

## Description

Marking a user as suspended does the following:

1. Not allowed to be assigned texts to from the campaign edit screen
2. Cannot see any texts on the todo page
3. Cannot be assigned any texts in the message review page
4. Cannot login (will get an access denied error)

## Motivation and Context

Fixes #899 899

## How Has This Been Tested?

Tested locally for the above scenarios

## Documentation Changes

Probably needs some changes talking about suspended users, will ask Ben for help updating this

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
