### PR TITLE
fix: bring assign loop into alignment with assignment targets

### DIFF
--- a/src/server/api/assignment.js
+++ b/src/server/api/assignment.js
@@ -856,7 +856,6 @@ export async function assignLoop(
         .join("user_team", "team.id", "=", "user_team.team_id")
         .where({
           user_id: parseInt(user.id, 10),
-          is_assignment_enabled: true,
           organization_id: parseInt(organizationId, 10)
         })
     )


### PR DESCRIPTION
## Description

This treats escalated tags the same way within assignLoop as it does fetching assignment targets.

## Motivation and Context

Currently, `assignLoop()` will try to assign conversations for a given target with custom escalation tags before other conversations for that target (`if myEscalationTags.length > 0`). Escalation tags are currently only included in `myEscalationTags` if auto-assignment is enabled for the custom escalation team.

This means a campaign with only custom escalation conversations can be picked as the preferred assignment target via `myCurrentAssignmentTargets()`, which does not care whether auto-assignment for custom escalation team is enabled or not, but then not have any conversations to assign within `assignLoop()`, which does care if the custom escalation team is enabled.

This standardizes on not caring whether a custom escalation team is enabled for auto-assignment.

Closes #1196

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Locally an in production for beta user.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
