### PR TITLE
fix: turn off initial autoassignment for campaigns that are autosending

### DIFF
--- a/migrations/20220516023025_exclude-autosend-campaigns-from-autoassign.js
+++ b/migrations/20220516023025_exclude-autosend-campaigns-from-autoassign.js
@@ -1,0 +1,58 @@
+exports.up = function up(knex) {
+  return knex.schema
+    .raw(
+      `
+          create or replace view assignable_campaigns as (
+            select id, title, organization_id, limit_assignment_to_teams, autosend_status
+            from campaign
+            where is_started = true
+              and is_archived = false
+              and is_autoassign_enabled = true
+              and texting_hours_end > extract(hour from (CURRENT_TIMESTAMP at time zone campaign.timezone))
+          )
+        `
+    )
+    .then(() => {
+      return knex.schema.raw(`
+          create or replace view assignable_campaigns_with_needs_message as (
+            select *
+            from assignable_campaigns
+            where exists (
+              select 1
+              from assignable_needs_message
+              where campaign_id = assignable_campaigns.id
+            )
+            and autosend_status <> 'sending'
+          );
+        `);
+    });
+};
+
+exports.down = function down(knex) {
+  return knex.schema
+    .raw(
+      `
+          create or replace view assignable_campaigns as (
+            select id, title, organization_id, limit_assignment_to_teams
+            from campaign
+            where is_started = true
+              and is_archived = false
+              and is_autoassign_enabled = true
+              and texting_hours_end > extract(hour from (CURRENT_TIMESTAMP at time zone campaign.timezone))
+          )
+        `
+    )
+    .then(() => {
+      return knex.schema.raw(`
+          create or replace view assignable_campaigns_with_needs_message as (
+            select *
+            from assignable_campaigns
+            where exists (
+              select 1
+              from assignable_needs_message
+              where campaign_id = assignable_campaigns.id
+            )
+          );
+        `);
+    });
+};


### PR DESCRIPTION
## Description
This prevents initials on campaigns that are actively being autosent from being assigned.

## Motivation and Context
Since autosending unassigns assigned initials, it can be confusing for texters to pick up initials for a campaign that is being autosent.

## How Has This Been Tested?
This has been tested locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
