### PR TITLE
fix: cleanup autosending counts

### DIFF
--- a/libs/spoke-codegen/src/graphql/autosending.graphql
+++ b/libs/spoke-codegen/src/graphql/autosending.graphql
@@ -10,6 +10,7 @@ fragment AutosendingTarget on Campaign {
     percentUnhandledReplies
     receivedMessagesCount
     countMessagedContacts
+    countNeedsMessageContacts
   }
   deliverabilityStats(filter: { initialMessagesOnly: true }) {
     deliveredCount

--- a/libs/spoke-codegen/src/graphql/autosending.graphql
+++ b/libs/spoke-codegen/src/graphql/autosending.graphql
@@ -6,6 +6,7 @@ fragment AutosendingTarget on Campaign {
   contactsCount
   stats {
     optOutsCount
+    needsMessageOptOutsCount
     percentUnhandledReplies
     receivedMessagesCount
     countMessagedContacts

--- a/src/api/campaign.ts
+++ b/src/api/campaign.ts
@@ -149,6 +149,7 @@ export const schema = `
     sentMessagesCount: Int
     receivedMessagesCount: Int
     optOutsCount: Int
+    needsMessageOptOutsCount: Int
     percentUnhandledReplies: Float!
     countMessagedContacts: Int!
   }

--- a/src/api/campaign.ts
+++ b/src/api/campaign.ts
@@ -152,6 +152,7 @@ export const schema = `
     needsMessageOptOutsCount: Int
     percentUnhandledReplies: Float!
     countMessagedContacts: Int!
+    countNeedsMessageContacts: Int!
   }
 
   type DeliverabilityErrorStat {

--- a/src/api/campaign.ts
+++ b/src/api/campaign.ts
@@ -149,7 +149,7 @@ export const schema = `
     sentMessagesCount: Int
     receivedMessagesCount: Int
     optOutsCount: Int
-    needsMessageOptOutsCount: Int
+    needsMessageOptOutsCount: Int!
     percentUnhandledReplies: Float!
     countMessagedContacts: Int!
     countNeedsMessageContacts: Int!

--- a/src/containers/AdminAutosending/components/AutosendingTargetRow.tsx
+++ b/src/containers/AdminAutosending/components/AutosendingTargetRow.tsx
@@ -46,7 +46,9 @@ export const AutosendingTargetRow: React.FC<AutosendingTargetRowProps> = (
   const totalSent = target.stats?.countMessagedContacts;
 
   const statusChipDisplay =
-    target.autosendStatus === "sending"
+    target.stats?.countNeedsMessageContacts === 0
+      ? "complete"
+      : target.autosendStatus === "sending"
       ? totalSent === 0
         ? "up next"
         : target.autosendStatus

--- a/src/containers/AdminAutosending/components/AutosendingTargetRow.tsx
+++ b/src/containers/AdminAutosending/components/AutosendingTargetRow.tsx
@@ -104,7 +104,9 @@ export const AutosendingTargetRow: React.FC<AutosendingTargetRowProps> = (
 
       <TableCell>{target.deliverabilityStats.deliveredCount}</TableCell>
       <TableCell>
-        {target.contactsCount! - totalSent! - (target.stats?.optOutsCount || 0)}
+        {target.contactsCount! -
+          totalSent! -
+          (target.stats?.needsMessageOptOutsCount || 0)}
       </TableCell>
       <TableCell>{waitingToDeliver}</TableCell>
       <TableCell>{target.deliverabilityStats.errorCount}</TableCell>

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -501,6 +501,7 @@ type CampaignStats {
   sentMessagesCount: Int
   receivedMessagesCount: Int
   optOutsCount: Int
+  needsMessageOptOutsCount: Int
   percentUnhandledReplies: Float!
   countMessagedContacts: Int!
 }

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -504,6 +504,7 @@ type CampaignStats {
   needsMessageOptOutsCount: Int
   percentUnhandledReplies: Float!
   countMessagedContacts: Int!
+  countNeedsMessageContacts: Int!
 }
 
 type DeliverabilityErrorStat {

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -501,7 +501,7 @@ type CampaignStats {
   sentMessagesCount: Int
   receivedMessagesCount: Int
   optOutsCount: Int
-  needsMessageOptOutsCount: Int
+  needsMessageOptOutsCount: Int!
   percentUnhandledReplies: Float!
   countMessagedContacts: Int!
   countNeedsMessageContacts: Int!

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -196,6 +196,29 @@ export const resolvers = {
       });
     },
 
+    needsMessageOptOutsCount: async (campaign) => {
+      const getNeedsMessageOptOutsCount = memoizer.memoize(
+        async ({ campaignId, archived }) => {
+          return r.getCount(
+            r
+              .reader("campaign_contact")
+              .where({
+                is_opted_out: true,
+                campaign_id: campaignId,
+                message_status: "needsMessage"
+              })
+              .whereRaw(`archived = ${archived}`) // partial index friendly
+          );
+        },
+        cacheOpts.CampaignNeedsMessageOptOutsCount
+      );
+
+      return getNeedsMessageOptOutsCount({
+        campaignId: campaign.id,
+        archived: campaign.is_archived
+      });
+    },
+
     countMessagedContacts: async (campaign) => {
       const getCountMessagedContacts = memoizer.memoize(
         async ({ campaignId, archived }) => {

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -236,7 +236,7 @@ export const resolvers = {
           const [{ count_messaged_contacts: result }] = rows;
           return result;
         },
-        cacheOpts.PercentUnhandledReplies
+        cacheOpts.CountMessagedContacts
       );
 
       return getCountMessagedContacts({
@@ -262,7 +262,7 @@ export const resolvers = {
           const [{ count_needs_message_contacts: result }] = rows;
           return result;
         },
-        cacheOpts.PercentUnhandledReplies
+        cacheOpts.CountNeedsMessageContacts
       );
 
       return getCountNeedsMessageContacts({

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -245,6 +245,32 @@ export const resolvers = {
       });
     },
 
+    countNeedsMessageContacts: async (campaign) => {
+      const getCountNeedsMessageContacts = memoizer.memoize(
+        async ({ campaignId, archived }) => {
+          const { rows } = await r.reader.raw(
+            `
+              select count(*) as count_needs_message_contacts
+              from campaign_contact
+              where message_status = 'needsMessage'
+                and archived = ${archived}
+                and campaign_id = ?
+            `,
+            [campaignId]
+          );
+
+          const [{ count_needs_message_contacts: result }] = rows;
+          return result;
+        },
+        cacheOpts.PercentUnhandledReplies
+      );
+
+      return getCountNeedsMessageContacts({
+        campaignId: campaign.id,
+        archived: campaign.is_archived
+      });
+    },
+
     percentUnhandledReplies: async (campaign) => {
       const getPercentUnhandledReplies = memoizer.memoize(
         async ({ campaignId, archived }) => {

--- a/src/server/memoredis.ts
+++ b/src/server/memoredis.ts
@@ -41,6 +41,10 @@ const cacheOptsPlain: Record<string, [string, number]> = {
     ONE_MINUTE
   ],
   CampaignOptOutsCount: ["campaign-opt-outs-count", ONE_MINUTE],
+  CampaignNeedsMessageOptOutsCount: [
+    "campaign-needs-message-opt-outs-count",
+    ONE_MINUTE
+  ],
   CampaignTeams: ["campaign-teams", ONE_WEEK],
   CampaignsList: ["campaigns-list", ONE_WEEK],
   CampaignsListRelay: ["campaigns-list-relay", ONE_WEEK],

--- a/src/server/memoredis.ts
+++ b/src/server/memoredis.ts
@@ -63,7 +63,9 @@ const cacheOptsPlain: Record<string, [string, number]> = {
   AssignmentCompleteLock: ["assignment-complete-lock", THIRTY_SECONDS],
   GetUsers: ["get-users", ONE_MINUTE * 5],
   MyCurrentAssignmentTargets: ["my-current-assignment-targets", ONE_SECOND * 5],
-  PercentUnhandledReplies: ["percent-unhandled-replies", ONE_SECOND * 5]
+  PercentUnhandledReplies: ["percent-unhandled-replies", ONE_SECOND * 5],
+  CountMessagedContacts: ["count-messaged-contacts", ONE_MINUTE],
+  CountNeedsMessageContacts: ["count-needs-message-contacts", ONE_MINUTE]
 };
 
 const cacheOpts = Object.fromEntries(

--- a/src/server/tasks/queue-autosend-initials.ts
+++ b/src/server/tasks/queue-autosend-initials.ts
@@ -95,7 +95,7 @@ const queueAutoSendInitials: Task = async (payload: Payload, helpers) => {
       ),
       campaign_breakdown as (
         select c.id as campaign_id, a.id as assignment_id,
-          ( select count(*) from jobs_queued where payload->>'campaignId' = c.id::text ) as count_queued,
+          ( select count(*) from jobs_queued where payload->>'campaignId' = c.id::text and attempts = 0) as count_queued,
           ( select count(*) from assignments_upserted ) as assignments_upserted_count,
           ( select array_agg(campaign_id) from contacts_to_queue ) as campaigns_contacts_queued_on
         from campaign c 


### PR DESCRIPTION
## Description

This PR makes 3 changes to autosending:
- Changes the "Waiting to Send" count to exclude opted out contacts (using a query)
- Prevents starting autosending on a campaign where there are no more initials
- Modifies the behavior of queue-autosend-initials to mark a campaign as complete if there are no more contacts with 0 sending attempts for the campaign

## Motivation and Context
Feedback from user testing.

## How Has This Been Tested?
This has been tested locally.

## Screenshots (if appropriate):

## Documentation Changes

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.