### PR TITLE
fix: fix fetching canned responses by texters

### DIFF
--- a/libs/spoke-codegen/src/graphql/canned-responses.graphql
+++ b/libs/spoke-codegen/src/graphql/canned-responses.graphql
@@ -12,3 +12,12 @@ query GetCampaignCannedResponses($campaignId: String!) {
     }
   }
 }
+
+query GetAssignmentCannedResponses($assignmentId: String!) {
+  assignment(id: $assignmentId) {
+    id
+    cannedResponses: campaignCannedResponses {
+      ...CannedResponseInfo
+    }
+  }
+}

--- a/src/api/assignment.ts
+++ b/src/api/assignment.ts
@@ -26,13 +26,13 @@ export const schema = `
   }
 
   type Assignment {
-    id: ID
-    texter: User
-    campaign: Campaign
-    contacts(contactsFilter: ContactsFilter): [CampaignContact]
-    contactsCount(contactsFilter: ContactsFilter): Int
-    userCannedResponses: [CannedResponse]
-    campaignCannedResponses: [CannedResponse]
+    id: ID!
+    texter: User!
+    campaign: Campaign!
+    contacts(contactsFilter: ContactsFilter): [CampaignContact!]!
+    contactsCount(contactsFilter: ContactsFilter): Int!
+    userCannedResponses: [CannedResponse!]!
+    campaignCannedResponses: [CannedResponse!]!
     maxContacts: Int
   }
 `;

--- a/src/components/CannedResponseMenu/hooks.ts
+++ b/src/components/CannedResponseMenu/hooks.ts
@@ -1,0 +1,37 @@
+/* eslint-disable import/prefer-default-export */
+import {
+  useGetAssignmentCannedResponsesQuery,
+  useGetCampaignCannedResponsesQuery
+} from "@spoke/spoke-codegen";
+
+import type { AssignmentIdOrCampaignId } from "./types";
+
+export const useGetCannedResponses = (ids: AssignmentIdOrCampaignId) => {
+  const assignmentId = "assignmentId" in ids ? ids.assignmentId : undefined;
+  const campaignId = "campaignId" in ids ? ids.campaignId : undefined;
+  const {
+    data: assignmentData,
+    loading: assignmentLoading,
+    error: assignmentError
+  } = useGetAssignmentCannedResponsesQuery({
+    variables: { assignmentId: assignmentId! },
+    skip: assignmentId === undefined
+  });
+  const {
+    data: campaignData,
+    loading: campaignLoading,
+    error: campaignError
+  } = useGetCampaignCannedResponsesQuery({
+    variables: { campaignId: campaignId! },
+    skip: campaignId === undefined
+  });
+
+  const cannedResponses = assignmentId
+    ? assignmentData?.assignment?.cannedResponses
+    : campaignData?.campaign?.cannedResponses;
+  const data = { cannedResponses };
+  const loading = assignmentId ? assignmentLoading : campaignLoading;
+  const error = assignmentId ? assignmentError : campaignError;
+
+  return { data, loading, error };
+};

--- a/src/components/CannedResponseMenu/index.tsx
+++ b/src/components/CannedResponseMenu/index.tsx
@@ -1,34 +1,39 @@
 import ListItemText from "@material-ui/core/ListItemText";
 import Menu from "@material-ui/core/Menu";
 import MenuItem from "@material-ui/core/MenuItem";
-import { useGetCampaignCannedResponsesQuery } from "@spoke/spoke-codegen";
 import React from "react";
 
-interface CannedResponseMenuProps {
+import { useGetCannedResponses } from "./hooks";
+import type { AssignmentIdOrCampaignId } from "./types";
+
+type CannedResponseMenuProps = {
   anchorEl?: Element;
-  campaignId: string;
   onSelectCannedResponse?: (script: string) => Promise<void> | void;
   onRequestClose?: () => Promise<void> | void;
-}
+} & AssignmentIdOrCampaignId;
 
 const CannedResponseMenu: React.FC<CannedResponseMenuProps> = (props) => {
-  const { campaignId, anchorEl } = props;
-  const { data, loading, error } = useGetCampaignCannedResponsesQuery({
-    variables: { campaignId: campaignId! },
-    skip: campaignId === undefined
-  });
+  const {
+    anchorEl,
+    onSelectCannedResponse,
+    onRequestClose,
+    children: _children,
+    ...ids
+  } = props;
+
+  const { data, loading, error } = useGetCannedResponses(ids);
 
   const handleOnClickFactory = (script: string) => () =>
-    props.onSelectCannedResponse?.(script);
+    onSelectCannedResponse?.(script);
 
-  const cannedResponses = data?.campaign?.cannedResponses ?? [];
+  const cannedResponses = data?.cannedResponses ?? [];
 
   return (
     <Menu
       anchorEl={anchorEl}
       keepMounted
       open={Boolean(anchorEl)}
-      onClose={props?.onRequestClose}
+      onClose={onRequestClose}
     >
       {loading && (
         <MenuItem disabled>

--- a/src/components/CannedResponseMenu/types.ts
+++ b/src/components/CannedResponseMenu/types.ts
@@ -1,0 +1,3 @@
+export type AssignmentIdOrCampaignId =
+  | { assignmentId: string }
+  | { campaignId: string };

--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -733,11 +733,11 @@ export class AssignmentTexterContact extends React.Component {
   }
 
   renderCannedResponsePopover() {
-    const { campaign } = this.props;
+    const { assignment } = this.props;
 
     return (
       <CannedResponseMenu
-        campaignId={campaign.id}
+        assignmentId={assignment.id}
         anchorEl={this.state.responsePopoverAnchorEl}
         onSelectCannedResponse={this.handleCannedResponseChange}
         onRequestClose={this.handleClosePopover}

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -667,13 +667,13 @@ input AssignmentsFilter {
 }
 
 type Assignment {
-  id: ID
-  texter: User
-  campaign: Campaign
-  contacts(contactsFilter: ContactsFilter): [CampaignContact]
-  contactsCount(contactsFilter: ContactsFilter): Int
-  userCannedResponses: [CannedResponse]
-  campaignCannedResponses: [CannedResponse]
+  id: ID!
+  texter: User!
+  campaign: Campaign!
+  contacts(contactsFilter: ContactsFilter): [CampaignContact!]!
+  contactsCount(contactsFilter: ContactsFilter): Int!
+  userCannedResponses: [CannedResponse!]!
+  campaignCannedResponses: [CannedResponse!]!
   maxContacts: Int
 }
 


### PR DESCRIPTION
## Description

This fixes the permission error introduced by #1142.

## Motivation and Context

Texters do not have access to Campaign resources directly. Instead they must go through Assignment resources they do have access to.

So in Texter view we only have access via `assignment` and in Message Review we are only guaranteed to have access to campaign resource (conversation may be unassigned). So we support fetching canned responses via assignment or campaign (but not both).

## How Has This Been Tested?

This has been tested locally with Texter and Owner role in Texter and Message Review, respectively.

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
