### PR TITLE
build: use node compatible with v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "engines": {
     "npm": "please-use-yarn",
     "yarn": ">= 1.19.1",
-    "node": ">= 16.14.0"
+    "node": "^16.14.0"
   },
   "scripts": {
     "preinstall": "node -e \"if(process.env.npm_execpath.indexOf('yarn') === -1) throw new Error('spoke must be installed with Yarn: https://yarnpkg.com/')\"",


### PR DESCRIPTION
## Description
Require Node compatible with v16.

## Motivation and Context
#1097 updates package.json to allow Node versions greater than v16 LTS. However, we are still using packages that rely on deprecated methods, which produces errors if using current release (v17) in local development. Additionally, we would expect similar errors if using v18 when it is released (soon) and later becomes LTS.

## How Has This Been Tested?
This has been tested locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
