### PR TITLE
fix: throw error and retry on empty email

### DIFF
--- a/src/server/lib/templates/notification.tsx
+++ b/src/server/lib/templates/notification.tsx
@@ -114,7 +114,7 @@ const getNotificationContent = (
       subject = `[${organization.name}] New Reply: ${campaign.title}`;
       break;
     default:
-      template = <div />;
+      throw new Error(`Unrecognized notification type ${notificationType}`);
   }
 
   const content = ReactDOMServer.renderToStaticMarkup(template);

--- a/src/server/mail.ts
+++ b/src/server/mail.ts
@@ -49,6 +49,10 @@ export const sendEmail = async (options: SendMailOptions) => {
     return null;
   }
 
+  if (!params.text || !params.html) {
+    throw new Error("Empty email body!");
+  }
+
   return sender.sendMail(params);
 };
 

--- a/src/server/mail.ts
+++ b/src/server/mail.ts
@@ -24,12 +24,6 @@ export interface SendMailOptions {
 export const sendEmail = async (options: SendMailOptions) => {
   const { to, subject, text, html, replyTo } = options;
 
-  if (config.isDevelopment) {
-    const body = text || html;
-    logger.info(`Would send e-mail with subject ${subject} and body ${body}.`);
-    return null;
-  }
-
   logger.info(`Sending e-mail to ${to} with subject ${subject}.`);
 
   const params: nodemailer.SendMailOptions = {
@@ -48,6 +42,11 @@ export const sendEmail = async (options: SendMailOptions) => {
 
   if (replyTo) {
     params.replyTo = replyTo;
+  }
+
+  if (config.isDevelopment) {
+    logger.info(`Would send e-mail with params`, { params });
+    return null;
   }
 
   return sender.sendMail(params);

--- a/src/server/tasks/queue-pending-notifications.ts
+++ b/src/server/tasks/queue-pending-notifications.ts
@@ -29,7 +29,8 @@ export const queuePendingNotifications: Task = async (_payload, helpers) => {
 
   for (const notification of notificationsToSend) {
     await helpers.addJob("send-notification-email", notification, {
-      jobKey: `send-notification-email-${notification.id}`
+      jobKey: `send-notification-email-${notification.id}`,
+      maxAttempts: 6
     });
   }
 };
@@ -41,7 +42,8 @@ export const queuePeriodicNotifications: Task = async (_payload, helpers) => {
 
   for (const user of usersToNotify) {
     await helpers.addJob("send-notification-digest", user, {
-      jobKey: `send-notification-periodic-${user.id}`
+      jobKey: `send-notification-periodic-${user.id}`,
+      maxAttempts: 6
     });
   }
 };
@@ -53,7 +55,8 @@ export const queueDailyNotifications: Task = async (_payload, helpers) => {
 
   for (const user of usersToNotify) {
     await helpers.addJob("send-notification-digest", user, {
-      jobKey: `send-notification-daily-${user.id}`
+      jobKey: `send-notification-daily-${user.id}`,
+      maxAttempts: 6
     });
   }
 };

--- a/src/server/tasks/send-notification-email.ts
+++ b/src/server/tasks/send-notification-email.ts
@@ -45,6 +45,7 @@ export const sendNotificationEmail: Task = async (payload, _helpers) => {
       });
     } catch (err) {
       logger.error("Failed to send email notification...", errToObj(err));
+      throw err;
     }
   });
 };
@@ -81,6 +82,7 @@ export const sendNotificationDigestForUser: Task = async (
         });
       } catch (err) {
         logger.error("Failed to send email notification...", errToObj(err));
+        throw err;
       }
     });
   }


### PR DESCRIPTION
## Description

This adds retry behavior to notification email sending.

## Motivation and Context

It may be the case that generating email content is either

1. not being awaited correctly (see [SO post]), or
2. returning empty content some of the time

We should throw an error and retry in both these cases.

We should also throw an error for unrecognized notification template types rather than returning a an empty `<div />` as content.

[SO post]: https://stackoverflow.com/a/54484820

## How Has This Been Tested?

I was able to reproduce the empty message error locally only once but was not able to capture enough detail to debug why the content is empty.

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202266689193943