### PR TITLE
fix: remove quotes around campaign preview script values

### DIFF
--- a/src/server/routes/campaign-preview.js
+++ b/src/server/routes/campaign-preview.js
@@ -34,7 +34,7 @@ const makeInteractionStepHtml = (
     : []
   ).concat(
     interactionStep.script_options
-      .map((opt) => ["p.script", ["em", `"${opt}"`]])
+      .map((opt) => ["p.script", ["em", `${opt}`]])
       .concat(
         interactionStep.question
           ? [
@@ -84,7 +84,7 @@ const makeCannedResponsesHtml = (cannedResponses) => {
     cannedResponses.map((cr) => [
       "li.canned-response",
       ["p.title", ["strong", cr.title]],
-      ["p.text", ["em", `"${cr.text}"`]]
+      ["p.text", ["em", `${cr.text}`]]
     ])
   ];
 };


### PR DESCRIPTION
## Description

Remove quotes around script values on campaign  preview page.

## Motivation and Context

Script values are often copied from the campaign preview into a different campaign. The user building the campaign must remember to remove the quotes, a step which can easily be missed.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<table>
<tr><td>

![Screen Shot 2022-05-07 at 8 25 00 AM](https://user-images.githubusercontent.com/2145526/167254547-74ca070b-b46d-4f9f-99e1-319b60303be3.png)

<p>before</p>

</td><td>

![Screen Shot 2022-05-07 at 8 24 26 AM](https://user-images.githubusercontent.com/2145526/167254569-0f5dea2e-f177-4080-a514-b1e0f3d10262.png)

<p>after</p>

</tr></table>

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
