### PR TITLE
fix: fix display of survey questions

### DIFF
--- a/src/components/AssignmentTexterSurveys.jsx
+++ b/src/components/AssignmentTexterSurveys.jsx
@@ -12,6 +12,7 @@ import Typography from "@material-ui/core/Typography";
 import ArrowDropDownIcon from "@material-ui/icons/ArrowDropDown";
 import ExpandLessIcon from "@material-ui/icons/ExpandLess";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import isEmpty from "lodash/isEmpty";
 import sample from "lodash/sample";
 import { grey50 } from "material-ui/styles/colors";
 import PropTypes from "prop-types";
@@ -141,16 +142,15 @@ class AssignmentTexterSurveys extends Component {
   render() {
     const { interactionSteps, currentInteractionStep } = this.props;
     const questions = interactionSteps.filter(
-      ({ question }) => (question.text || "") !== ""
+      ({ question }) => !isEmpty(question.text)
     );
 
-    const currentQuestion =
-      (currentInteractionStep.question.text || "") !== ""
-        ? currentInteractionStep
-        : undefined;
+    const currentQuestion = isEmpty(currentInteractionStep.question.text)
+      ? undefined
+      : currentInteractionStep;
 
     const pastQuestions = questions.filter(
-      (step) => step.id !== (currentQuestion || {}).id
+      (step) => step.id !== currentQuestion?.id
     );
 
     const { showAllQuestions } = this.state;

--- a/src/components/AssignmentTexterSurveys.jsx
+++ b/src/components/AssignmentTexterSurveys.jsx
@@ -125,6 +125,7 @@ class AssignmentTexterSurveys extends Component {
           <Select
             name={step.id}
             value={responseValue ?? ""}
+            autoWidth
             IconComponent={LargeDropDownIcon}
             onChange={(e) => this.handleSelectChange(step, e.target.value)}
           >
@@ -143,6 +144,15 @@ class AssignmentTexterSurveys extends Component {
       ({ question }) => (question.text || "") !== ""
     );
 
+    const currentQuestion =
+      (currentInteractionStep.question.text || "") !== ""
+        ? currentInteractionStep
+        : undefined;
+
+    const pastQuestions = questions.filter(
+      (step) => step.id !== (currentQuestion || {}).id
+    );
+
     const { showAllQuestions } = this.state;
     return questions.length === 0 ? null : (
       <Card style={styles.card}>
@@ -154,21 +164,19 @@ class AssignmentTexterSurveys extends Component {
           }
           style={styles.cardHeader}
           action={
-            questions.length > 1 && (
+            pastQuestions.length > 0 && (
               <IconButton onClick={this.handleExpandChange}>
-                {showAllQuestions ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                {showAllQuestions ? <ExpandMoreIcon /> : <ExpandLessIcon />}
               </IconButton>
             )
           }
         />
         <CardContent style={styles.cardContent}>
-          {currentInteractionStep && this.renderStep(currentInteractionStep)}
+          {currentQuestion && this.renderStep(currentQuestion)}
         </CardContent>
         <Collapse in={showAllQuestions}>
           <CardContent style={styles.cardContent}>
-            {questions
-              .filter((step) => step.id !== currentInteractionStep.id)
-              .map((step) => this.renderStep(step))}
+            {pastQuestions.map((step) => this.renderStep(step))}
           </CardContent>
         </Collapse>
       </Card>


### PR DESCRIPTION
## Description

This fixes conditional logic for displaying past survey questions.

It also sets the dropdown width to auto, addressing some user complaints, and makes expand/collapse icons more intuitive for vertically-expanding card.

## Motivation and Context

Previous logic did not handle the case of a single already answered survey question.

Closes #1115 .

## How Has This Been Tested?

This as been tested locally.

## Screenshots (if appropriate):

<table>
<tr>
<td>

![Screenshot_3_18_22__11_41_AM](https://user-images.githubusercontent.com/2145526/159035710-9288fe73-b94a-421b-8225-642d916fd84d.png)

</td>
<td>

![Screenshot_3_18_22__11_45_AM](https://user-images.githubusercontent.com/2145526/159035802-3ec73bf4-e724-485c-b6ca-b1d23985e0d6.png)

</td>
</tr>
</table>

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
