### PR TITLE
fix(passport): standardize on spoke user

### DIFF
--- a/src/server/api/types.ts
+++ b/src/server/api/types.ts
@@ -56,6 +56,7 @@ export interface UserRecord {
   is_superadmin: boolean | null;
   terms: boolean;
   updated_at: string;
+  is_suspended: boolean;
 }
 
 export interface OrganizationRecord {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -14,6 +14,7 @@ import logger from "../logger";
 import { fulfillPendingRequestFor } from "./api/assignment";
 import pgPool from "./db";
 import appRenderer from "./middleware/app-renderer";
+import { userLoggedIn } from "./models/cacheable_queries";
 import {
   assembleRouter,
   authRouter,
@@ -74,6 +75,16 @@ export const createApp = async () => {
   );
   app.use(passport.initialize());
   app.use(passport.session());
+
+  passport.serializeUser(({ id }: { id: string }, done: any) => {
+    done(null, id);
+  });
+
+  passport.deserializeUser((userId: any, done: any) =>
+    userLoggedIn(userId, "id")
+      .then((user: any) => done(null, user || false))
+      .catch((error: any) => done(error))
+  );
 
   if (PUBLIC_DIR) {
     app.use(express.static(PUBLIC_DIR, { maxAge: "180 days" }));

--- a/src/server/auth-passport/auth0.ts
+++ b/src/server/auth-passport/auth0.ts
@@ -51,7 +51,7 @@ export function setupAuth0Passport() {
       }
 
       // eslint-disable-next-line no-underscore-dangle
-      const userJson = req.user._json;
+      const userJson = auth0User._json;
       const userMetadata =
         userJson["https://spoke/user_metadata"] || userJson.user_metadata || {};
       const userData = {

--- a/src/server/auth-passport/auth0.ts
+++ b/src/server/auth-passport/auth0.ts
@@ -1,15 +1,14 @@
 import passport from "@passport-next/passport";
-import type { Response } from "express";
 import express from "express";
 import Auth0Strategy from "passport-auth0";
 
 import { config } from "../../config";
+import logger from "../../logger";
 import { capitalizeWord } from "../api/lib/utils";
 import { contextForRequest } from "../contexts";
-import { getUserByAuth0Id, userLoggedIn } from "../models/cacheable_queries";
 import type { SpokeRequest } from "../types";
-import type { PassportCallback } from "./util";
-import { handleSuspendedUser, redirectPostSignIn } from "./util";
+import type { PassportCallback, UserWithStatus } from "./util";
+import { passportCallback } from "./util";
 
 const { BASE_URL, AUTH0_DOMAIN, AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET } = config;
 
@@ -19,47 +18,38 @@ export function setupAuth0Passport() {
       domain: AUTH0_DOMAIN,
       clientID: AUTH0_CLIENT_ID,
       clientSecret: AUTH0_CLIENT_SECRET,
-      callbackURL: `${BASE_URL}/login-callback`
+      callbackURL: `${BASE_URL}/login-callback`,
+      passReqToCallback: true
     },
-    (
+    async (
+      req: SpokeRequest,
       accessToken: string,
       refreshToken: string,
       extraParams: Record<string, unknown>,
-      profile: any,
+      auth0User: any,
       done: PassportCallback
-    ) => done(null, profile)
-  );
+    ) => {
+      const auth0Id = auth0User.id ?? auth0User._json.sub;
+      if (!auth0Id) {
+        return done(new Error("Null user in Auth0 login callback"));
+      }
 
-  passport.use(strategy);
+      const { db } = contextForRequest(req);
 
-  passport.serializeUser((auth0User: any, done: any) => {
-    // This is the Auth0 user object, not the db one
-    // eslint-disable-next-line no-underscore-dangle
-    const auth0Id = auth0User.id || auth0User._json.sub;
-    getUserByAuth0Id({ auth0Id })
-      .then((spokeUser) => done(null, spokeUser?.id))
-      .catch((err) => done(err));
-  });
+      // Attempt login
+      try {
+        const spokeUser = await db
+          .reader("user")
+          .where({ auth0_id: auth0Id })
+          .first();
+        if (spokeUser) {
+          return done(null, spokeUser);
+        }
+      } catch (err: any) {
+        logger.error("Auth0 login error: could not find existing user: ", err);
+        return done(err);
+      }
 
-  passport.deserializeUser((userId: string, done: any) =>
-    userLoggedIn(userId, "id")
-      .then((user: any) => done(null, user || false))
-      .catch((error: any) => done(error))
-  );
-
-  const handleLogin = async (req: SpokeRequest, res: Response) => {
-    const { db } = contextForRequest(req);
-    const auth0Id = req.user && (req.user.id || req.user._json.sub);
-    if (!auth0Id) {
-      throw new Error("Null user in login callback");
-    }
-
-    const existingUser = await db
-      .reader("user")
-      .where({ auth0_id: auth0Id })
-      .first();
-
-    if (!existingUser) {
       // eslint-disable-next-line no-underscore-dangle
       const userJson = req.user._json;
       const userMetadata =
@@ -73,25 +63,27 @@ export function setupAuth0Passport() {
         is_superadmin: false
       };
 
-      await db.primary("user").insert(userData);
-
-      return redirectPostSignIn(req, res, true);
+      try {
+        const spokeUser = await db
+          .primary<UserWithStatus>("user")
+          .insert(userData)
+          .returning("*")
+          .then(([user]) => ({ ...user, isNew: true }));
+        return done(null, spokeUser);
+      } catch (err: any) {
+        logger.error("Error creating new Auth0 user: ", err);
+        return done(err);
+      }
     }
+  );
 
-    if (existingUser.is_suspended === true) {
-      await handleSuspendedUser(req, res);
-      return;
-    }
-
-    return redirectPostSignIn(req, res, false);
-  };
+  passport.use(strategy);
 
   const app = express();
-  app.get(
-    "/login-callback",
-    passport.authenticate("auth0", { failureRedirect: "/login" }),
-    handleLogin
-  );
+  app.get("/login-callback", (req, res, next) => {
+    const callback = passportCallback(req, res, next);
+    return passport.authenticate("auth0", callback)(req, res, next);
+  });
   return app;
 }
 

--- a/src/server/auth-passport/slack.ts
+++ b/src/server/auth-passport/slack.ts
@@ -1,17 +1,15 @@
 import passport from "@passport-next/passport";
 import passportSlack from "@rewired/passport-slack";
-import type { Response } from "express";
 import express from "express";
 
 import { config } from "../../config";
 import logger from "../../logger";
 import { contextForRequest } from "../contexts";
 import { botClient } from "../lib/slack";
-import { getUserByAuth0Id, userLoggedIn } from "../models/cacheable_queries";
 import type { SpokeRequest } from "../types";
 import { errToObj } from "../utils";
-import type { PassportCallback } from "./util";
-import { handleSuspendedUser, redirectPostSignIn } from "./util";
+import type { PassportCallback, UserWithStatus } from "./util";
+import { passportCallback } from "./util";
 
 const {
   BASE_URL,
@@ -21,6 +19,29 @@ const {
   SLACK_SCOPES,
   SLACK_CONVERT_EXISTING
 } = config;
+
+const namePartsFromSlack = (slackUser: any) => {
+  let firstName;
+  let lastName;
+  const splitName = slackUser.name
+    ? slackUser.name.split(" ")
+    : ["First", "Last"];
+  if (slackUser.first_name && slackUser.last_name) {
+    // Spoke was granted the 'users.profile:read' scope so use Slack-provided first/last
+    firstName = slackUser.first_name;
+    lastName = slackUser.last_name;
+  } else if (splitName.length === 1) {
+    [firstName] = splitName;
+    lastName = "";
+  } else if (splitName.length === 2) {
+    [firstName, lastName] = splitName;
+  } else {
+    [firstName] = splitName;
+    lastName = splitName.slice(1, splitName.length + 1).join(" ");
+  }
+
+  return { firstName, lastName };
+};
 
 export function setupSlackPassport() {
   const options = {
@@ -33,121 +54,92 @@ export function setupSlackPassport() {
   };
 
   const strategy = new passportSlack.Strategy(
-    options,
+    { ...options, passReqToCallback: true },
     async (
+      req: SpokeRequest,
       accessToken: string,
       scopes: string[],
       team: string,
       // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
       { bot, incomingWebhook }: { bot: string; incomingWebhook: string },
       // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-      { user, team: teamProfile }: { user: any; team: any },
+      { user: slackUser, team: teamProfile }: { user: any; team: any },
       done: PassportCallback
     ) => {
       // scopes is a Set
       if (config.SLACK_TOKEN) {
         try {
-          const response = await botClient.users.profile.get({ user: user.id });
+          const response = await botClient.users.profile.get({
+            user: slackUser.id
+          });
           const userProfile = response.profile as any;
           const { real_name, first_name, last_name, phone } = userProfile;
-          user = { ...user, real_name, first_name, last_name, phone };
+          slackUser = { ...slackUser, real_name, first_name, last_name, phone };
         } catch (err) {
           logger.error("Error fetching Slack profile: ", errToObj(err));
         }
       }
 
-      return done(null, user);
+      const { db } = contextForRequest(req);
+
+      try {
+        const spokeUser = await db
+          .reader<UserWithStatus>("user")
+          .where({ auth0_id: slackUser.id })
+          .first();
+        if (spokeUser) {
+          return done(null, spokeUser);
+        }
+      } catch (err: any) {
+        logger.error("Slack login error: could not find existing user: ", err);
+        return done(err);
+      }
+
+      if (SLACK_CONVERT_EXISTING) {
+        try {
+          const [spokeUser] = await db
+            .primary("user")
+            .update({ auth0_id: slackUser.id })
+            .where({ email: slackUser.email })
+            .returning("*");
+          if (spokeUser) {
+            return done(null, spokeUser);
+          }
+        } catch (err: any) {
+          logger.error("Error converting existing Slack user: ", err);
+          return done(err);
+        }
+      }
+
+      const { firstName, lastName } = namePartsFromSlack(slackUser);
+      const spokeUserData = {
+        auth0_id: slackUser.id,
+        first_name: firstName,
+        last_name: lastName,
+        cell: slackUser.phone || "unknown",
+        email: slackUser.email,
+        is_superadmin: false
+      };
+
+      try {
+        const spokeUser = await db
+          .primary<UserWithStatus>("user")
+          .insert(spokeUserData)
+          .returning("*")
+          .then(([user]) => ({ ...user, isNew: true }))
+          .catch((err) => {
+            logger.error("Slack login error: could not insert new user: ", err);
+            throw err;
+          });
+        return done(null, spokeUser);
+      } catch (err: any) {
+        logger.error("Error creating new Slack user: ", err);
+        return done(err);
+      }
     }
   );
 
   passport.use(strategy);
-
-  passport.serializeUser(({ id: slackUserId }: { id: string }, done: any) => {
-    getUserByAuth0Id({ auth0Id: slackUserId })
-      .then((spokeUser) => done(null, spokeUser?.id))
-      .catch((err) => done(err));
-  });
-
-  passport.deserializeUser((userId: any, done: any) =>
-    userLoggedIn(userId, "id")
-      .then((user: any) => done(null, user || false))
-      .catch((error: any) => done(error))
-  );
-
-  const handleLogin = async (req: SpokeRequest, res: Response) => {
-    const { db } = contextForRequest(req);
-    const { user } = req;
-    // set slack_id to auth0Id to avoid changing the schema
-    const auth0Id = user && user.id;
-    if (!auth0Id) {
-      throw new Error("Null user in login callback");
-    }
-    let existingUser = await db
-      .reader("user")
-      .where({ auth0_id: auth0Id })
-      .first()
-      .catch((err) => {
-        logger.error("Slack login error: could not find existing user: ", err);
-        throw err;
-      });
-
-    if (!existingUser && SLACK_CONVERT_EXISTING) {
-      const [existingEmailUser] = await db
-        .primary("user")
-        .update({ auth0_id: user.id })
-        .where({ email: user.email })
-        .returning("*");
-
-      if (existingEmailUser) {
-        existingUser = existingEmailUser;
-      }
-    }
-
-    if (!existingUser) {
-      let first_name;
-      let last_name;
-      const splitName = user.name ? user.name.split(" ") : ["First", "Last"];
-      if (user.first_name && user.last_name) {
-        // Spoke was granted the 'users.profile:read' scope so use Slack-provided first/last
-        first_name = user.first_name;
-        last_name = user.last_name;
-      } else if (splitName.length === 1) {
-        [first_name] = splitName;
-        last_name = "";
-      } else if (splitName.length === 2) {
-        [first_name, last_name] = splitName;
-      } else {
-        [first_name] = splitName;
-        last_name = splitName.slice(1, splitName.length + 1).join(" ");
-      }
-
-      const userData = {
-        auth0_id: auth0Id,
-        first_name,
-        last_name,
-        cell: user.phone || "unknown",
-        email: user.email,
-        is_superadmin: false
-      };
-
-      await db
-        .primary("user")
-        .insert(userData)
-        .catch((err) => {
-          logger.error("Slack login error: could not insert new user: ", err);
-          throw err;
-        });
-
-      return redirectPostSignIn(req, res, true);
-    }
-
-    if (existingUser.is_suspended === true) {
-      await handleSuspendedUser(req, res);
-      return;
-    }
-
-    return redirectPostSignIn(req, res, false);
-  };
 
   const app = express();
   app.get("/login", (req, res, next) => {
@@ -159,11 +151,10 @@ export function setupSlackPassport() {
     return passport.authenticate("slack", passportOptions)(req, res, next);
   });
 
-  app.get(
-    "/login-callback",
-    passport.authenticate("slack", { failureRedirect: "/login" }),
-    handleLogin
-  );
+  app.get("/login-callback", (req, res, next) => {
+    const callback = passportCallback(req, res, next);
+    return passport.authenticate("slack", callback)(req, res, next);
+  });
   return app;
 }
 

--- a/src/server/models/cacheable_queries/user.ts
+++ b/src/server/models/cacheable_queries/user.ts
@@ -9,10 +9,10 @@ import thinky from "../thinky";
 
 const { r } = thinky;
 
-const getUserByAuth0Id = memoizer.memoize(
+export const getUserByAuth0Id = memoizer.memoize(
   async ({ auth0Id }: { auth0Id: string | number }) => {
     const userAuth = await r
-      .reader("user")
+      .reader<UserRecord>("user")
       .where("auth0_id", auth0Id)
       .first("*");
 

--- a/src/server/models/cacheable_queries/user.ts
+++ b/src/server/models/cacheable_queries/user.ts
@@ -9,10 +9,10 @@ import thinky from "../thinky";
 
 const { r } = thinky;
 
-export const getUserByAuth0Id = memoizer.memoize(
+const getUserByAuth0Id = memoizer.memoize(
   async ({ auth0Id }: { auth0Id: string | number }) => {
     const userAuth = await r
-      .reader<UserRecord>("user")
+      .reader("user")
       .where("auth0_id", auth0Id)
       .first("*");
 


### PR DESCRIPTION
## Description

This PR does a few things:
- Standardizes return type of Passport strategies on Spoke user record. This involves moving all Spoke user checking and creation into all Passport strategies (as Passport examples show it is intended to be done).
- Consolidates all post-authentication logic into a single `passportCallback`.

## Motivation and Context

This is the intended Passport flow: the strategy callback processes the authentication result and returns an _application_ user. That application user, standardized across all strategies, is what we store in the session.

This fixes an issue where `auth0Id`-based sessions (`auth0` and `slack` strategies) couldn't be stored because `express-session` expected a Spoke user's _integer_ ID, not text.

## How Has This Been Tested?

This has been tested locally:
- [x] Local login
- [x] Local signup without autojoin uuid
- [x] Local signup with autojoin uuid (testing redirect)
- [x] Slack login
- [x] Slack sign up
- [x] Auth0 login
- [x] Auth0 sign up

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
