### PR TITLE
ci: replace / with - in image name

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -103,6 +103,7 @@ jobs:
           export GIT_REF=${GITHUB_REF#refs/*/}
           echo "$GIT_REF"
           export SPOKE_VERSION=${GIT_REF#"v"}
+          export SPOKE_VERSION=${SPOKE_VERSION//[\/]/-}
           echo "::set-output name=version::$SPOKE_VERSION"
 
       - name: Login to GAR


### PR DESCRIPTION
## Description

When building container images for feature branches the branch name is used for the image tag. This change replaces `/` in branch names with `-`.

## Motivation and Context

`/` is not allowed in container image tags.

## How Has This Been Tested?

This has been tested in #1128 .

## Screenshots (if appropriate):

N/A

## Documentation Changes

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
