### PR TITLE
feat: allow navigation to campaign stats page from campaign edit page

### DIFF
--- a/src/components/CampaignNavigation.tsx
+++ b/src/components/CampaignNavigation.tsx
@@ -1,6 +1,5 @@
 import Button from "@material-ui/core/Button";
 import ButtonGroup from "@material-ui/core/ButtonGroup";
-import { css, StyleSheet } from "aphrodite";
 import React from "react";
 
 import { useGetCampaignNavigationQuery } from "../../libs/spoke-codegen/src";
@@ -17,16 +16,6 @@ interface Props {
   };
 }
 
-const styles = StyleSheet.create({
-  buttonContainer: {
-    display: "flex",
-    justifyContent: "flex-end",
-    paddingTop: 20,
-    paddingBottom: 20,
-    flexWrap: "wrap"
-  }
-});
-
 const CampaignNavigation: React.FC<Props> = (props) => {
   const { data, loading } = useGetCampaignNavigationQuery({
     variables: { campaignId: props.campaignId }
@@ -34,7 +23,7 @@ const CampaignNavigation: React.FC<Props> = (props) => {
 
   if (loading) {
     return (
-      <div className={css(styles.buttonContainer)}>
+      <div>
         <ButtonGroup disableElevation variant="contained" color="primary">
           <Button disabled>Previous</Button>
           <Button disabled>Next</Button>
@@ -45,7 +34,7 @@ const CampaignNavigation: React.FC<Props> = (props) => {
   const campaignNavigation = data?.campaignNavigation;
 
   return (
-    <div className={css(styles.buttonContainer)}>
+    <div>
       <ButtonGroup disableElevation variant="contained" color="primary">
         <Button
           disabled={!campaignNavigation?.prevCampaignId}

--- a/src/containers/AdminCampaignEdit/index.jsx
+++ b/src/containers/AdminCampaignEdit/index.jsx
@@ -751,8 +751,8 @@ class AdminCampaignEdit extends React.Component {
 
   handleNavigateToStats = () => {
     const { organizationId, campaignId } = this.props.match.params;
-    const editUrl = `/admin/${organizationId}/campaigns/${campaignId}`;
-    this.props.history.push(editUrl);
+    const statsUrl = `/admin/${organizationId}/campaigns/${campaignId}`;
+    this.props.history.push(statsUrl);
   };
 
   render() {

--- a/src/containers/AdminCampaignEdit/index.jsx
+++ b/src/containers/AdminCampaignEdit/index.jsx
@@ -3,6 +3,7 @@ import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
 import DialogTitle from "@material-ui/core/DialogTitle";
+import Grid from "@material-ui/core/Grid";
 import { withTheme } from "@material-ui/core/styles";
 import isEqual from "lodash/isEqual";
 import pick from "lodash/pick";
@@ -640,11 +641,24 @@ class AdminCampaignEdit extends React.Component {
           fontSize: 16
         }}
       >
-        <CampaignNavigation
-          prevCampaignClicked={this.prevCampaignClicked}
-          nextCampaignClicked={this.nextCampaignClicked}
-          campaignId={this.props.campaignData.campaign.id}
-        />
+        <Grid container>
+          <Grid item xs={4}>
+            <RaisedButton
+              style={{ marginTop: 15 }}
+              onClick={this.handleNavigateToStats}
+            >
+              Details
+            </RaisedButton>
+          </Grid>
+          <Grid item xs={4} />
+          <Grid item xs={4}>
+            <CampaignNavigation
+              prevCampaignClicked={this.prevCampaignClicked}
+              nextCampaignClicked={this.nextCampaignClicked}
+              campaignId={this.props.campaignData.campaign.id}
+            />
+          </Grid>
+        </Grid>
         <Divider style={{ marginBottom: 20 }} />
         {title && <h1> {title} </h1>}
         {this.state.startingCampaign ? (
@@ -737,6 +751,12 @@ class AdminCampaignEdit extends React.Component {
 
   handleExpandChange = (sectionIndex) => (isExpended) =>
     this.onExpandChange(sectionIndex, isExpended);
+
+  handleNavigateToStats = () => {
+    const { organizationId, campaignId } = this.props.match.params;
+    const editUrl = `/admin/${organizationId}/campaigns/${campaignId}`;
+    this.props.history.push(editUrl);
+  };
 
   render() {
     const sections = this.sections();

--- a/src/containers/AdminCampaignEdit/index.jsx
+++ b/src/containers/AdminCampaignEdit/index.jsx
@@ -642,18 +642,13 @@ class AdminCampaignEdit extends React.Component {
           fontSize: 16
         }}
       >
-        <Grid container>
-          <Grid item xs={4}>
-            <Button
-              variant="contained"
-              style={{ marginTop: 20 }}
-              onClick={this.handleNavigateToStats}
-            >
+        <Grid container justify="space-between">
+          <Grid item>
+            <Button variant="contained" onClick={this.handleNavigateToStats}>
               Details
             </Button>
           </Grid>
-          <Grid item xs={4} />
-          <Grid item xs={4}>
+          <Grid item>
             <CampaignNavigation
               prevCampaignClicked={this.prevCampaignClicked}
               nextCampaignClicked={this.nextCampaignClicked}
@@ -661,7 +656,7 @@ class AdminCampaignEdit extends React.Component {
             />
           </Grid>
         </Grid>
-        <Divider style={{ marginBottom: 20 }} />
+        <Divider style={{ marginTop: 20, marginBottom: 20 }} />
         {title && <h1> {title} </h1>}
         {this.state.startingCampaign ? (
           <div style={{ color: theme.colors.gray }}>

--- a/src/containers/AdminCampaignEdit/index.jsx
+++ b/src/containers/AdminCampaignEdit/index.jsx
@@ -1,3 +1,4 @@
+import Button from "@material-ui/core/Button";
 import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
@@ -643,12 +644,13 @@ class AdminCampaignEdit extends React.Component {
       >
         <Grid container>
           <Grid item xs={4}>
-            <RaisedButton
-              style={{ marginTop: 15 }}
+            <Button
+              variant="contained"
+              style={{ marginTop: 20 }}
               onClick={this.handleNavigateToStats}
             >
               Details
-            </RaisedButton>
+            </Button>
           </Grid>
           <Grid item xs={4} />
           <Grid item xs={4}>

--- a/src/containers/AdminCampaignStats/index.jsx
+++ b/src/containers/AdminCampaignStats/index.jsx
@@ -1,4 +1,5 @@
 import { gql } from "@apollo/client";
+import Grid from "@material-ui/core/Grid";
 import { css, StyleSheet } from "aphrodite";
 import Divider from "material-ui/Divider";
 import RaisedButton from "material-ui/RaisedButton";
@@ -180,12 +181,16 @@ class AdminCampaignStats extends React.Component {
         <Helmet>
           <title>{newTitle}</title>
         </Helmet>
-        <CampaignNavigation
-          prevCampaignClicked={this.prevCampaignClicked}
-          nextCampaignClicked={this.nextCampaignClicked}
-          campaignId={campaign.id}
-        />
-        <Divider style={{ marginBottom: 20 }} />
+        <Grid container justify="flex-end">
+          <Grid item>
+            <CampaignNavigation
+              prevCampaignClicked={this.prevCampaignClicked}
+              nextCampaignClicked={this.nextCampaignClicked}
+              campaignId={campaign.id}
+            />
+          </Grid>
+        </Grid>
+        <Divider style={{ marginTop: 20, marginBottom: 20 }} />
         <div className={css(styles.container)}>
           {campaign.isArchived ? (
             <div className={css(styles.archivedBanner)}>


### PR DESCRIPTION
## Description
This adds a button to the campaign edit page that allows navigation to the campaign stats page.

## Motivation and Context
To navigate to the campaign stats page from the campaign edit page, users must currently edit the url directly (ex. admin/1/campaigns/1/edit → admin/1/campaigns/1).

## How Has This Been Tested?
This has been tested locally.

## Screenshots (if appropriate):
![Screenshot 2022-04-08 210514](https://user-images.githubusercontent.com/76596635/162550598-d4e7b9a9-71a1-4278-b107-144703218ec1.png)

## Documentation Changes

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
