### PR TITLE
fix: cleanup autosending

### DIFF
--- a/src/containers/AdminAutosending/components/AutosendingTargetRow.tsx
+++ b/src/containers/AdminAutosending/components/AutosendingTargetRow.tsx
@@ -103,7 +103,9 @@ export const AutosendingTargetRow: React.FC<AutosendingTargetRowProps> = (
       <TableCell>{target.contactsCount}</TableCell>
 
       <TableCell>{target.deliverabilityStats.deliveredCount}</TableCell>
-      <TableCell>{target.contactsCount! - totalSent!}</TableCell>
+      <TableCell>
+        {target.contactsCount! - totalSent! - (target.stats?.optOutsCount || 0)}
+      </TableCell>
       <TableCell>{waitingToDeliver}</TableCell>
       <TableCell>{target.deliverabilityStats.errorCount}</TableCell>
       <TableCell>

--- a/src/containers/AdminAutosending/index.tsx
+++ b/src/containers/AdminAutosending/index.tsx
@@ -162,7 +162,7 @@ const AdminAutosending: React.FC = () => {
               </TableRow>
               <TableRow>
                 <TableCell>Campaign</TableCell>
-                <TableCell>Status</TableCell>
+                <TableCell>Autosending Status</TableCell>
                 {/* Actions */}
                 <TableCell />
                 <TableCell>Contacts</TableCell>

--- a/src/server/tasks/queue-autosend-initials.spec.ts
+++ b/src/server/tasks/queue-autosend-initials.spec.ts
@@ -159,4 +159,65 @@ describe("queue-autosend-initials", () => {
       );
     });
   });
+
+  // This test was added when we changed autoassign to steal assignments from users
+  // Before that, part of the mechanism preventing duplicate sends was that the
+  // contact got assigned to the autosend user before getting queued, so a
+  // subsequent run wouldn't pick them up
+  // Now, that doesn't happen, so this test seemed like a useful check since we're
+  // only relying on job_key
+  it("does not double queue contacts after change to include assigned messages", async () => {
+    await withClient(pool, async (client) => {
+      const campaign = await createCampaign(client, {
+        organizationId: organization.id,
+        isStarted: true,
+        autosendUserId: texter.id,
+        autosendStatus: "unstarted"
+      });
+
+      await createInteractionStep(client, {
+        campaignId: campaign.id,
+        scriptOptions: ["Have a text {firstName}"]
+      });
+
+      await Promise.all(
+        [...Array(6)].map(() =>
+          createCampaignContact(client, {
+            campaignId: campaign.id,
+            firstName: faker.name.firstName()
+          })
+        )
+      );
+
+      const runQueueAutoSendInitials = async () => {
+        await client.query(`select graphile_worker.add_job($1)`, [
+          "queue-autosend-initials"
+        ]);
+
+        await runTaskListOnce(
+          workerOptions,
+          {
+            "queue-autosend-initials": queueAutoSendInitials
+          },
+          client
+        );
+      };
+
+      await runQueueAutoSendInitials();
+      await runQueueAutoSendInitials();
+
+      const {
+        rowCount
+      } = await client.query(
+        `select * from graphile_worker.jobs where payload->>'campaignId' = $1`,
+        [campaign.id]
+      );
+      expect(rowCount).toBe(6);
+
+      await pool.query(
+        `delete from graphile_worker.jobs where task_identifier = ANY($1)`,
+        [["queue-autosend-initials", "retry-interaction-step"]]
+      );
+    });
+  });
 });

--- a/src/server/tasks/queue-autosend-initials.spec.ts
+++ b/src/server/tasks/queue-autosend-initials.spec.ts
@@ -172,7 +172,7 @@ describe("queue-autosend-initials", () => {
         organizationId: organization.id,
         isStarted: true,
         autosendUserId: texter.id,
-        autosendStatus: "unstarted"
+        autosendStatus: "sending"
       });
 
       await createInteractionStep(client, {

--- a/src/server/tasks/queue-autosend-initials.ts
+++ b/src/server/tasks/queue-autosend-initials.ts
@@ -25,7 +25,6 @@ const queueAutoSendInitials: Task = async (payload: Payload, helpers) => {
           -- contact requirements
           and cc.archived = false
           and cc.message_status = 'needsMessage'
-          and cc.assignment_id is null
           -- campaign requirements for autosending
           and c.is_archived = false
           and c.is_started = true
@@ -50,7 +49,7 @@ const queueAutoSendInitials: Task = async (payload: Payload, helpers) => {
           --    and graphile_worker.jobs.key = cc.id::text
           -- )
         -- ordering by campaign id and cell should be fastest since theres a compound key on them
-        order by cc.campaign_id, cc.cell asc
+        order by assignment_id nulls last, cc.campaign_id, cc.cell asc
         limit $1
       ),
       assignments_upserted as (

--- a/src/server/tasks/queue-autosend-initials.ts
+++ b/src/server/tasks/queue-autosend-initials.ts
@@ -78,7 +78,7 @@ const queueAutoSendInitials: Task = async (payload: Payload, helpers) => {
           'retry-interaction-step' as task_identifier, 
           json_build_object(
             'campaignContactId', id, 
-            'campaignId', campaign_id
+            'campaignId', campaign_id,
             'unassignAfterSend', true
           ) as payload,
           id::text as key,

--- a/src/server/tasks/queue-autosend-initials.ts
+++ b/src/server/tasks/queue-autosend-initials.ts
@@ -76,7 +76,11 @@ const queueAutoSendInitials: Task = async (payload: Payload, helpers) => {
         insert into graphile_worker.jobs (task_identifier, payload, key, queue_name, max_attempts, run_at)
         select 
           'retry-interaction-step' as task_identifier, 
-          json_build_object('campaignContactId', id, 'campaignId', campaign_id) as payload,
+          json_build_object(
+            'campaignContactId', id, 
+            'campaignId', campaign_id
+            'unassignAfterSend', true
+          ) as payload,
           id::text as key,
           null as queue_name,
           1 as max_attempts,

--- a/src/server/tasks/retry-interaction-step.ts
+++ b/src/server/tasks/retry-interaction-step.ts
@@ -17,6 +17,7 @@ import { r } from "../models";
 
 export interface RetryInteractionStepPayload {
   campaignContactId: number;
+  unassignAfterSend?: boolean;
 }
 
 interface RetryInteractionStepRecord {
@@ -81,5 +82,12 @@ export const retryInteractionStep: Task = async (
 
   await r.knex.transaction(async (trx) => {
     await sendMessage(trx, user, `${campaignContactId}`, message);
+
+    // if false or undefined, dont execute
+    if (payload.unassignAfterSend === true) {
+      await trx("campaign_contact")
+        .update({ assignment_id: null })
+        .where({ id: payload.campaignContactId });
+    }
   });
 };


### PR DESCRIPTION
## Description

This PR makes 4 changes to autosending:

- Changes the status header to clarify that it's the Autosend Status instead of the campaign status
- Changes the "Waiting to Send" count to exclude opted out contacts
- Modifies the behavior of `queue-autosend-initials` to autosend unassigned messages as well
- Unassigns contacts after they've been autosent

## Motivation and Context

Feedback from user testing.

## How Has This Been Tested?

Locally, + test

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.

Need to update autosending HelpScout page to clarify the 2 behavioral changes above.