### PR TITLE
fix: ensure non-null value for campaign isApproved

### DIFF
--- a/migrations/20220115111920_support-superadmin-campaign-approval.js
+++ b/migrations/20220115111920_support-superadmin-campaign-approval.js
@@ -1,7 +1,7 @@
 exports.up = function up(knex) {
   return knex.schema.raw(`
     alter table campaign
-      add column is_approved boolean default false;
+      add column is_approved boolean not null default false;
   `);
 };
 

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -1,4 +1,4 @@
-import { isNil } from "lodash/isNil";
+import isNil from "lodash/isNil";
 
 import { ExternalSyncReadinessState } from "../../api/campaign";
 import { emptyRelayPage } from "../../api/pagination";

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -1,3 +1,5 @@
+import { isNil } from "lodash/isNil";
+
 import { ExternalSyncReadinessState } from "../../api/campaign";
 import { emptyRelayPage } from "../../api/pagination";
 import { config } from "../../config";
@@ -260,7 +262,6 @@ export const resolvers = {
       "id",
       "title",
       "description",
-      "isApproved",
       "isStarted",
       "isArchived",
       // TODO: re-enable once dynamic assignment is fixed (#548)
@@ -274,6 +275,8 @@ export const resolvers = {
       "createdAt",
       "landlinesFiltered"
     ]),
+    isApproved: (campaign) =>
+      isNil(campaign.is_approved) ? false : campaign.is_approved,
     timezone: (campaign) => parseIanaZone(campaign.timezone),
     readiness: (campaign) => campaign,
     repliesStaleAfter: (campaign) => campaign.replies_stale_after_minutes,


### PR DESCRIPTION
## Description

This ensures a non-null value for the `isApproved` GraphQL property added in #1050.

## Motivation and Context

The migration in #1050 added a default of `false` for the `is_approved` column but did not set `not null` so there may still be null values in production.

## How Has This Been Tested?

TBD

## Screenshots (if appropriate):

N/A

## Documentation Changes

N/A

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
