### PR TITLE
fix: pass assignmentPriority as Int

### DIFF
--- a/src/containers/AdminTeamEditor/index.jsx
+++ b/src/containers/AdminTeamEditor/index.jsx
@@ -63,6 +63,10 @@ class AdminTeamEditor extends Component {
       "backgroundColor",
       "assignmentPriority"
     ]);
+    if ("assignmentPriority" in team) {
+      team.assignmentPriority = parseInt(team.assignmentPriority, 10);
+    }
+
     this.setState({ isWorking: true });
     try {
       const result = await this.props.mutations.saveTeams([team]);


### PR DESCRIPTION
## Description

Pass `assignmentPriority` as a number, matching the GraphQL schema.

## Motivation and Context

Currently, saving a team throws a generic 400 error.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
