### PR TITLE
fix: turn off initial autoassignment for campaigns that are autosending

### DIFF
--- a/libs/spoke-codegen/src/graphql/autosending.graphql
+++ b/libs/spoke-codegen/src/graphql/autosending.graphql
@@ -10,6 +10,7 @@ fragment AutosendingTarget on Campaign {
     percentUnhandledReplies
     receivedMessagesCount
     countMessagedContacts
+    countNeedsMessageContacts
   }
   deliverabilityStats(filter: { initialMessagesOnly: true }) {
     deliveredCount

--- a/libs/spoke-codegen/src/graphql/autosending.graphql
+++ b/libs/spoke-codegen/src/graphql/autosending.graphql
@@ -6,6 +6,7 @@ fragment AutosendingTarget on Campaign {
   contactsCount
   stats {
     optOutsCount
+    needsMessageOptOutsCount
     percentUnhandledReplies
     receivedMessagesCount
     countMessagedContacts

--- a/migrations/20220516005043_exclude-autosend-campaigns-from-needs-message-autoassign.js
+++ b/migrations/20220516005043_exclude-autosend-campaigns-from-needs-message-autoassign.js
@@ -1,0 +1,58 @@
+exports.up = function up(knex) {
+  return knex.schema
+    .raw(
+      `
+        create or replace view assignable_campaigns as (
+          select id, title, organization_id, limit_assignment_to_teams, autosend_status
+          from campaign
+          where is_started = true
+            and is_archived = false
+            and is_autoassign_enabled = true
+            and texting_hours_end > extract(hour from (CURRENT_TIMESTAMP at time zone campaign.timezone))
+        )
+      `
+    )
+    .then(() => {
+      return knex.schema.raw(`
+        create or replace view assignable_campaigns_with_needs_message as (
+          select *
+          from assignable_campaigns
+          where exists (
+            select 1
+            from assignable_needs_message
+            where campaign_id = assignable_campaigns.id
+          )
+          and autosend_status <> 'sending'
+        );
+      `);
+    });
+};
+
+exports.down = function down(knex) {
+  return knex.schema
+    .raw(
+      `
+        create or replace view assignable_campaigns as (
+          select id, title, organization_id, limit_assignment_to_teams
+          from campaign
+          where is_started = true
+            and is_archived = false
+            and is_autoassign_enabled = true
+            and texting_hours_end > extract(hour from (CURRENT_TIMESTAMP at time zone campaign.timezone))
+        )
+      `
+    )
+    .then(() => {
+      return knex.schema.raw(`
+        create or replace view assignable_campaigns_with_needs_message as (
+          select *
+          from assignable_campaigns
+          where exists (
+            select 1
+            from assignable_needs_message
+            where campaign_id = assignable_campaigns.id
+          )
+        );
+      `);
+    });
+};

--- a/src/api/campaign.ts
+++ b/src/api/campaign.ts
@@ -149,6 +149,7 @@ export const schema = `
     sentMessagesCount: Int
     receivedMessagesCount: Int
     optOutsCount: Int
+    needsMessageOptOutsCount: Int
     percentUnhandledReplies: Float!
     countMessagedContacts: Int!
   }

--- a/src/api/campaign.ts
+++ b/src/api/campaign.ts
@@ -152,6 +152,7 @@ export const schema = `
     needsMessageOptOutsCount: Int
     percentUnhandledReplies: Float!
     countMessagedContacts: Int!
+    countNeedsMessageContacts: Int!
   }
 
   type DeliverabilityErrorStat {

--- a/src/containers/AdminAutosending/components/AutosendingTargetRow.tsx
+++ b/src/containers/AdminAutosending/components/AutosendingTargetRow.tsx
@@ -46,7 +46,9 @@ export const AutosendingTargetRow: React.FC<AutosendingTargetRowProps> = (
   const totalSent = target.stats?.countMessagedContacts;
 
   const statusChipDisplay =
-    target.autosendStatus === "sending"
+    target.stats?.countNeedsMessageContacts === 0
+      ? "complete"
+      : target.autosendStatus === "sending"
       ? totalSent === 0
         ? "up next"
         : target.autosendStatus

--- a/src/containers/AdminAutosending/components/AutosendingTargetRow.tsx
+++ b/src/containers/AdminAutosending/components/AutosendingTargetRow.tsx
@@ -104,7 +104,9 @@ export const AutosendingTargetRow: React.FC<AutosendingTargetRowProps> = (
 
       <TableCell>{target.deliverabilityStats.deliveredCount}</TableCell>
       <TableCell>
-        {target.contactsCount! - totalSent! - (target.stats?.optOutsCount || 0)}
+        {target.contactsCount! -
+          totalSent! -
+          (target.stats?.needsMessageOptOutsCount || 0)}
       </TableCell>
       <TableCell>{waitingToDeliver}</TableCell>
       <TableCell>{target.deliverabilityStats.errorCount}</TableCell>

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -501,6 +501,7 @@ type CampaignStats {
   sentMessagesCount: Int
   receivedMessagesCount: Int
   optOutsCount: Int
+  needsMessageOptOutsCount: Int
   percentUnhandledReplies: Float!
   countMessagedContacts: Int!
 }

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -504,6 +504,7 @@ type CampaignStats {
   needsMessageOptOutsCount: Int
   percentUnhandledReplies: Float!
   countMessagedContacts: Int!
+  countNeedsMessageContacts: Int!
 }
 
 type DeliverabilityErrorStat {

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -196,6 +196,29 @@ export const resolvers = {
       });
     },
 
+    needsMessageOptOutsCount: async (campaign) => {
+      const getNeedsMessageOptOutsCount = memoizer.memoize(
+        async ({ campaignId, archived }) => {
+          return r.getCount(
+            r
+              .reader("campaign_contact")
+              .where({
+                is_opted_out: true,
+                campaign_id: campaignId,
+                message_status: "needsMessage"
+              })
+              .whereRaw(`archived = ${archived}`) // partial index friendly
+          );
+        },
+        cacheOpts.CampaignNeedsMessageOptOutsCount
+      );
+
+      return getNeedsMessageOptOutsCount({
+        campaignId: campaign.id,
+        archived: campaign.is_archived
+      });
+    },
+
     countMessagedContacts: async (campaign) => {
       const getCountMessagedContacts = memoizer.memoize(
         async ({ campaignId, archived }) => {

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -236,7 +236,7 @@ export const resolvers = {
           const [{ count_messaged_contacts: result }] = rows;
           return result;
         },
-        cacheOpts.PercentUnhandledReplies
+        cacheOpts.CountMessagedContacts
       );
 
       return getCountMessagedContacts({
@@ -262,7 +262,7 @@ export const resolvers = {
           const [{ count_needs_message_contacts: result }] = rows;
           return result;
         },
-        cacheOpts.PercentUnhandledReplies
+        cacheOpts.CountNeedsMessageContacts
       );
 
       return getCountNeedsMessageContacts({

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -245,6 +245,32 @@ export const resolvers = {
       });
     },
 
+    countNeedsMessageContacts: async (campaign) => {
+      const getCountNeedsMessageContacts = memoizer.memoize(
+        async ({ campaignId, archived }) => {
+          const { rows } = await r.reader.raw(
+            `
+              select count(*) as count_needs_message_contacts
+              from campaign_contact
+              where message_status = 'needsMessage'
+                and archived = ${archived}
+                and campaign_id = ?
+            `,
+            [campaignId]
+          );
+
+          const [{ count_needs_message_contacts: result }] = rows;
+          return result;
+        },
+        cacheOpts.PercentUnhandledReplies
+      );
+
+      return getCountNeedsMessageContacts({
+        campaignId: campaign.id,
+        archived: campaign.is_archived
+      });
+    },
+
     percentUnhandledReplies: async (campaign) => {
       const getPercentUnhandledReplies = memoizer.memoize(
         async ({ campaignId, archived }) => {

--- a/src/server/memoredis.ts
+++ b/src/server/memoredis.ts
@@ -41,6 +41,10 @@ const cacheOptsPlain: Record<string, [string, number]> = {
     ONE_MINUTE
   ],
   CampaignOptOutsCount: ["campaign-opt-outs-count", ONE_MINUTE],
+  CampaignNeedsMessageOptOutsCount: [
+    "campaign-needs-message-opt-outs-count",
+    ONE_MINUTE
+  ],
   CampaignTeams: ["campaign-teams", ONE_WEEK],
   CampaignsList: ["campaigns-list", ONE_WEEK],
   CampaignsListRelay: ["campaigns-list-relay", ONE_WEEK],

--- a/src/server/memoredis.ts
+++ b/src/server/memoredis.ts
@@ -63,7 +63,9 @@ const cacheOptsPlain: Record<string, [string, number]> = {
   AssignmentCompleteLock: ["assignment-complete-lock", THIRTY_SECONDS],
   GetUsers: ["get-users", ONE_MINUTE * 5],
   MyCurrentAssignmentTargets: ["my-current-assignment-targets", ONE_SECOND * 5],
-  PercentUnhandledReplies: ["percent-unhandled-replies", ONE_SECOND * 5]
+  PercentUnhandledReplies: ["percent-unhandled-replies", ONE_SECOND * 5],
+  CountMessagedContacts: ["count-messaged-contacts", ONE_MINUTE],
+  CountNeedsMessageContacts: ["count-needs-message-contacts", ONE_MINUTE]
 };
 
 const cacheOpts = Object.fromEntries(

--- a/src/server/tasks/queue-autosend-initials.ts
+++ b/src/server/tasks/queue-autosend-initials.ts
@@ -95,7 +95,7 @@ const queueAutoSendInitials: Task = async (payload: Payload, helpers) => {
       ),
       campaign_breakdown as (
         select c.id as campaign_id, a.id as assignment_id,
-          ( select count(*) from jobs_queued where payload->>'campaignId' = c.id::text ) as count_queued,
+          ( select count(*) from jobs_queued where payload->>'campaignId' = c.id::text and attempts = 0) as count_queued,
           ( select count(*) from assignments_upserted ) as assignments_upserted_count,
           ( select array_agg(campaign_id) from contacts_to_queue ) as campaigns_contacts_queued_on
         from campaign c 


### PR DESCRIPTION
## Description
This prevents initials on campaigns that are actively being autosent from being assigned.

## Motivation and Context
Since autosending unassigns assigned initials, it can be confusing for texters to pick up initials for a campaign that is being autosent.

## How Has This Been Tested?
This has been tested locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
