### PR TITLE
fix: make opt out button orange again

### DIFF
--- a/src/components/ColorButton.tsx
+++ b/src/components/ColorButton.tsx
@@ -1,0 +1,26 @@
+import type { ButtonProps } from "@material-ui/core/Button";
+import Button from "@material-ui/core/Button";
+import { createTheme, ThemeProvider } from "@material-ui/core/styles";
+import React from "react";
+
+export type ColorButtonProps = {
+  backgroundColor: string;
+} & Omit<ButtonProps, "color">;
+
+export const ColorButton: React.FC<ColorButtonProps> = (props) => {
+  const { backgroundColor, children, ...rest } = props;
+  const theme = createTheme({
+    palette: {
+      primary: { main: backgroundColor }
+    }
+  });
+  return (
+    <ThemeProvider theme={theme}>
+      <Button {...rest} color="primary">
+        {children}
+      </Button>
+    </ThemeProvider>
+  );
+};
+
+export default ColorButton;

--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageList/MessageColumn/MessageOptOut.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageList/MessageColumn/MessageOptOut.tsx
@@ -1,5 +1,6 @@
 import { ApolloQueryResult, gql } from "@apollo/client";
 import Button from "@material-ui/core/Button";
+import { deepOrange } from "@material-ui/core/colors";
 import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
@@ -9,6 +10,7 @@ import React, { Component } from "react";
 
 import { CampaignContact } from "../../../../../api/campaign-contact";
 import { ContactActionInput } from "../../../../../api/types";
+import ColorButton from "../../../../../components/ColorButton";
 import { MutationMap } from "../../../../../network/types";
 import {
   formatErrorMessage,
@@ -155,24 +157,25 @@ class MessageOptOut extends Component<Props, State> {
           </p>
           <div style={{ flexShrink: 1 }}>
             {isOptedOut && (
-              <Button
+              <ColorButton
                 variant="contained"
-                style={{ float: "right", backgroundColor: "#ff0033" }}
+                style={{ float: "right" }}
+                backgroundColor="#ff0033"
                 disabled={this.state.isMakingRequest}
                 onClick={this.openOptInConfirmation}
               >
                 Opt-In
-              </Button>
+              </ColorButton>
             )}
             {!isOptedOut && (
-              <Button
+              <ColorButton
                 variant="contained"
-                color="secondary"
+                backgroundColor={deepOrange[500]}
                 disabled={this.state.isMakingRequest}
                 onClick={this.handleClickOptOut}
               >
                 Opt-Out
-              </Button>
+              </ColorButton>
             )}
           </div>
         </div>

--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-unused-state */
 import Button from "@material-ui/core/Button";
-import { blueGrey, grey } from "@material-ui/core/colors";
+import { blueGrey, deepOrange, grey } from "@material-ui/core/colors";
 import IconButton from "@material-ui/core/IconButton";
 import Tooltip from "@material-ui/core/Tooltip";
 import LocalOfferIcon from "@material-ui/icons/LocalOffer";
@@ -22,6 +22,7 @@ import * as yup from "yup";
 import AssignmentTexterSurveys from "../../components/AssignmentTexterSurveys";
 import BulkSendButton from "../../components/BulkSendButton";
 import CannedResponseMenu from "../../components/CannedResponseMenu";
+import ColorButton from "../../components/ColorButton";
 import Empty from "../../components/Empty";
 import GSForm from "../../components/forms/GSForm";
 import MessageLengthInfo from "../../components/MessageLengthInfo";
@@ -662,14 +663,14 @@ export class AssignmentTexterContact extends React.Component {
           }}
         >
           <Tooltip title="Opt out this contact">
-            <Button
+            <ColorButton
               {...dataTest("optOut")}
               variant="contained"
-              color="secondary"
+              backgroundColor={deepOrange[500]}
               onClick={this.handleOpenOptOutDialog}
             >
               Opt out
-            </Button>
+            </ColorButton>
           </Tooltip>
           <Button
             variant="contained"
@@ -720,14 +721,14 @@ export class AssignmentTexterContact extends React.Component {
               >
                 Canned responses
               </Button>
-              <Button
+              <ColorButton
                 {...dataTest("optOut")}
                 variant="contained"
-                color="secondary"
+                backgroundColor={deepOrange[500]}
                 onClick={this.handleOpenOptOutDialog}
               >
                 Opt out
-              </Button>
+              </ColorButton>
               <Button
                 variant="contained"
                 style={{ backgroundColor: blueGrey[100] }}


### PR DESCRIPTION
## Description

This makes Opt Out buttons orange again.

## Motivation and Context

Orange is the color users are accustomed to and shouldn't be changed.

Closes #1198

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<table><tr><td>

<img width="216" alt="Screen Shot 2022-05-15 at 9 16 22 PM" src="https://user-images.githubusercontent.com/2145526/168504800-230b9ba9-f15b-4a77-aea8-572818cdcad5.png">

</td><td>

<img width="764" alt="Screen Shot 2022-05-15 at 9 23 56 PM" src="https://user-images.githubusercontent.com/2145526/168504809-9930ec63-31d4-4672-aad5-552bdf1fb091.png">

</td></tr></table>

## Documentation Changes

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
