### PR TITLE
feat: allow collapsing interaction steps

### DIFF
--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/components/InteractionStepCard.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/components/InteractionStepCard.tsx
@@ -7,9 +7,11 @@ import CardHeader from "@material-ui/core/CardHeader";
 import IconButton from "@material-ui/core/IconButton";
 import Tooltip from "@material-ui/core/Tooltip";
 import DeleteIcon from "@material-ui/icons/Delete";
+import ExpandLess from "@material-ui/icons/ExpandLess";
+import ExpandMore from "@material-ui/icons/ExpandMore";
 import HelpIconOutline from "@material-ui/icons/HelpOutline";
 import isNil from "lodash/isNil";
-import React from "react";
+import React, { useCallback, useState } from "react";
 import * as yup from "yup";
 
 import {
@@ -65,7 +67,9 @@ interface Props {
 }
 
 export const InteractionStepCard: React.FC<Props> = (props) => {
+  const [expanded, setExpanded] = useState(true);
   const stableMuiTheme = useTheme();
+
   const {
     interactionStep,
     customFields,
@@ -106,6 +110,21 @@ export const InteractionStepCard: React.FC<Props> = (props) => {
 
   const clipboardEnabled = supportsClipboard();
 
+  const handleToggleExpanded = useCallback(() => setExpanded(!expanded), [
+    expanded,
+    setExpanded
+  ]);
+
+  const handleAddResponse = useCallback(() => {
+    setExpanded(true);
+    addStepFactory(stepId)();
+  }, [setExpanded, addStepFactory, stepId]);
+
+  const handlePasteBlock = useCallback(() => {
+    setExpanded(true);
+    pasteBlockFactory(stepId)();
+  }, [setExpanded, pasteBlockFactory, stepId]);
+
   return (
     <div key={stepId}>
       <Card
@@ -122,6 +141,13 @@ export const InteractionStepCard: React.FC<Props> = (props) => {
             parentInteractionId
               ? ""
               : "Enter a script for your texter along with the question you want the texter be able to answer on behalf of the contact."
+          }
+          action={
+            childSteps?.length > 0 && (
+              <IconButton onClick={handleToggleExpanded}>
+                {expanded ? <ExpandLess /> : <ExpandMore />}
+              </IconButton>
+            )
           }
         />
         <CardActions>
@@ -228,7 +254,7 @@ export const InteractionStepCard: React.FC<Props> = (props) => {
             {...dataTest("addResponse")}
             style={{ marginBottom: "10px" }}
             disabled={disabled}
-            onClick={addStepFactory(stepId)}
+            onClick={handleAddResponse}
           >
             + Add a response
           </Button>
@@ -239,31 +265,32 @@ export const InteractionStepCard: React.FC<Props> = (props) => {
             variant="contained"
             disabled={disabled}
             style={{ marginBottom: "10px" }}
-            onClick={pasteBlockFactory(stepId)}
+            onClick={handlePasteBlock}
           >
             + Paste Block
           </Button>
         )}
-        {(childSteps ?? [])
-          .filter((is) => !is.isDeleted)
-          .map((childStep) => (
-            <InteractionStepCard
-              key={childStep.id}
-              title={`Question: ${questionText}`}
-              interactionStep={childStep}
-              customFields={customFields}
-              integrationSourced={integrationSourced}
-              availableActions={availableActions}
-              hasBlockCopied={hasBlockCopied}
-              disabled={disabled}
-              onFormChange={onFormChange}
-              onCopyBlock={onCopyBlock}
-              onRequestRootPaste={onRequestRootPaste}
-              addStepFactory={addStepFactory}
-              deleteStepFactory={deleteStepFactory}
-              pasteBlockFactory={pasteBlockFactory}
-            />
-          ))}
+        {expanded &&
+          (childSteps ?? [])
+            .filter((is) => !is.isDeleted)
+            .map((childStep) => (
+              <InteractionStepCard
+                key={childStep.id}
+                title={`Question: ${questionText}`}
+                interactionStep={childStep}
+                customFields={customFields}
+                integrationSourced={integrationSourced}
+                availableActions={availableActions}
+                hasBlockCopied={hasBlockCopied}
+                disabled={disabled}
+                onFormChange={onFormChange}
+                onCopyBlock={onCopyBlock}
+                onRequestRootPaste={onRequestRootPaste}
+                addStepFactory={addStepFactory}
+                deleteStepFactory={deleteStepFactory}
+                pasteBlockFactory={pasteBlockFactory}
+              />
+            ))}
       </div>
     </div>
   );

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/components/InteractionStepCard.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/components/InteractionStepCard.tsx
@@ -1,10 +1,14 @@
 import { useTheme } from "@material-ui/core";
+import Button from "@material-ui/core/Button";
+import Card from "@material-ui/core/Card";
+import CardActions from "@material-ui/core/CardActions";
+import CardContent from "@material-ui/core/CardContent";
+import CardHeader from "@material-ui/core/CardHeader";
+import IconButton from "@material-ui/core/IconButton";
+import Tooltip from "@material-ui/core/Tooltip";
+import DeleteIcon from "@material-ui/icons/Delete";
+import HelpIconOutline from "@material-ui/icons/HelpOutline";
 import isNil from "lodash/isNil";
-import { Card, CardActions, CardHeader, CardText } from "material-ui/Card";
-import IconButton from "material-ui/IconButton";
-import RaisedButton from "material-ui/RaisedButton";
-import DeleteIcon from "material-ui/svg-icons/action/delete";
-import HelpIconOutline from "material-ui/svg-icons/action/help-outline";
 import React from "react";
 import * as yup from "yup";
 
@@ -114,30 +118,34 @@ export const InteractionStepCard: React.FC<Props> = (props) => {
         <CardHeader
           style={styles.cardHeader}
           title={title}
-          subtitle={
+          subheader={
             parentInteractionId
               ? ""
               : "Enter a script for your texter along with the question you want the texter be able to answer on behalf of the contact."
           }
         />
         <CardActions>
-          <RaisedButton
-            label="Copy Block"
+          <Button
+            variant="contained"
             disabled={disabled || !clipboardEnabled}
             onClick={() => onCopyBlock(interactionStep)}
-          />
+          >
+            Copy Block
+          </Button>
           {hasBlockCopied && isRootStep && (
-            <RaisedButton
-              label="+ Paste Block"
+            <Button
+              variant="contained"
               disabled={disabled || !clipboardEnabled}
               onClick={onRequestRootPaste}
-            />
+            >
+              + Paste Block
+            </Button>
           )}
           {!clipboardEnabled && (
             <span>Your browser does not support clipboard actions</span>
           )}
         </CardActions>
-        <CardText>
+        <CardContent>
           <GSForm
             {...dataTest("childInteraction", !parentInteractionId)}
             schema={interactionStepSchema}
@@ -177,12 +185,11 @@ export const InteractionStepCard: React.FC<Props> = (props) => {
                   ]}
                   disabled={disabled}
                 />
-                <IconButton
-                  tooltip="An action is something that is triggered by this answer being chosen, often in an outside system"
-                  disabled={disabled}
-                >
-                  <HelpIconOutline />
-                </IconButton>
+                <Tooltip title="An action is something that is triggered by this answer being chosen, often in an outside system">
+                  <IconButton disabled={disabled}>
+                    <HelpIconOutline />
+                  </IconButton>
+                </Tooltip>
                 <div>
                   {answerActions &&
                     availableActions.filter((a) => a.name === answerActions)[0]
@@ -211,29 +218,33 @@ export const InteractionStepCard: React.FC<Props> = (props) => {
               disabled={disabled}
             />
           </GSForm>
-        </CardText>
+        </CardContent>
       </Card>
       <div style={styles.answerContainer}>
         {isAbleToAddResponse && (
-          <RaisedButton
+          <Button
             key="add"
+            variant="contained"
             {...dataTest("addResponse")}
-            label="+ Add a response"
             style={{ marginBottom: "10px" }}
             disabled={disabled}
             onClick={addStepFactory(stepId)}
-          />
+          >
+            + Add a response
+          </Button>
         )}
         {isAbleToAddResponse && hasBlockCopied && (
-          <RaisedButton
+          <Button
             key="paste"
-            label="+ Paste Block"
+            variant="contained"
             disabled={disabled}
             style={{ marginBottom: "10px" }}
             onClick={pasteBlockFactory(stepId)}
-          />
+          >
+            + Paste Block
+          </Button>
         )}
-        {childSteps
+        {(childSteps ?? [])
           .filter((is) => !is.isDeleted)
           .map((childStep) => (
             <InteractionStepCard

--- a/src/server/routes/campaign-preview.js
+++ b/src/server/routes/campaign-preview.js
@@ -46,6 +46,10 @@ const makeInteractionStepHtml = (
           : []
       )
       .concat([
+        ["i", { class: "bi bi-chevron-down" }],
+        ["i", { class: "bi bi-chevron-up" }]
+      ])
+      .concat([
         [
           "ul",
           childrenInteractionSteps.map((is) =>
@@ -55,10 +59,16 @@ const makeInteractionStepHtml = (
       ])
   );
 
+  const className =
+    childrenInteractionSteps.length === 0
+      ? "interaction-step no-children"
+      : "interaction-step";
+
   const result = [
     "li",
     {
       id: `id-${interactionStep.id}`,
+      class: className,
       style: `border-left: 5px solid ${
         colors[depth % colors.length]
       }; padding-left: 10px;`
@@ -105,20 +115,16 @@ const makeCampaignPreviewHtml = async (campaignId) => {
   ]);
 
   return h([
-    "html",
+    ["h1", `Preview for Campaign ${campaign.id}`],
+    ["h2", campaign.title],
+    ["ol", toc],
+    ["h2#script", "Script"],
+    makeInteractionStepHtml(rootInteractionStep, interactionSteps),
+    ["h2#canned-responses", "Canned Responses"],
+    makeCannedResponsesHtml(cannnedResponses),
     [
-      "body",
-      ["h1", `Preview for Campaign ${campaign.id}`],
-      ["h2", campaign.title],
-      ["ol", toc],
-      ["h2#script", "Script"],
-      makeInteractionStepHtml(rootInteractionStep, interactionSteps),
-      ["h2#canned-responses", "Canned Responses"],
-      makeCannedResponsesHtml(cannnedResponses),
-      [
-        "style",
-        `html{background-color:#fefefe}body{font-family:Open Sans,Arial;color:#454545;font-size:16px;margin:2em auto;max-width:800px;padding:1em;line-height:1.4;text-align:justify}html.contrast body{color:#050505}html.contrast blockquote{color:#11151a}html.contrast blockquote:before{color:#262626}html.contrast a{color:#0051c9}html.contrast a:visited{color:#7d013e}html.contrast span.wr{color:#800}html.contrast span.mfw{color:#4d0000}html.inverted{background-color:#010101}html.inverted body{color:#bababa}html.inverted div#contrast,html.inverted div#invmode{color:#fff;background-color:#000}html.inverted blockquote{color:#dad0c7}html.inverted blockquote:before{color:#bfbfbf}html.inverted a{color:#07a}html.inverted a:visited{color:#ac5a82}html.inverted span.wr{color:#c0392b}html.inverted span.mfw{color:#8a0000}html.inverted.contrast{background-color:#010101}html.inverted.contrast body{color:#fff}html.inverted.contrast div#contrast,html.inverted.contrast div#invmode{color:#fff;background-color:#000}html.inverted.contrast blockquote{color:#f8f6f5}html.inverted.contrast blockquote:before{color:#e5e5e5}html.inverted.contrast a{color:#07a}html.inverted.contrast a:visited{color:#ac5a82}html.inverted.contrast span.wr{color:#c0392b}html.inverted.contrast span.mfw{color:#a10000}a{color:#07a}a:visited{color:#941352}.noselect{-webkit-touch-callout:none;-webkit-user-select:none;-khtml-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}span.citneed{vertical-align:top;font-size:.7em;padding-left:.3em}small{font-size:.4em}p.st{margin-top:-1em}div.fancyPositioning div.picture-left{float:left;width:40%;overflow:hidden;margin-right:1em}div.fancyPositioning div.picture-left img{width:100%}div.fancyPositioning div.picture-left p.caption{font-size:.7em}div.fancyPositioning div.tleft{float:left;width:55%}div.fancyPositioning div.tleft p:first-child{margin-top:0}div.fancyPositioning:after{display:block;content:"";clear:both}ul li img{height:1em}blockquote{color:#456;margin-left:0;margin-top:2em;margin-bottom:2em}blockquote span{float:left;margin-left:1rem;padding-top:1rem}blockquote author{display:block;clear:both;font-size:.6em;margin-left:2.4rem;font-style:oblique}blockquote author:before{content:"- ";margin-right:1em}blockquote:before{font-family:Times New Roman,Times,Arial;color:#666;content:open-quote;font-size:2.2em;font-weight:600;float:left;margin-top:0;margin-right:.2rem;width:1.2rem}blockquote:after{content:"";display:block;clear:both}@media screen and (max-width:500px){body{text-align:left}div.fancyPositioning div.picture-left,div.fancyPositioning div.tleft{float:none;width:inherit}blockquote span{width:80%}blockquote author{padding-top:1em;width:80%;margin-left:15%}blockquote author:before{content:"";margin-right:inherit}}span.visited{color:#941352}span.visited-maroon{color:#85144b}span.wr{color:#c0392b;font-weight:600;text-decoration:underline}div#contrast{color:#000;top:10px}div#contrast,div#invmode{cursor:pointer;position:absolute;right:10px;font-size:.8em;text-decoration:underline;-webkit-touch-callout:none;-webkit-user-select:none;-khtml-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}div#invmode{color:#fff;background-color:#000;top:34px;padding:2px 5px}span.sb{color:#00e}span.sb,span.sv{cursor:not-allowed}span.sv{color:#551a8b}span.foufoufou{color:#444;font-weight:700}span.foufoufou:before{content:"";display:inline-block;width:1em;height:1em;margin-left:.2em;margin-right:.2em;background-color:#444}span.foufivfoufivfoufiv{color:#454545;font-weight:700}span.foufivfoufivfoufiv:before{content:"";display:inline-block;width:1em;height:1em;margin-left:.2em;margin-right:.2em;background-color:#454545}span.mfw{color:#730000}a.kopimi,a.kopimi img.kopimi{display:block;margin-left:auto;margin-right:auto}a.kopimi img.kopimi{height:2em}p.fakepre{font-family:monospace;font-size:.9em}`
-      ]
+      "style",
+      `html{background-color:#fefefe}body{font-family:Open Sans,Arial;color:#454545;font-size:16px;margin:2em auto;max-width:800px;padding:1em;line-height:1.4;text-align:justify}html.contrast body{color:#050505}html.contrast blockquote{color:#11151a}html.contrast blockquote:before{color:#262626}html.contrast a{color:#0051c9}html.contrast a:visited{color:#7d013e}html.contrast span.wr{color:#800}html.contrast span.mfw{color:#4d0000}html.inverted{background-color:#010101}html.inverted body{color:#bababa}html.inverted div#contrast,html.inverted div#invmode{color:#fff;background-color:#000}html.inverted blockquote{color:#dad0c7}html.inverted blockquote:before{color:#bfbfbf}html.inverted a{color:#07a}html.inverted a:visited{color:#ac5a82}html.inverted span.wr{color:#c0392b}html.inverted span.mfw{color:#8a0000}html.inverted.contrast{background-color:#010101}html.inverted.contrast body{color:#fff}html.inverted.contrast div#contrast,html.inverted.contrast div#invmode{color:#fff;background-color:#000}html.inverted.contrast blockquote{color:#f8f6f5}html.inverted.contrast blockquote:before{color:#e5e5e5}html.inverted.contrast a{color:#07a}html.inverted.contrast a:visited{color:#ac5a82}html.inverted.contrast span.wr{color:#c0392b}html.inverted.contrast span.mfw{color:#a10000}a{color:#07a}a:visited{color:#941352}.noselect{-webkit-touch-callout:none;-webkit-user-select:none;-khtml-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}span.citneed{vertical-align:top;font-size:.7em;padding-left:.3em}small{font-size:.4em}p.st{margin-top:-1em}div.fancyPositioning div.picture-left{float:left;width:40%;overflow:hidden;margin-right:1em}div.fancyPositioning div.picture-left img{width:100%}div.fancyPositioning div.picture-left p.caption{font-size:.7em}div.fancyPositioning div.tleft{float:left;width:55%}div.fancyPositioning div.tleft p:first-child{margin-top:0}div.fancyPositioning:after{display:block;content:"";clear:both}ul li img{height:1em}blockquote{color:#456;margin-left:0;margin-top:2em;margin-bottom:2em}blockquote span{float:left;margin-left:1rem;padding-top:1rem}blockquote author{display:block;clear:both;font-size:.6em;margin-left:2.4rem;font-style:oblique}blockquote author:before{content:"- ";margin-right:1em}blockquote:before{font-family:Times New Roman,Times,Arial;color:#666;content:open-quote;font-size:2.2em;font-weight:600;float:left;margin-top:0;margin-right:.2rem;width:1.2rem}blockquote:after{content:"";display:block;clear:both}@media screen and (max-width:500px){body{text-align:left}div.fancyPositioning div.picture-left,div.fancyPositioning div.tleft{float:none;width:inherit}blockquote span{width:80%}blockquote author{padding-top:1em;width:80%;margin-left:15%}blockquote author:before{content:"";margin-right:inherit}}span.visited{color:#941352}span.visited-maroon{color:#85144b}span.wr{color:#c0392b;font-weight:600;text-decoration:underline}div#contrast{color:#000;top:10px}div#contrast,div#invmode{cursor:pointer;position:absolute;right:10px;font-size:.8em;text-decoration:underline;-webkit-touch-callout:none;-webkit-user-select:none;-khtml-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}div#invmode{color:#fff;background-color:#000;top:34px;padding:2px 5px}span.sb{color:#00e}span.sb,span.sv{cursor:not-allowed}span.sv{color:#551a8b}span.foufoufou{color:#444;font-weight:700}span.foufoufou:before{content:"";display:inline-block;width:1em;height:1em;margin-left:.2em;margin-right:.2em;background-color:#444}span.foufivfoufivfoufiv{color:#454545;font-weight:700}span.foufivfoufivfoufiv:before{content:"";display:inline-block;width:1em;height:1em;margin-left:.2em;margin-right:.2em;background-color:#454545}span.mfw{color:#730000}a.kopimi,a.kopimi img.kopimi{display:block;margin-left:auto;margin-right:auto}a.kopimi img.kopimi{height:2em}p.fakepre{font-family:monospace;font-size:.9em}`
     ]
   ]);
 };
@@ -133,7 +139,43 @@ router.get("/preview/:campaignId", async (req, res) => {
     return res.status(400).send("bad token");
   }
   const campaignPreviewHtml = await makeCampaignPreviewHtml(campaignId);
-  return res.send(campaignPreviewHtml);
+  const page = `
+<html>
+  <head>
+    <title>${`Preview for Campaign ${campaignId}`}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.0/font/bootstrap-icons.css" integrity="sha384-ejwKkLla8gPP8t2u0eQyL0Q/4ItcnyveF505U0NIobD/SMsNyXrLti6CWaD0L52l" crossorigin="anonymous">
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <style>
+      li.collapsed ul {
+        display: none;
+      }
+      li.interaction-step > i.bi-chevron-down {
+        display: none;
+      }
+      li.collapsed > i.bi-chevron-up {
+        display: none;
+      }
+      li.collapsed > i.bi-chevron-down {
+        display: inline !important;
+      }
+      .no-children i.bi {
+        display: none !important;
+      }
+    </style>
+  </head>
+  <body>
+    ${campaignPreviewHtml}
+  <script>
+    $(".interaction-step").on('click', function(event){
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+      $(this).toggleClass("collapsed");
+    });
+  </script>
+  </body>
+</html>
+`;
+  return res.send(page);
 });
 
 export default router;


### PR DESCRIPTION
## Description

This adds the ability to collapse interaction step children.

## Motivation and Context

Managing large scripts can get complicated. The ability to collapse a section of it makes navigating the script much easier.

Closes #912.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<table>
<tr><td>

<img width="1435" alt="Politics_Rewired_-_Campaigns_-_15__Debug_Survey_Question_Visibility" src="https://user-images.githubusercontent.com/2145526/162338262-812c66fb-10a2-466b-9d9f-a9acacf74fae.png">

</td></tr><tr><td>

<img width="1324" alt="Politics_Rewired_-_Campaigns_-_15__Debug_Survey_Question_Visibility" src="https://user-images.githubusercontent.com/2145526/162338187-b31231e2-8ef2-410b-b5cf-1b795ccba124.png">

</td></tr>
</table>

## Documentation Changes

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
