### PR TITLE
fix: remove header element styling from interaction step titles

### DIFF
--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/components/InteractionStepCard.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/components/InteractionStepCard.tsx
@@ -136,6 +136,8 @@ export const InteractionStepCard: React.FC<Props> = (props) => {
       >
         <CardHeader
           style={styles.cardHeader}
+          titleTypographyProps={{ variant: "body1" }}
+          subheaderTypographyProps={{ variant: "body2" }}
           title={title}
           subheader={
             parentInteractionId


### PR DESCRIPTION
## Description

Restore the previous styling to interaction step card headers.

## Motivation and Context

#1137 updated the card components to material ui v4, changing the typography of the header in an undesirable way.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

![Politics_Rewired_-_Campaigns_-_22__New_Campaign](https://user-images.githubusercontent.com/2145526/163566109-fbec8029-075c-492f-8c72-735e71ad68f8.png)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
