### PR TITLE
fix: fix permissions in script preview url resolver

### DIFF
--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -12,6 +12,7 @@ import { getDeliverabilityStats } from "./lib/campaign";
 import { symmetricEncrypt } from "./lib/crypto";
 import { formatPage } from "./lib/pagination";
 import { sqlResolvers } from "./lib/utils";
+import { getOrgFeature } from "./organization-settings";
 import { getUsers } from "./user";
 
 export function addCampaignsFilterToQuery(queryParam, campaignsFilter) {
@@ -500,11 +501,21 @@ export const resolvers = {
     },
     creator: async (campaign, _, { loaders }) =>
       campaign.creator_id ? loaders.user.load(campaign.creator_id) : null,
-    previewUrl: async (campaign, _, { user }) => {
-      const organizaitonId = await getCampaignOrganization({
-        campaignId: campaign.id
-      });
-      await accessRequired(user, organizaitonId, "ADMIN");
+    previewUrl: async (campaign, _, { user, loaders }) => {
+      const campaignId = campaign.id;
+      const organizationId = await getCampaignOrganization({ campaignId });
+      const { features } = await loaders.organization.load(organizationId);
+      const supervolAccess = getOrgFeature(
+        "scriptPreviewForSupervolunteers",
+        features
+      );
+      const requiredRole = supervolAccess ? "SUPERVOLUNTEER" : "ADMIN";
+      try {
+        await accessRequired(user, organizationId, requiredRole);
+      } catch {
+        // Return null because Message Review uses loadData() HOC which does not tolerate errors
+        return null;
+      }
       const token = symmetricEncrypt(`${campaign.id}`);
       return token;
     },

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -1,6 +1,7 @@
 import isNil from "lodash/isNil";
 
 import { ExternalSyncReadinessState } from "../../api/campaign";
+import { UserRoleType } from "../../api/organization-membership";
 import { emptyRelayPage } from "../../api/pagination";
 import { config } from "../../config";
 import { parseIanaZone } from "../../lib/datetime";
@@ -509,7 +510,9 @@ export const resolvers = {
         "scriptPreviewForSupervolunteers",
         features
       );
-      const requiredRole = supervolAccess ? "SUPERVOLUNTEER" : "ADMIN";
+      const requiredRole = supervolAccess
+        ? UserRoleType.SUPERVOLUNTEER
+        : UserRoleType.ADMIN;
       try {
         await accessRequired(user, organizationId, requiredRole);
       } catch {


### PR DESCRIPTION
## Description

Fix permission checks in resolver for `Campaign.previewUrl`.

## Motivation and Context

Message Review uses the `loadData()` HOC which does not allow for ignoring expected GraphQL errors. We must explicitly return `null` for `previewUrl` if the permissions check fails.

The permissions check also needs to look at the organization setting to determine which role is sufficient.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
