### PR TITLE
fix(session): handle suspension check when no user is found

### DIFF
--- a/src/server/auth-passport/auth0.ts
+++ b/src/server/auth-passport/auth0.ts
@@ -57,11 +57,6 @@ export function setupAuth0Passport() {
       .where({ auth0_id: auth0Id })
       .first();
 
-    if (existingUser.is_suspended) {
-      await handleSuspendedUser(req, res);
-      return;
-    }
-
     if (!existingUser) {
       // eslint-disable-next-line no-underscore-dangle
       const userJson = req.user._json;
@@ -79,6 +74,11 @@ export function setupAuth0Passport() {
       await db.primary("user").insert(userData);
 
       return redirectPostSignIn(req, res, true);
+    }
+
+    if (existingUser.is_suspended) {
+      await handleSuspendedUser(req, res);
+      return;
     }
 
     return redirectPostSignIn(req, res, false);

--- a/src/server/auth-passport/auth0.ts
+++ b/src/server/auth-passport/auth0.ts
@@ -76,7 +76,7 @@ export function setupAuth0Passport() {
       return redirectPostSignIn(req, res, true);
     }
 
-    if (existingUser.is_suspended) {
+    if (existingUser.is_suspended === true) {
       await handleSuspendedUser(req, res);
       return;
     }

--- a/src/server/auth-passport/local.ts
+++ b/src/server/auth-passport/local.ts
@@ -58,7 +58,7 @@ export function setupLocalAuthPassport() {
           uuidMatch,
           reqBody: req.body
         });
-        if (user.is_suspended) {
+        if (user?.is_suspended === true) {
           return done(new SuspendedUserError());
         }
         return done(null, user);

--- a/src/server/auth-passport/slack.ts
+++ b/src/server/auth-passport/slack.ts
@@ -89,11 +89,6 @@ export function setupSlackPassport() {
         throw err;
       });
 
-    if (existingUser.is_suspended) {
-      await handleSuspendedUser(req, res);
-      return;
-    }
-
     if (!existingUser && SLACK_CONVERT_EXISTING) {
       const [existingEmailUser] = await db
         .primary("user")
@@ -142,6 +137,11 @@ export function setupSlackPassport() {
         });
 
       return redirectPostSignIn(req, res, true);
+    }
+
+    if (existingUser.is_suspended) {
+      await handleSuspendedUser(req, res);
+      return;
     }
 
     return redirectPostSignIn(req, res, false);

--- a/src/server/auth-passport/slack.ts
+++ b/src/server/auth-passport/slack.ts
@@ -139,7 +139,7 @@ export function setupSlackPassport() {
       return redirectPostSignIn(req, res, true);
     }
 
-    if (existingUser.is_suspended) {
+    if (existingUser.is_suspended === true) {
       await handleSuspendedUser(req, res);
       return;
     }

--- a/src/server/models/cacheable_queries/user.ts
+++ b/src/server/models/cacheable_queries/user.ts
@@ -41,7 +41,7 @@ export async function userLoggedIn(
       ? await getUserByAuth0Id({ auth0Id: val })
       : null;
 
-  return result.is_suspended ? null : result;
+  return result?.is_suspended === true ? null : result;
 }
 
 export async function currentEditors(


### PR DESCRIPTION
## Description

Check `is_suspended` in a safe way.

## Motivation and Context

Evaluating `user.is_suspended` throws a TypeError when user is undefined.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
