### PR TITLE
fix: disable secure option for session cookies

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -58,7 +58,7 @@ export const createApp = async () => {
       secret: SESSION_SECRET,
       cookie: {
         httpOnly: true,
-        secure: config.isProduction,
+        secure: false, // config.isProduction,
         maxAge: 30 * 24 * 60 * 60 * 1000 // 30 days
       },
       store: new PgSession({


### PR DESCRIPTION
## Description

Temporarily disable the secure option for `express-session` cookies.

## Motivation and Context

Sessions do not work in production otherwise.

`ingress-nginx` is not setting the correct `X-Forward-Proto` header, breaking `secure`.

https://github.com/kubernetes/ingress-nginx/issues/8195

## How Has This Been Tested?

This has been tested on stagingenv.

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.

**To-do**

- [x] Disable CI build
