### PR TITLE
feat(campaign-builder): add basic mode

### DIFF
--- a/libs/spoke-codegen/src/graphql/general-settings.graphql
+++ b/libs/spoke-codegen/src/graphql/general-settings.graphql
@@ -5,6 +5,7 @@ query GetCampaignBuilderSettings($organizationId: String!) {
       id
       confirmationClickForScriptLinks
       startCampaignRequiresApproval
+      defaultCampaignBuilderMode
     }
   }
 }
@@ -13,17 +14,20 @@ mutation UpdateCampaignBuilderSettings(
   $organizationId: String!
   $confirmationClicks: Boolean
   $requiresApproval: Boolean
+  $builderMode: CampaignBuilderMode
 ) {
   editOrganizationSettings(
     id: $organizationId
     input: {
       confirmationClickForScriptLinks: $confirmationClicks
       startCampaignRequiresApproval: $requiresApproval
+      defaultCampaignBuilderMode: $builderMode
     }
   ) {
     id
     confirmationClickForScriptLinks
     startCampaignRequiresApproval
+    defaultCampaignBuilderMode
   }
 }
 
@@ -43,12 +47,9 @@ mutation UpdateMessageReviewSettings(
 ) {
   editOrganizationSettings(
     id: $organizationId
-    input: {
-      scriptPreviewForSupervolunteers: $forSupervols
-    }
+    input: { scriptPreviewForSupervolunteers: $forSupervols }
   ) {
     id
     scriptPreviewForSupervolunteers
   }
 }
-

--- a/libs/spoke-codegen/src/graphql/spoke-context.graphql
+++ b/libs/spoke-codegen/src/graphql/spoke-context.graphql
@@ -18,4 +18,5 @@ fragment OrganizationSettingsInfo on OrganizationSettings {
   confirmationClickForScriptLinks
   startCampaignRequiresApproval
   scriptPreviewForSupervolunteers
+  defaultCampaignBuilderMode
 }

--- a/src/api/organization-settings.ts
+++ b/src/api/organization-settings.ts
@@ -45,6 +45,7 @@ export const schema = `
     numbersApiKey: String
     trollbotWebhookUrl: String
     scriptPreviewForSupervolunteers: Boolean
+    defaultCampaignBuilderMode: CampaignBuilderMode
 
     # Superadmin
     startCampaignRequiresApproval: Boolean
@@ -62,6 +63,7 @@ export const schema = `
     # Supervolunteer
     startCampaignRequiresApproval: Boolean
     scriptPreviewForSupervolunteers: Boolean
+    defaultCampaignBuilderMode: CampaignBuilderMode
 
     # Owner
     defaulTexterApprovalStatus: RequestAutoApprove

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -31,6 +31,11 @@ import { schema as trollbotSchema } from "./trollbot";
 import { schema as userSchema } from "./user";
 
 const rootSchema = `
+  enum CampaignBuilderMode {
+    BASIC
+    ADVANCED
+  }
+
   input BulkUpdateScriptInput {
     searchString: String!
     replaceString: String!

--- a/src/containers/Settings/components/CampaignBuilderSettingsCard.tsx
+++ b/src/containers/Settings/components/CampaignBuilderSettingsCard.tsx
@@ -1,12 +1,18 @@
 import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
 import CardHeader from "@material-ui/core/CardHeader";
+import FormControl from "@material-ui/core/FormControl";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import FormGroup from "@material-ui/core/FormGroup";
+import InputLabel from "@material-ui/core/InputLabel";
+import MenuItem from "@material-ui/core/MenuItem";
+import Select from "@material-ui/core/Select";
+import type { SelectInputProps } from "@material-ui/core/Select/SelectInput";
 import Switch from "@material-ui/core/Switch";
 import React from "react";
 
 import {
+  CampaignBuilderMode,
   useGetCampaignBuilderSettingsQuery,
   useUpdateCampaignBuilderSettingsMutation
 } from "../../../../libs/spoke-codegen/src";
@@ -65,6 +71,21 @@ export const CampaignBuilderSettingsCard: React.FC<CampaignBuilderSettingsCardPr
     });
   };
 
+  const handleChangeBuilderMode: SelectInputProps["onChange"] = async (
+    event
+  ) => {
+    if (working) return;
+
+    const builderMode = event.target.value as CampaignBuilderMode;
+
+    await setRequiresApproval({
+      variables: {
+        organizationId,
+        builderMode
+      }
+    });
+  };
+
   return (
     <Card style={style}>
       <CardHeader title="Campaign Builder Settings" disableTypography />
@@ -94,6 +115,23 @@ export const CampaignBuilderSettingsCard: React.FC<CampaignBuilderSettingsCardPr
               authz.isSuperadmin ? "" : "(superadmin-only)"
             }`}
           />
+        </FormGroup>
+        <FormGroup row>
+          <FormControl style={{ width: 200 }}>
+            <InputLabel id="campaign-builder-mode-label">
+              Default Builder Mode
+            </InputLabel>
+            <Select
+              labelId="campaign-builder-mode-label"
+              id="campaign-builder-mode-select"
+              fullWidth
+              value={settings?.defaultCampaignBuilderMode}
+              onChange={handleChangeBuilderMode}
+            >
+              <MenuItem value={CampaignBuilderMode.Basic}>Basic</MenuItem>
+              <MenuItem value={CampaignBuilderMode.Advanced}>Advanced</MenuItem>
+            </Select>
+          </FormControl>
         </FormGroup>
       </CardContent>
     </Card>

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -1,4 +1,9 @@
 
+enum CampaignBuilderMode {
+  BASIC
+  ADVANCED
+}
+
 input BulkUpdateScriptInput {
   searchString: String!
   replaceString: String!
@@ -420,6 +425,7 @@ input OrganizationSettingsInput {
   numbersApiKey: String
   trollbotWebhookUrl: String
   scriptPreviewForSupervolunteers: Boolean
+  defaultCampaignBuilderMode: CampaignBuilderMode
 
   # Superadmin
   startCampaignRequiresApproval: Boolean
@@ -437,6 +443,7 @@ type OrganizationSettings {
   # Supervolunteer
   startCampaignRequiresApproval: Boolean
   scriptPreviewForSupervolunteers: Boolean
+  defaultCampaignBuilderMode: CampaignBuilderMode
 
   # Owner
   defaulTexterApprovalStatus: RequestAutoApprove

--- a/src/server/api/organization-settings.ts
+++ b/src/server/api/organization-settings.ts
@@ -8,6 +8,11 @@ import { r } from "../models";
 import { organizationCache } from "../models/cacheable_queries/organization";
 import { accessRequired, roleIndex } from "./errors";
 
+export enum CampaignBuilderMode {
+  Basic = "BASIC",
+  Advanced = "ADVANCED"
+}
+
 interface IOrganizationSettings {
   defaulTexterApprovalStatus: string;
   optOutMessage: string;
@@ -18,6 +23,7 @@ interface IOrganizationSettings {
   confirmationClickForScriptLinks: boolean;
   startCampaignRequiresApproval: boolean;
   scriptPreviewForSupervolunteers: boolean;
+  defaultCampaignBuilderMode: CampaignBuilderMode;
 }
 
 const SETTINGS_PERMISSIONS: {
@@ -29,6 +35,7 @@ const SETTINGS_PERMISSIONS: {
   confirmationClickForScriptLinks: UserRoleType.TEXTER,
   startCampaignRequiresApproval: UserRoleType.SUPERVOLUNTEER,
   scriptPreviewForSupervolunteers: UserRoleType.SUPERVOLUNTEER,
+  defaultCampaignBuilderMode: UserRoleType.SUPERVOLUNTEER,
   defaulTexterApprovalStatus: UserRoleType.OWNER,
   numbersApiKey: UserRoleType.OWNER,
   trollbotWebhookUrl: UserRoleType.OWNER
@@ -45,6 +52,7 @@ const SETTINGS_WRITE_PERMISSIONS: {
   numbersApiKey: UserRoleType.OWNER,
   trollbotWebhookUrl: UserRoleType.OWNER,
   scriptPreviewForSupervolunteers: UserRoleType.OWNER,
+  defaultCampaignBuilderMode: UserRoleType.OWNER,
   startCampaignRequiresApproval: UserRoleType.SUPERADMIN
 };
 
@@ -63,7 +71,8 @@ const SETTINGS_DEFAULTS: IOrganizationSettings = {
   showContactCell: false,
   confirmationClickForScriptLinks: true,
   startCampaignRequiresApproval: false,
-  scriptPreviewForSupervolunteers: false
+  scriptPreviewForSupervolunteers: false,
+  defaultCampaignBuilderMode: CampaignBuilderMode.Advanced
 };
 
 const SETTINGS_TRANSFORMERS: Partial<
@@ -88,6 +97,16 @@ const SETTINGS_VALIDATORS: {
   trollbotWebhookUrl: (value: string) => {
     if (!stringIsAValidUrl(value)) {
       throw new Error("TrollBot webhook URL must be a valid URL");
+    }
+  },
+  defaultCampaignBuilderMode: (value: string) => {
+    if (
+      ![
+        CampaignBuilderMode.Basic as string,
+        CampaignBuilderMode.Advanced as string
+      ].includes(value)
+    ) {
+      throw new Error("Invalid campaign builder mode");
     }
   }
 };
@@ -146,7 +165,8 @@ export const resolvers = {
       "showContactCell",
       "confirmationClickForScriptLinks",
       "startCampaignRequiresApproval",
-      "scriptPreviewForSupervolunteers"
+      "scriptPreviewForSupervolunteers",
+      "defaultCampaignBuilderMode"
     ])
   }
 };


### PR DESCRIPTION
## Description

This adds Basic / Advanced (default) campaign builder modes.

## Motivation and Context

Closes #1183 

## How Has This Been Tested?

This has been tested locally.

- [ ] Add `defaultCampaignBuilderMode` to org settings test suite

## Screenshots (if appropriate):

<table><tr><td>

<img width="564" alt="Politics_Rewired_-_Settings" src="https://user-images.githubusercontent.com/2145526/168514190-adf82357-0c08-45ed-88e8-9675ad46843c.png">

</td></tr><tr><td>

<img width="1180" alt="Politics_Rewired_-_Campaigns_-_35__COPY_-_Debug_Survey_Question_Visibility" src="https://user-images.githubusercontent.com/2145526/168514388-21ba6970-b8e1-4c6d-b0f2-16d60e59cf93.png">

</td></tr></table>

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

Campaign builder modes should be documented, but are not yet.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
