### PR TITLE
feat: add template campaigns

### DIFF
--- a/libs/spoke-codegen/src/graphql/template-campaigns.graphql
+++ b/libs/spoke-codegen/src/graphql/template-campaigns.graphql
@@ -1,0 +1,47 @@
+fragment TemplateCampaign on Campaign {
+  id
+  title
+  description
+  introHtml
+  primaryColor
+  logoImageUrl
+  teams {
+    id
+    title
+  }
+  isAssignmentLimitedToTeams
+  campaignGroups {
+    pageInfo {
+      totalCount
+    }
+  }
+  createdAt
+  creator {
+    id
+    email
+    displayName
+  }
+}
+
+query GetTemplateCampaigns($organizationId: String!) {
+  organization(id: $organizationId) {
+    id
+    templateCampaigns {
+      pageInfo {
+        startCursor
+        hasNextPage
+      }
+      edges {
+        node {
+          ...TemplateCampaign
+        }
+      }
+    }
+  }
+}
+
+mutation CreateTemplateCampaign($organizationId: String!) {
+  createTemplateCampaign(organizationId: $organizationId) {
+    ...TemplateCampaign
+  }
+}

--- a/src/api/campaign.ts
+++ b/src/api/campaign.ts
@@ -76,7 +76,7 @@ export interface CampaignInput {
   isAssignmentLimitedToTeams: boolean | null;
   teamIds: string[];
   campaignGroupIds: string[] | null;
-  texters: TexterInput;
+  texters: TexterInput | null;
   interactionSteps: InteractionStepWithChildren;
   cannedResponses: CannedResponseInput[];
   textingHoursStart: number | null;
@@ -212,6 +212,7 @@ export const schema = `
     isApproved: Boolean!
     isStarted: Boolean
     isArchived: Boolean
+    isTemplate: Boolean!
     creator: User
     texters: [User]
     assignments(assignmentsFilter: AssignmentsFilter): [Assignment]

--- a/src/api/organization.ts
+++ b/src/api/organization.ts
@@ -112,6 +112,7 @@ export const schema = `
     externalSystems(after: Cursor, first: Int): ExternalSystemPage!
     messagingServices(after: Cursor, first: Int): MessagingServicePage!
     campaignGroups(after: Cursor, first: Int): CampaignGroupPage!
+    templateCampaigns(after: Cursor, first: Int): CampaignPage!
   }
 
   input EditOrganizationInput {

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -34,6 +34,7 @@ const rootSchema = `
   enum CampaignBuilderMode {
     BASIC
     ADVANCED
+    TEMPLATE
   }
 
   input BulkUpdateScriptInput {
@@ -242,6 +243,7 @@ const rootSchema = `
   type RootMutation {
     createInvite(invite:InviteInput!): Invite
     createCampaign(campaign:CampaignInput!): Campaign
+    createTemplateCampaign(organizationId: String!): Campaign!
     editCampaign(id:String!, campaign:CampaignInput!): Campaign
     saveCampaignGroups(organizationId: String!, campaignGroups: [CampaignGroupInput!]!): [CampaignGroup!]!
     deleteCampaignGroup(organizationId: String!, campaignGroupId: String!): Boolean!

--- a/src/components/AdminDashboard.jsx
+++ b/src/components/AdminDashboard.jsx
@@ -68,6 +68,7 @@ class AdminDashboard extends React.Component {
 
     const sections = [
       { name: "Campaigns", path: "campaigns", role: "ADMIN" },
+      { name: "Template Campaigns", path: "template-campaigns", role: "ADMIN" },
       { name: "Campaign Groups", path: "campaign-groups", role: "ADMIN" },
       { name: "People", path: "people", role: "ADMIN" },
       { name: "Teams", path: "teams", role: "ADMIN" },

--- a/src/containers/AdminCampaignEdit/index.jsx
+++ b/src/containers/AdminCampaignEdit/index.jsx
@@ -77,7 +77,9 @@ class AdminCampaignEdit extends React.Component {
       startingCampaign: false,
       isWorking: false,
       requestError: undefined,
-      builderMode: props.orgSettings.defaultCampaignBuilderMode
+      builderMode: props.campaignData.campaign.isTemplate
+        ? CampaignBuilderMode.Template
+        : props.orgSettings.defaultCampaignBuilderMode
     };
   }
 
@@ -319,7 +321,11 @@ class AdminCampaignEdit extends React.Component {
         title: "Basics",
         content: CampaignBasicsForm,
         isStandalone: true,
-        showForModes: [CampaignBuilderMode.Basic, CampaignBuilderMode.Advanced],
+        showForModes: [
+          CampaignBuilderMode.Basic,
+          CampaignBuilderMode.Advanced,
+          CampaignBuilderMode.Template
+        ],
         keys: [
           "title",
           "description",
@@ -339,7 +345,10 @@ class AdminCampaignEdit extends React.Component {
         title: "Campaign Groups",
         content: CampaignGroupsForm,
         isStandalone: true,
-        showForModes: [CampaignBuilderMode.Advanced],
+        showForModes: [
+          CampaignBuilderMode.Advanced,
+          CampaignBuilderMode.Template
+        ],
         keys: ["campaignGroups"],
         exclude: !window.ENABLE_CAMPAIGN_GROUPS,
         checkCompleted: () => true,
@@ -363,7 +372,11 @@ class AdminCampaignEdit extends React.Component {
         title: "Integration",
         content: CampaignIntegrationForm,
         isStandalone: true,
-        showForModes: [CampaignBuilderMode.Basic, CampaignBuilderMode.Advanced],
+        showForModes: [
+          CampaignBuilderMode.Basic,
+          CampaignBuilderMode.Advanced,
+          CampaignBuilderMode.Template
+        ],
         keys: ["externalSystem"],
         checkCompleted: () => true,
         blocksStarting: false,
@@ -452,7 +465,10 @@ class AdminCampaignEdit extends React.Component {
       {
         title: "Teams",
         content: CampaignTeamsForm,
-        showForModes: [CampaignBuilderMode.Advanced],
+        showForModes: [
+          CampaignBuilderMode.Advanced,
+          CampaignBuilderMode.Template
+        ],
         keys: ["teams", "isAssignmentLimitedToTeams"],
         checkSaved: () => {
           const {
@@ -501,7 +517,11 @@ class AdminCampaignEdit extends React.Component {
         title: "Interactions",
         content: CampaignInteractionStepsForm,
         isStandalone: true,
-        showForModes: [CampaignBuilderMode.Basic, CampaignBuilderMode.Advanced],
+        showForModes: [
+          CampaignBuilderMode.Basic,
+          CampaignBuilderMode.Advanced,
+          CampaignBuilderMode.Template
+        ],
         keys: ["interactionSteps"],
         checkCompleted: () =>
           this.props.campaignData.campaign.readiness.interactions,
@@ -517,7 +537,10 @@ class AdminCampaignEdit extends React.Component {
         title: "Canned Responses",
         content: CampaignCannedResponsesForm,
         isStandalone: true,
-        showForModes: [CampaignBuilderMode.Advanced],
+        showForModes: [
+          CampaignBuilderMode.Advanced,
+          CampaignBuilderMode.Template
+        ],
         keys: ["cannedResponses"],
         checkCompleted: () => true,
         blocksStarting: true,
@@ -635,7 +658,7 @@ class AdminCampaignEdit extends React.Component {
 
   renderHeader = () => {
     const {
-      campaign: { dueBy, isStarted, title } = {}
+      campaign: { dueBy, isStarted, title, isTemplate } = {}
     } = this.props.campaignData;
 
     const isOverdue = DateTime.local() >= DateTime.fromISO(dueBy);
@@ -663,44 +686,52 @@ class AdminCampaignEdit extends React.Component {
           fontSize: 16
         }}
       >
-        <Grid container justifyContent="space-between">
-          <Grid item>
-            <Button variant="contained" onClick={this.handleNavigateToStats}>
-              Details
-            </Button>
-          </Grid>
-          <Grid item>
-            <FormControl style={{ width: 120 }}>
-              <InputLabel id="campaign-builder-mode-label">
-                Builder Mode
-              </InputLabel>
-              <Select
-                labelId="campaign-builder-mode-label"
-                id="campaign-builder-mode-select"
-                fullWidth
-                value={this.state.builderMode}
-                onChange={(event) => {
-                  this.setState({ builderMode: event.target.value });
-                }}
-              >
-                <MenuItem value={CampaignBuilderMode.Basic}>Basic</MenuItem>
-                <MenuItem value={CampaignBuilderMode.Advanced}>
-                  Advanced
-                </MenuItem>
-              </Select>
-            </FormControl>
-          </Grid>
-          <Grid item>
-            <CampaignNavigation
-              prevCampaignClicked={this.prevCampaignClicked}
-              nextCampaignClicked={this.nextCampaignClicked}
-              campaignId={this.props.campaignData.campaign.id}
-            />
-          </Grid>
-        </Grid>
-        <Divider style={{ marginTop: 20, marginBottom: 20 }} />
+        {!isTemplate && (
+          <>
+            <Grid container justifyContent="space-between">
+              <Grid item>
+                <Button
+                  variant="contained"
+                  onClick={this.handleNavigateToStats}
+                >
+                  Details
+                </Button>
+              </Grid>
+              <Grid item>
+                <FormControl style={{ width: 120 }}>
+                  <InputLabel id="campaign-builder-mode-label">
+                    Builder Mode
+                  </InputLabel>
+                  <Select
+                    labelId="campaign-builder-mode-label"
+                    id="campaign-builder-mode-select"
+                    fullWidth
+                    value={this.state.builderMode}
+                    onChange={(event) => {
+                      this.setState({ builderMode: event.target.value });
+                    }}
+                  >
+                    <MenuItem value={CampaignBuilderMode.Basic}>Basic</MenuItem>
+                    <MenuItem value={CampaignBuilderMode.Advanced}>
+                      Advanced
+                    </MenuItem>
+                  </Select>
+                </FormControl>
+              </Grid>
+              <Grid item>
+                <CampaignNavigation
+                  prevCampaignClicked={this.prevCampaignClicked}
+                  nextCampaignClicked={this.nextCampaignClicked}
+                  campaignId={this.props.campaignData.campaign.id}
+                />
+              </Grid>
+            </Grid>
+
+            <Divider style={{ marginTop: 20, marginBottom: 20 }} />
+          </>
+        )}
         {title && <h1> {title} </h1>}
-        {this.state.startingCampaign ? (
+        {!isTemplate && this.state.startingCampaign && (
           <div style={{ color: theme.colors.gray }}>
             <CircularProgress
               size={0.5}
@@ -711,9 +742,8 @@ class AdminCampaignEdit extends React.Component {
             />
             Starting your campaign...
           </div>
-        ) : (
-          notStarting
         )}
+        {!isTemplate && !this.state.startingCampaign && notStarting}
       </div>
     );
   };

--- a/src/containers/AdminCampaignEdit/queries.ts
+++ b/src/containers/AdminCampaignEdit/queries.ts
@@ -70,6 +70,7 @@ export const EditCampaignFragment = gql`
     isStarted
     isApproved
     isArchived
+    isTemplate
     contactsCount
     datawarehouseAvailable
     customFields

--- a/src/containers/AdminTemplateCampaigns/components/TemplateCampaignRow.tsx
+++ b/src/containers/AdminTemplateCampaigns/components/TemplateCampaignRow.tsx
@@ -1,0 +1,94 @@
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import CardHeader from "@material-ui/core/CardHeader";
+import Chip from "@material-ui/core/Chip";
+import IconButton from "@material-ui/core/IconButton";
+import { makeStyles } from "@material-ui/core/styles";
+import EditIcon from "@material-ui/icons/Edit";
+import type { TemplateCampaignFragment } from "@spoke/spoke-codegen";
+import isEmpty from "lodash/isEmpty";
+import type { ReactNode } from "react";
+import React from "react";
+
+import { DateTime } from "../../../lib/datetime";
+
+const useStyles = makeStyles((theme) => ({
+  campaignInfo: {
+    display: "flex",
+    flexWrap: "wrap",
+    "& > *": {
+      margin: theme.spacing(1)
+    }
+  }
+}));
+
+export interface TemplateCampaignRowProps {
+  templateCampaign: TemplateCampaignFragment;
+  onClickEdit?: () => Promise<void> | void;
+}
+
+export const TemplateCampaignRow: React.FC<TemplateCampaignRowProps> = ({
+  templateCampaign,
+  onClickEdit
+}) => {
+  const classes = useStyles();
+
+  const createdAt = DateTime.fromISO(
+    templateCampaign.createdAt
+  ).toLocaleString();
+
+  const campaignGroupCount =
+    templateCampaign.campaignGroups?.pageInfo.totalCount ?? 0;
+  const teamCount = templateCampaign.teams.length;
+
+  const chips: ReactNode[] = [];
+  if (campaignGroupCount > 0) {
+    chips.push(
+      <Chip
+        key="campaign-groups"
+        label={`${campaignGroupCount} Campaign Groups`}
+      />
+    );
+  }
+  if (teamCount > 0) {
+    chips.push(<Chip key="teams" label={`${teamCount} Teams`} />);
+  }
+  if (templateCampaign.isAssignmentLimitedToTeams) {
+    chips.push(
+      <Chip key="assignment-restriction" label="Assignment Limited to Teams" />
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader
+        title={templateCampaign.title}
+        subheader={
+          <>
+            <span>
+              {isEmpty(templateCampaign.description)
+                ? "No description"
+                : templateCampaign.description}
+            </span>
+            <br />
+            <span>
+              Created {createdAt} by {templateCampaign.creator?.displayName}
+            </span>
+          </>
+        }
+        action={
+          <IconButton aria-label="edit" onClick={onClickEdit}>
+            <EditIcon />
+          </IconButton>
+        }
+      />
+      {chips.length > 0 && (
+        <CardContent>
+          <div className={classes.campaignInfo}>{chips}</div>
+        </CardContent>
+      )}
+    </Card>
+  );
+};
+
+export default TemplateCampaignRow;

--- a/src/containers/AdminTemplateCampaigns/index.tsx
+++ b/src/containers/AdminTemplateCampaigns/index.tsx
@@ -2,6 +2,7 @@ import Fab from "@material-ui/core/Fab";
 import { makeStyles } from "@material-ui/core/styles";
 import AddIcon from "@material-ui/icons/Add";
 import {
+  GetTemplateCampaignsDocument,
   useCreateTemplateCampaignMutation,
   useGetTemplateCampaignsQuery
 } from "@spoke/spoke-codegen";
@@ -33,15 +34,26 @@ export const AdminTemplateCampaigns: React.FC = () => {
   const [
     createTemplateCampaign,
     { loading: createTemplateLoading }
-  ] = useCreateTemplateCampaignMutation();
+  ] = useCreateTemplateCampaignMutation({
+    refetchQueries: [
+      { query: GetTemplateCampaignsDocument, variables: { organizationId } }
+    ]
+  });
 
   const templateCampaigns = (
     data?.organization?.templateCampaigns?.edges ?? []
   ).map(({ node }) => node);
 
   const handleClickCreateTemplate = useCallback(async () => {
-    await createTemplateCampaign({ variables: { organizationId } });
-  }, [createTemplateCampaign]);
+    const result = await createTemplateCampaign({
+      variables: { organizationId }
+    });
+    if (result.errors) throw result.errors[0];
+    const newTemplateId = result.data?.createTemplateCampaign.id;
+    history.push(
+      `/admin/${organizationId}/template-campaigns/${newTemplateId}`
+    );
+  }, [createTemplateCampaign, history]);
 
   const createHandleClickEdit = (templateCampaignId: string) => () => {
     history.push(

--- a/src/containers/AdminTemplateCampaigns/index.tsx
+++ b/src/containers/AdminTemplateCampaigns/index.tsx
@@ -1,0 +1,79 @@
+import Fab from "@material-ui/core/Fab";
+import { makeStyles } from "@material-ui/core/styles";
+import AddIcon from "@material-ui/icons/Add";
+import {
+  useCreateTemplateCampaignMutation,
+  useGetTemplateCampaignsQuery
+} from "@spoke/spoke-codegen";
+import React, { useCallback } from "react";
+import { useHistory, useParams } from "react-router-dom";
+
+import TemplateCampaignRow from "./components/TemplateCampaignRow";
+
+const useStyles = makeStyles((theme) => ({
+  listContainer: {
+    "& > *": {
+      margin: theme.spacing(1)
+    }
+  },
+  fab: {
+    position: "absolute",
+    bottom: theme.spacing(2),
+    right: theme.spacing(2)
+  }
+}));
+
+export const AdminTemplateCampaigns: React.FC = () => {
+  const classes = useStyles();
+  const history = useHistory();
+  const { organizationId } = useParams<{ organizationId: string }>();
+  const { data, loading, error } = useGetTemplateCampaignsQuery({
+    variables: { organizationId }
+  });
+  const [
+    createTemplateCampaign,
+    { loading: createTemplateLoading }
+  ] = useCreateTemplateCampaignMutation();
+
+  const templateCampaigns = (
+    data?.organization?.templateCampaigns?.edges ?? []
+  ).map(({ node }) => node);
+
+  const handleClickCreateTemplate = useCallback(async () => {
+    await createTemplateCampaign({ variables: { organizationId } });
+  }, [createTemplateCampaign]);
+
+  const createHandleClickEdit = (templateCampaignId: string) => () => {
+    history.push(
+      `/admin/${organizationId}/template-campaigns/${templateCampaignId}`
+    );
+  };
+
+  return (
+    <>
+      {loading && "Loading..."}
+      {error && <p>{error.message}</p>}
+      {!loading && templateCampaigns.length === 0 && "No Campaigns"}
+      <div className={classes.listContainer}>
+        {templateCampaigns.map((templateCampaign) => (
+          <TemplateCampaignRow
+            key={templateCampaign.id}
+            templateCampaign={templateCampaign}
+            onClickEdit={createHandleClickEdit(templateCampaign.id)}
+          />
+        ))}
+      </div>
+      <Fab
+        color="primary"
+        className={classes.fab}
+        aria-label="add"
+        disabled={createTemplateLoading}
+        onClick={handleClickCreateTemplate}
+      >
+        <AddIcon />
+      </Fab>
+    </>
+  );
+};
+
+export default AdminTemplateCampaigns;

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -27,6 +27,7 @@ import AdminShortLinkDomains from "./containers/AdminShortLinkDomains";
 import AdminTagEditor from "./containers/AdminTagEditor";
 import AdminTeamEditor from "./containers/AdminTeamEditor";
 import TeamEditorDetail from "./containers/AdminTeamEditor/TeamEditorDetail";
+import AdminTemplateCampaigns from "./containers/AdminTemplateCampaigns";
 import AdminTrollAlarms from "./containers/AdminTrollAlarms";
 import CreateOrganization from "./containers/CreateOrganization";
 import DashboardLoader from "./containers/DashboardLoader";
@@ -120,6 +121,21 @@ const AdminTeamRoutes = () => {
   );
 };
 
+const AdminTemplateCampaignRoutes = () => {
+  // Use full path over props.match.path to get access to organizationId param
+  const templatesPath = "/admin/:organizationId/template-campaigns";
+  return (
+    <Switch>
+      <Route path={templatesPath} exact component={AdminTemplateCampaigns} />
+      <Route
+        path={`${templatesPath}/:campaignId`}
+        component={AdminCampaignEdit}
+      />
+      <Redirect to={templatesPath} />
+    </Switch>
+  );
+};
+
 const AdminOrganizationRoutes = (props) => {
   // Use full path over props.match.path to get access to organizationId param
   const organizationPath = "/admin/:organizationId";
@@ -131,6 +147,10 @@ const AdminOrganizationRoutes = (props) => {
           <Route
             path={`${organizationPath}/campaigns`}
             component={AdminCampaignListRoutes}
+          />
+          <Route
+            path={`${organizationPath}/template-campaigns`}
+            component={AdminTemplateCampaignRoutes}
           />
           <Route
             path={`${organizationPath}/campaign-groups`}

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -2,6 +2,7 @@
 enum CampaignBuilderMode {
   BASIC
   ADVANCED
+  TEMPLATE
 }
 
 input BulkUpdateScriptInput {
@@ -210,6 +211,7 @@ input SecondPassInput {
 type RootMutation {
   createInvite(invite:InviteInput!): Invite
   createCampaign(campaign:CampaignInput!): Campaign
+  createTemplateCampaign(organizationId: String!): Campaign!
   editCampaign(id:String!, campaign:CampaignInput!): Campaign
   saveCampaignGroups(organizationId: String!, campaignGroups: [CampaignGroupInput!]!): [CampaignGroup!]!
   deleteCampaignGroup(organizationId: String!, campaignGroupId: String!): Boolean!
@@ -387,6 +389,7 @@ type Organization {
   externalSystems(after: Cursor, first: Int): ExternalSystemPage!
   messagingServices(after: Cursor, first: Int): MessagingServicePage!
   campaignGroups(after: Cursor, first: Int): CampaignGroupPage!
+  templateCampaigns(after: Cursor, first: Int): CampaignPage!
 }
 
 input EditOrganizationInput {
@@ -571,6 +574,7 @@ type Campaign {
   isApproved: Boolean!
   isStarted: Boolean
   isArchived: Boolean
+  isTemplate: Boolean!
   creator: User
   texters: [User]
   assignments(assignmentsFilter: AssignmentsFilter): [Assignment]

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -396,6 +396,8 @@ export const resolvers = {
     ]),
     isApproved: (campaign) =>
       isNil(campaign.is_approved) ? false : campaign.is_approved,
+    isTemplate: (campaign) =>
+      isNil(campaign.is_template) ? false : campaign.is_template,
     timezone: (campaign) => parseIanaZone(campaign.timezone),
     readiness: (campaign) => campaign,
     repliesStaleAfter: (campaign) => campaign.replies_stale_after_minutes,

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -48,6 +48,15 @@ export const resolvers = {
       filter.organizationId = organization.id;
       return getCampaignsRelay({ first, after, filter });
     },
+    templateCampaigns: async (organization, { first, after }, { user }) => {
+      await accessRequired(user, organization.id, "SUPERVOLUNTEER");
+      const query = r
+        .reader("all_campaign")
+        .where({ is_template: true })
+        .select("*");
+      const pagerOptions = { first, after };
+      return formatPage(query, pagerOptions);
+    },
     uuid: async (organization, _, { user }) => {
       await accessRequired(user, organization.id, "SUPERVOLUNTEER");
       const result = await r

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -942,7 +942,7 @@ const rootMutations = {
       { id, campaign: campaignEdits },
       { user, loaders }
     ) => {
-      const origCampaign = await r.knex("campaign").where({ id }).first();
+      const origCampaign = await r.knex("all_campaign").where({ id }).first();
       const { features } = await loaders.organization.load(
         origCampaign.organization_id
       );

--- a/src/server/api/types.ts
+++ b/src/server/api/types.ts
@@ -85,6 +85,7 @@ export interface CampaignRecord {
   description: string;
   is_approved: boolean;
   is_started: boolean | null;
+  is_template: boolean;
   due_by: string | null;
   created_at: string;
   is_archived: boolean | null;

--- a/src/server/models/cacheable_queries/campaign.js
+++ b/src/server/models/cacheable_queries/campaign.js
@@ -51,7 +51,7 @@ const clear = async (id) => {
 
 const loadDeep = async (id) => {
   if (r.redis) {
-    const campaign = await r.reader("campaign").where({ id }).first();
+    const campaign = await r.reader("all_campaign").where({ id }).first();
     if (campaign.is_archived) {
       // do not cache archived campaigns
       await clear(id);
@@ -95,7 +95,7 @@ export const campaignCache = {
         return campaign;
       }
     }
-    return r.reader("campaign").where({ id }).first();
+    return r.reader("all_campaign").where({ id }).first();
   },
   reload: loadDeep,
   dbCustomFields,

--- a/src/server/models/index.ts
+++ b/src/server/models/index.ts
@@ -48,7 +48,7 @@ const createLoader = <T = unknown>(
 const createLoaders = (context: SpokeContext) => ({
   assignment: createLoader(context, "assignment"),
   assignmentRequest: createLoader(context, "assignment_request"),
-  campaign: createLoader(context, "campaign", {
+  campaign: createLoader(context, "all_campaign", {
     cacheObj: cacheableData.campaign
   }),
   campaignContact: createLoader(context, "campaign_contact"),


### PR DESCRIPTION
## Description

This adds management of Template Campaigns.

It also fixes a small bug in how `editCampaign()` handles editing `texters` and brings it in line with how other sections are handled.

## Motivation and Context

Part 2 of 3 for #1181.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<table>
<tr><td>

![Screen Shot 2022-05-16 at 7 33 58 AM](https://user-images.githubusercontent.com/2145526/168820666-1ac9837f-8a8b-4004-844e-b59fb77dd003.png)

Template Campaign management.

</td><tr>
<tr><td>

![Screen Shot 2022-05-16 at 7 35 28 AM](https://user-images.githubusercontent.com/2145526/168820519-980c5d14-6550-4a4b-a873-1d382acd30a5.png)

Campaign Builder

</td><tr>
</table>

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

This is user-facing and should be documented, but is not yet. Documentation will be added as part of part 3 (creating campaigns from templates).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
