### PR TITLE
fix: handle null campaign groups for supervolunteer role

### DIFF
--- a/src/api/campaign.ts
+++ b/src/api/campaign.ts
@@ -113,7 +113,7 @@ export interface Campaign {
   hasUnsentInitialMessages?: boolean | null;
   hasUnhandledMessages?: boolean | null;
   teams: Team[];
-  campaignGroups: CampaignGroupPage | null;
+  campaignGroups?: CampaignGroupPage | null;
   externalSystem?: ExternalSystem | null;
   creator?: User | null;
   deliverabilityStats: CampaignDeliverabilityStats;

--- a/src/api/campaign.ts
+++ b/src/api/campaign.ts
@@ -113,7 +113,7 @@ export interface Campaign {
   hasUnsentInitialMessages?: boolean | null;
   hasUnhandledMessages?: boolean | null;
   teams: Team[];
-  campaignGroups: CampaignGroupPage;
+  campaignGroups: CampaignGroupPage | null;
   externalSystem?: ExternalSystem | null;
   creator?: User | null;
   deliverabilityStats: CampaignDeliverabilityStats;
@@ -223,7 +223,7 @@ export const schema = `
     logoImageUrl: String
     editors: String
     teams: [Team]!
-    campaignGroups: CampaignGroupPage!
+    campaignGroups: CampaignGroupPage
     textingHoursStart: Int
     textingHoursEnd: Int
     isAutoassignEnabled: Boolean!

--- a/src/containers/CampaignList/CampaignListRow.tsx
+++ b/src/containers/CampaignList/CampaignListRow.tsx
@@ -108,9 +108,11 @@ export const CampaignListRow: React.FC<Props> = (props) => {
   }
 
   tags = tags.concat(teams.map(({ title }) => ({ title })));
-  tags = tags.concat(
-    campaignGroups.edges.map(({ node }) => ({ title: node.name }))
-  );
+  if (campaignGroups) {
+    tags = tags.concat(
+      campaignGroups.edges.map(({ node }) => ({ title: node.name }))
+    );
+  }
 
   const primaryText = (
     <div style={inlineStyles.chipWrapper}>

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -563,7 +563,7 @@ type Campaign {
   logoImageUrl: String
   editors: String
   teams: [Team]!
-  campaignGroups: CampaignGroupPage!
+  campaignGroups: CampaignGroupPage
   textingHoursStart: Int
   textingHoursEnd: Int
   isAutoassignEnabled: Boolean!


### PR DESCRIPTION
## Description

This fixes the campaign list page for the Supervolunteer role.

## Motivation and Context

The `campaignGroups` resolver requires at least Admin role. This means it returns `null` for Supervolunteer. The field was not previously nullable, however, so this resulted in an error and broken page.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

N/A

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
