### PR TITLE
refactor: convert conversation modal to ts, muiv4, functional components

### DIFF
--- a/libs/spoke-codegen/src/graphql/message-review.graphql
+++ b/libs/spoke-codegen/src/graphql/message-review.graphql
@@ -1,0 +1,74 @@
+fragment ConversationMessage on Message {
+  id
+  text
+  isFromContact
+  createdAt
+  userId
+  sendStatus
+}
+
+fragment ConversationInfo on Conversation {
+  texter {
+    id
+    displayName
+  }
+  contact {
+    id
+    assignmentId
+    firstName
+    lastName
+    cell
+    messageStatus
+    messages {
+      ...ConversationMessage
+    }
+    optOut {
+      cell
+    }
+    updatedAt
+  }
+  campaign {
+    id
+    title
+    previewUrl
+  }
+}
+
+query GetConversationsForMessageReview(
+  $organizationId: String!
+  $cursor: OffsetLimitCursor!
+  $contactsFilter: ContactsFilter
+  $campaignsFilter: CampaignsFilter
+  $assignmentsFilter: AssignmentsFilter
+  $tagsFilter: TagsFilter
+  $contactNameFilter: ContactNameFilter
+) {
+  conversations(
+    cursor: $cursor
+    organizationId: $organizationId
+    campaignsFilter: $campaignsFilter
+    contactsFilter: $contactsFilter
+    assignmentsFilter: $assignmentsFilter
+    tagsFilter: $tagsFilter
+    contactNameFilter: $contactNameFilter
+  ) {
+    pageInfo {
+      limit
+      offset
+      total
+    }
+    conversations {
+      ...ConversationInfo
+    }
+  }
+}
+
+mutation CloseConversation($campaignContactId: String!) {
+  editCampaignContactMessageStatus(
+    campaignContactId: $campaignContactId
+    messageStatus: "closed"
+  ) {
+    id
+    messageStatus
+  }
+}

--- a/src/api/campaign-contact.ts
+++ b/src/api/campaign-contact.ts
@@ -73,7 +73,7 @@ export const schema = `
     zip: String
     external_id: String
     customFields: JSON
-    messages: [Message]
+    messages: [Message!]!
     timezone: String
     location: Location
     optOut: OptOut

--- a/src/components/IncomingMessageList/ConversationPreviewModal.tsx
+++ b/src/components/IncomingMessageList/ConversationPreviewModal.tsx
@@ -5,6 +5,7 @@ import Paper from "@material-ui/core/Paper";
 import ChevronLeft from "@material-ui/icons/ChevronLeft";
 import ChevronRight from "@material-ui/icons/ChevronRight";
 import CloseIcon from "@material-ui/icons/Close";
+import { ConversationInfoFragment } from "@spoke/spoke-codegen";
 import { css, StyleSheet } from "aphrodite";
 import React from "react";
 
@@ -12,7 +13,7 @@ import MessageColumn from "./MessageColumn";
 import SurveyColumn from "./SurveyColumn";
 
 interface ConversationPreviewHeaderProps {
-  campaignTitle: string;
+  campaignTitle?: string;
   onRequestClose: () => Promise<void> | void;
 }
 
@@ -54,7 +55,7 @@ const columnStyles = StyleSheet.create({
 
 interface ConversationPreviewBodyProps {
   organizationId: string;
-  conversation: any;
+  conversation: ConversationInfoFragment;
 }
 
 const ConversationPreviewBody: React.FC<ConversationPreviewBodyProps> = ({
@@ -78,14 +79,9 @@ const ConversationPreviewBody: React.FC<ConversationPreviewBodyProps> = ({
   </div>
 );
 
-ConversationPreviewBody.propTypes = {
-  conversation: PropTypes.object.isRequired,
-  organizationId: PropTypes.string.isRequired
-};
-
 interface ConversationPreviewModalProps {
   organizationId: string;
-  conversation: any;
+  conversation: ConversationInfoFragment;
   navigation?: {
     previous: boolean;
     next: boolean;
@@ -122,7 +118,7 @@ const ConversationPreviewModal: React.FC<ConversationPreviewModalProps> = (
       onClick={(e) => e.stopPropagation()}
     >
       <ConversationPreviewHeader
-        campaignTitle={conversation && conversation.campaign.title}
+        campaignTitle={conversation.campaign?.title ?? undefined}
         onRequestClose={onRequestClose}
       />
       <div style={{ flex: "1 1 auto", display: "flex" }}>

--- a/src/components/IncomingMessageList/ConversationPreviewModal.tsx
+++ b/src/components/IncomingMessageList/ConversationPreviewModal.tsx
@@ -118,7 +118,7 @@ const ConversationPreviewModal: React.FC<ConversationPreviewModalProps> = (
       onClick={(e) => e.stopPropagation()}
     >
       <ConversationPreviewHeader
-        campaignTitle={conversation.campaign?.title ?? undefined}
+        campaignTitle={conversation?.campaign?.title ?? undefined}
         onRequestClose={onRequestClose}
       />
       <div style={{ flex: "1 1 auto", display: "flex" }}>

--- a/src/components/IncomingMessageList/ConversationPreviewModal.tsx
+++ b/src/components/IncomingMessageList/ConversationPreviewModal.tsx
@@ -1,12 +1,11 @@
+import Button from "@material-ui/core/Button";
+import CardActions from "@material-ui/core/CardActions";
+import IconButton from "@material-ui/core/IconButton";
+import Paper from "@material-ui/core/Paper";
+import ChevronLeft from "@material-ui/icons/ChevronLeft";
+import ChevronRight from "@material-ui/icons/ChevronRight";
+import CloseIcon from "@material-ui/icons/Close";
 import { css, StyleSheet } from "aphrodite";
-import { CardActions } from "material-ui/Card";
-import FlatButton from "material-ui/FlatButton";
-import IconButton from "material-ui/IconButton";
-import Paper from "material-ui/Paper";
-import ChevronLeft from "material-ui/svg-icons/navigation/chevron-left";
-import ChevronRight from "material-ui/svg-icons/navigation/chevron-right";
-import CloseIcon from "material-ui/svg-icons/navigation/close";
-import PropTypes from "prop-types";
 import React from "react";
 
 import MessageColumn from "./MessageColumn";
@@ -34,12 +33,9 @@ const ConversationPreviewHeader: React.FC<ConversationPreviewHeaderProps> = ({
         : "Conversation Review"}
     </h2>
     <span style={{ flex: "1" }} />
-    <FlatButton
-      label="Close"
-      labelPosition="before"
-      icon={<CloseIcon />}
-      onClick={onRequestClose}
-    />
+    <Button endIcon={<CloseIcon />} onClick={onRequestClose}>
+      Close
+    </Button>
   </div>
 );
 
@@ -121,7 +117,7 @@ const ConversationPreviewModal: React.FC<ConversationPreviewModalProps> = (
         right: "20px",
         bottom: "20px",
         left: "20px",
-        zIndex: "1000"
+        zIndex: 1000
       }}
       onClick={(e) => e.stopPropagation()}
     >

--- a/src/components/IncomingMessageList/ConversationPreviewModal.tsx
+++ b/src/components/IncomingMessageList/ConversationPreviewModal.tsx
@@ -12,7 +12,15 @@ import React from "react";
 import MessageColumn from "./MessageColumn";
 import SurveyColumn from "./SurveyColumn";
 
-const ConversationPreviewHeader = ({ campaignTitle, onRequestClose }) => (
+interface ConversationPreviewHeaderProps {
+  campaignTitle: string;
+  onRequestClose: () => Promise<void> | void;
+}
+
+const ConversationPreviewHeader: React.FC<ConversationPreviewHeaderProps> = ({
+  campaignTitle,
+  onRequestClose
+}) => (
   <div
     style={{
       display: "flex",
@@ -48,7 +56,15 @@ const columnStyles = StyleSheet.create({
   }
 });
 
-const ConversationPreviewBody = ({ conversation, organizationId }) => (
+interface ConversationPreviewBodyProps {
+  organizationId: string;
+  conversation: any;
+}
+
+const ConversationPreviewBody: React.FC<ConversationPreviewBodyProps> = ({
+  conversation,
+  organizationId
+}) => (
   <div className={css(columnStyles.container)}>
     <div className={css(columnStyles.column)}>
       <MessageColumn
@@ -71,13 +87,27 @@ ConversationPreviewBody.propTypes = {
   organizationId: PropTypes.string.isRequired
 };
 
-const ConversationPreviewModal = (props) => {
+interface ConversationPreviewModalProps {
+  organizationId: string;
+  conversation: any;
+  navigation?: {
+    previous: boolean;
+    next: boolean;
+  };
+  onRequestPrevious: () => Promise<void> | void;
+  onRequestNext: () => Promise<void> | void;
+  onRequestClose: () => Promise<void> | void;
+}
+
+const ConversationPreviewModal: React.FC<ConversationPreviewModalProps> = (
+  props
+) => {
   const {
     conversation,
-    navigation,
-    onRequestPrevious,
-    onRequestNext,
-    onRequestClose
+    navigation = { previous: false, next: false },
+    onRequestPrevious = () => {},
+    onRequestNext = () => {},
+    onRequestClose = () => {}
   } = props;
   const isOpen = conversation !== undefined;
 
@@ -118,25 +148,6 @@ const ConversationPreviewModal = (props) => {
       </CardActions>
     </Paper>
   );
-};
-
-ConversationPreviewModal.defaultProps = {
-  navigation: { previous: false, next: false },
-  onRequestPrevious: () => {},
-  onRequestNext: () => {},
-  onRequestClose: () => {}
-};
-
-ConversationPreviewModal.propTypes = {
-  organizationId: PropTypes.string.isRequired,
-  conversation: PropTypes.object,
-  navigation: PropTypes.shape({
-    previous: PropTypes.bool.isRequired,
-    next: PropTypes.bool.isRequired
-  }),
-  onRequestPrevious: PropTypes.func,
-  onRequestNext: PropTypes.func,
-  onRequestClose: PropTypes.func
 };
 
 export default ConversationPreviewModal;

--- a/src/components/IncomingMessageList/ConversationPreviewModal.tsx
+++ b/src/components/IncomingMessageList/ConversationPreviewModal.tsx
@@ -81,7 +81,7 @@ const ConversationPreviewBody: React.FC<ConversationPreviewBodyProps> = ({
 
 interface ConversationPreviewModalProps {
   organizationId: string;
-  conversation: ConversationInfoFragment;
+  conversation?: ConversationInfoFragment;
   navigation?: {
     previous: boolean;
     next: boolean;

--- a/src/components/IncomingMessageList/MessageColumn/index.tsx
+++ b/src/components/IncomingMessageList/MessageColumn/index.tsx
@@ -29,6 +29,7 @@ const MessageColumn: React.FC<Props> = (props) => {
   const [isOptedOut, setIsOptedOut] = useState(
     !isNil(conversation.contact.optOut?.cell)
   );
+  // TODO: use apollo client cache rather than state to manage changes to messages list
   const [messages, setMessages] = useState<ConversationMessageFragment[]>([]);
 
   useEffect(() => {

--- a/src/components/IncomingMessageList/MessageColumn/index.tsx
+++ b/src/components/IncomingMessageList/MessageColumn/index.tsx
@@ -1,7 +1,10 @@
-import React, { Component } from "react";
+import {
+  ConversationInfoFragment,
+  ConversationMessageFragment
+} from "@spoke/spoke-codegen";
+import isNil from "lodash/isNil";
+import React, { useEffect, useState } from "react";
 
-import { Conversation } from "../../../api/conversations";
-import { Message } from "../../../api/message";
 import MessageList from "./MessageList";
 import MessageOptOut from "./MessageOptOut";
 import MessageResponse from "./MessageResponse";
@@ -16,61 +19,39 @@ const styles: Record<string, React.CSSProperties> = {
 
 interface Props {
   organizationId: string;
-  conversation: Conversation;
+  conversation: ConversationInfoFragment;
 }
 
-interface State {
-  isOptedOut: boolean;
-  messages: Message[];
-}
+const MessageColumn: React.FC<Props> = (props) => {
+  const { organizationId, conversation } = props;
+  const { contact } = conversation;
 
-class MessageColumn extends Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
+  const [isOptedOut, setIsOptedOut] = useState(
+    !isNil(conversation.contact.optOut?.cell)
+  );
+  const [messages, setMessages] = useState<ConversationMessageFragment[]>([]);
 
-    const { conversation } = props;
-    const isOptedOut =
-      conversation.contact.optOut && !!conversation.contact.optOut.cell;
-    this.state = {
-      messages: conversation.contact.messages,
-      isOptedOut
-    };
-  }
+  useEffect(() => {
+    setMessages(conversation.contact.messages);
+  }, [setMessages]);
 
-  messagesChanged = (messages: Message[]) => {
-    this.setState({ messages });
-  };
-
-  optOutChanged = (isOptedOut: boolean) => {
-    this.setState({ isOptedOut });
-  };
-
-  render() {
-    const { messages, isOptedOut } = this.state;
-    const { conversation } = this.props;
-    const { contact } = conversation;
-
-    return (
-      <div style={styles.container}>
-        <h4>Messages</h4>
-        <MessageList
-          messages={messages}
-          organizationId={this.props.organizationId}
+  return (
+    <div style={styles.container}>
+      <h4>Messages</h4>
+      <MessageList messages={messages} organizationId={organizationId} />
+      {!isOptedOut && (
+        <MessageResponse
+          conversation={conversation}
+          messagesChanged={setMessages}
         />
-        {!isOptedOut && (
-          <MessageResponse
-            conversation={conversation}
-            messagesChanged={this.messagesChanged}
-          />
-        )}
-        <MessageOptOut
-          contact={contact}
-          isOptedOut={isOptedOut}
-          optOutChanged={this.optOutChanged}
-        />
-      </div>
-    );
-  }
-}
+      )}
+      <MessageOptOut
+        contact={contact}
+        isOptedOut={isOptedOut}
+        optOutChanged={setIsOptedOut}
+      />
+    </div>
+  );
+};
 
 export default MessageColumn;

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -800,7 +800,7 @@ type CampaignContact {
   zip: String
   external_id: String
   customFields: JSON
-  messages: [Message]
+  messages: [Message!]!
   timezone: String
   location: Location
   optOut: OptOut


### PR DESCRIPTION
## Description

This updates the conversation modal to:
- be fully typescript
- use material ui v4 components
- use functional components and hooks over stateful class components

## Motivation and Context

All three of these are goals for the entire codebase.

This also serves as the foundation for additional work on message review.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
