### PR TITLE
chore: upgrade react-file-drop to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "react": "^17.0.2",
     "react-chartjs-2": "^2.11.1",
     "react-dom": "^17.0.2",
-    "react-file-drop": "^0.2.8",
+    "react-file-drop": "^3.1.4",
     "react-formal": "^2.2.2",
     "react-helmet": "^6.1.0",
     "react-markdown": "^4.1.0",

--- a/src/containers/AdminCampaignEdit/sections/CampaignContactsForm/components/CSVForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignContactsForm/components/CSVForm.tsx
@@ -4,7 +4,7 @@ import PublishIcon from "@material-ui/icons/Publish";
 import { css, StyleSheet } from "aphrodite";
 import RaisedButton from "material-ui/RaisedButton";
 import React from "react";
-import FileDrop from "react-file-drop";
+import { FileDrop } from "react-file-drop";
 
 import theme from "../../../../../styles/theme";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -20552,7 +20552,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -20955,12 +20955,12 @@ react-fast-compare@^3.1.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-file-drop@^0.2.8:
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/react-file-drop/-/react-file-drop-0.2.8.tgz#de1e26cef0f1a5855fa1fb1e0cee32bc03c34466"
-  integrity sha512-tcrDDbU25C45eusLGpnRg5qx7BexsjJ+5qZMnjwvj0IrRiv7VWEtJ2h2XZsLCkuaAtQe8cF5WYFJbzhfctoZjA==
+react-file-drop@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-file-drop/-/react-file-drop-3.1.4.tgz#0ceb3fcbf27283eb7f3ac817a5f8db0e265886c0"
+  integrity sha512-83633H9CK/IoBXBl77qBS36K0pGb5sQn6c1rc54nxWYkAbM/zo+xuxFnwUDib4Yh+xVmWBZeTAnY5ZSN2PmUCQ==
   dependencies:
-    prop-types "^15.6.1"
+    prop-types "^15.7.2"
 
 react-formal@^2.2.2:
   version "2.2.2"


### PR DESCRIPTION
## Description

This updates [`react-file-drop`](https://github.com/sarink/react-file-drop) to v3.

## Motivation and Context

Yarn complains about v0.2 compatibility with React 17.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
