### PR TITLE
feat: add contact name and campaign title to message review

### DIFF
--- a/src/api/campaign-contact.ts
+++ b/src/api/campaign-contact.ts
@@ -66,10 +66,10 @@ export const schema = `
   }
 
   type CampaignContact {
-    id: ID
-    firstName: String
-    lastName: String
-    cell: Phone
+    id: ID!
+    firstName: String!
+    lastName: String!
+    cell: Phone!
     zip: String
     external_id: String
     customFields: JSON
@@ -77,13 +77,13 @@ export const schema = `
     timezone: String
     location: Location
     optOut: OptOut
-    campaign: Campaign
-    questionResponseValues: [AnswerOption]
-    questionResponses: [AnswerOption]
-    interactionSteps: [InteractionStep]
-    messageStatus: String
+    campaign: Campaign!
+    questionResponseValues: [AnswerOption!]!
+    questionResponses: [AnswerOption!]!
+    interactionSteps: [InteractionStep!]!
+    messageStatus: String!
     assignmentId: String
-    updatedAt: Date
+    updatedAt: Date!
 
     contactTags: [Tag]
   }

--- a/src/components/IncomingMessageList/ConversationPreviewModal.tsx
+++ b/src/components/IncomingMessageList/ConversationPreviewModal.tsx
@@ -74,17 +74,18 @@ const ConversationPreviewModal: React.FC<ConversationPreviewModalProps> = (
     onRequestNext = () => {},
     onRequestClose = () => {}
   } = props;
-  const isOpen = conversation !== undefined;
 
-  const { firstName, lastName } = conversation?.contact ?? {};
+  if (!conversation) return null;
+
+  const { firstName, lastName } = conversation.contact;
   const title = `Conversation Review: ${firstName} ${lastName}`;
-  const { id: campaignId, title: campaignTitle } = conversation?.campaign ?? {};
+  const { id: campaignId, title: campaignTitle } = conversation.campaign;
   const subheader = `Campaign ${campaignId}: ${campaignTitle}`;
 
   return (
     <Paper
       style={{
-        display: isOpen ? "flex" : "none",
+        display: "flex",
         flexDirection: "column",
         position: "fixed",
         top: "20px",
@@ -105,13 +106,11 @@ const ConversationPreviewModal: React.FC<ConversationPreviewModalProps> = (
         }
       />
       <div style={{ flex: "1 1 auto", display: "flex" }}>
-        {isOpen && (
-          <ConversationPreviewBody
-            key={conversation.contact.id}
-            conversation={conversation}
-            organizationId={props.organizationId}
-          />
-        )}
+        <ConversationPreviewBody
+          key={conversation.contact.id}
+          conversation={conversation}
+          organizationId={props.organizationId}
+        />
       </div>
       <CardActions>
         <IconButton disabled={!navigation.previous} onClick={onRequestPrevious}>

--- a/src/components/IncomingMessageList/ConversationPreviewModal.tsx
+++ b/src/components/IncomingMessageList/ConversationPreviewModal.tsx
@@ -1,5 +1,6 @@
 import Button from "@material-ui/core/Button";
 import CardActions from "@material-ui/core/CardActions";
+import CardHeader from "@material-ui/core/CardHeader";
 import IconButton from "@material-ui/core/IconButton";
 import Paper from "@material-ui/core/Paper";
 import ChevronLeft from "@material-ui/icons/ChevronLeft";
@@ -11,34 +12,6 @@ import React from "react";
 
 import MessageColumn from "./MessageColumn";
 import SurveyColumn from "./SurveyColumn";
-
-interface ConversationPreviewHeaderProps {
-  campaignTitle?: string;
-  onRequestClose: () => Promise<void> | void;
-}
-
-const ConversationPreviewHeader: React.FC<ConversationPreviewHeaderProps> = ({
-  campaignTitle,
-  onRequestClose
-}) => (
-  <div
-    style={{
-      display: "flex",
-      alignItems: "baseline",
-      padding: "0 10px"
-    }}
-  >
-    <h2>
-      {campaignTitle
-        ? `Conversation Review: ${campaignTitle}`
-        : "Conversation Review"}
-    </h2>
-    <span style={{ flex: "1" }} />
-    <Button endIcon={<CloseIcon />} onClick={onRequestClose}>
-      Close
-    </Button>
-  </div>
-);
 
 const columnStyles = StyleSheet.create({
   container: {
@@ -103,6 +76,11 @@ const ConversationPreviewModal: React.FC<ConversationPreviewModalProps> = (
   } = props;
   const isOpen = conversation !== undefined;
 
+  const { firstName, lastName } = conversation.contact;
+  const title = `Conversation Review: ${firstName} ${lastName}`;
+  const { id: campaignId, title: campaignTitle } = conversation.campaign;
+  const subheader = `Campaign ${campaignId}: ${campaignTitle}`;
+
   return (
     <Paper
       style={{
@@ -117,9 +95,14 @@ const ConversationPreviewModal: React.FC<ConversationPreviewModalProps> = (
       }}
       onClick={(e) => e.stopPropagation()}
     >
-      <ConversationPreviewHeader
-        campaignTitle={conversation?.campaign?.title ?? undefined}
-        onRequestClose={onRequestClose}
+      <CardHeader
+        title={title}
+        subheader={subheader}
+        action={
+          <Button endIcon={<CloseIcon />} onClick={onRequestClose}>
+            Close
+          </Button>
+        }
       />
       <div style={{ flex: "1 1 auto", display: "flex" }}>
         {isOpen && (

--- a/src/components/IncomingMessageList/ConversationPreviewModal.tsx
+++ b/src/components/IncomingMessageList/ConversationPreviewModal.tsx
@@ -76,9 +76,9 @@ const ConversationPreviewModal: React.FC<ConversationPreviewModalProps> = (
   } = props;
   const isOpen = conversation !== undefined;
 
-  const { firstName, lastName } = conversation.contact;
+  const { firstName, lastName } = conversation?.contact ?? {};
   const title = `Conversation Review: ${firstName} ${lastName}`;
-  const { id: campaignId, title: campaignTitle } = conversation.campaign;
+  const { id: campaignId, title: campaignTitle } = conversation?.campaign ?? {};
   const subheader = `Campaign ${campaignId}: ${campaignTitle}`;
 
   return (

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -793,10 +793,10 @@ input ContactNameFilter {
 }
 
 type CampaignContact {
-  id: ID
-  firstName: String
-  lastName: String
-  cell: Phone
+  id: ID!
+  firstName: String!
+  lastName: String!
+  cell: Phone!
   zip: String
   external_id: String
   customFields: JSON
@@ -804,13 +804,13 @@ type CampaignContact {
   timezone: String
   location: Location
   optOut: OptOut
-  campaign: Campaign
-  questionResponseValues: [AnswerOption]
-  questionResponses: [AnswerOption]
-  interactionSteps: [InteractionStep]
-  messageStatus: String
+  campaign: Campaign!
+  questionResponseValues: [AnswerOption!]!
+  questionResponses: [AnswerOption!]!
+  interactionSteps: [InteractionStep!]!
+  messageStatus: String!
   assignmentId: String
-  updatedAt: Date
+  updatedAt: Date!
 
   contactTags: [Tag]
 }


### PR DESCRIPTION
## Description

Adds contact's name and campaign title to the message review conversation modal.

## Motivation and Context

This is important information when reviewing conversations.

Closes #831.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<table><tr><td>

<img width="1419" alt="Screen_Shot_2022-04-08_at_9_09_10_AM" src="https://user-images.githubusercontent.com/2145526/162589297-de2b650e-0b0d-484c-a231-1d4975efcc88.png">

</td></tr></table>

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
