### PR TITLE
chore: use apollo-native pagination

### DIFF
--- a/libs/spoke-codegen/src/graphql/campaign-list.graphql
+++ b/libs/spoke-codegen/src/graphql/campaign-list.graphql
@@ -1,0 +1,57 @@
+fragment CampaignListEntry on Campaign {
+  id
+  title
+  isStarted
+  isApproved
+  isArchived
+  isAutoassignEnabled
+  hasUnassignedContacts
+  hasUnsentInitialMessages
+  hasUnhandledMessages
+  description
+  dueBy
+  creator {
+    displayName
+  }
+  teams {
+    id
+    title
+  }
+  campaignGroups {
+    edges {
+      node {
+        id
+        name
+      }
+    }
+  }
+  externalSystem {
+    id
+    type
+    name
+  }
+}
+
+query GetAdminCampaigns(
+  $organizationId: String!
+  $limit: Int
+  $after: Cursor
+  $filter: CampaignsFilter
+) {
+  organization(id: $organizationId) {
+    id
+    campaignsRelay(first: $limit, after: $after, filter: $filter) {
+      pageInfo {
+        totalCount
+        endCursor
+        hasNextPage
+      }
+      edges {
+        cursor
+        node {
+          ...CampaignListEntry
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@material-ui/lab": "^4.0.0-alpha.61",
     "@passport-next/passport": "^3.1.0",
     "@rewired/passport-slack": "^1.0.6",
+    "@rooks/use-intersection-observer-ref": "^4.11.2",
     "@slack/web-api": "^6.0.0",
     "@trt2/gsm-charset-utils": "^1.0.13",
     "@types/jest": "^27.4.0",

--- a/src/api/campaign.ts
+++ b/src/api/campaign.ts
@@ -232,7 +232,7 @@ export const schema = `
     primaryColor: String
     logoImageUrl: String
     editors: String
-    teams: [Team]!
+    teams: [Team!]!
     campaignGroups: CampaignGroupPage
     textingHoursStart: Int
     textingHoursEnd: Int

--- a/src/containers/CampaignList/CampaignList.tsx
+++ b/src/containers/CampaignList/CampaignList.tsx
@@ -1,15 +1,15 @@
 import List from "@material-ui/core/List";
 import SpeakerNotesIcon from "@material-ui/icons/SpeakerNotes";
+import type { CampaignListEntryFragment } from "@spoke/spoke-codegen";
 import React from "react";
 
-import { Campaign } from "../../api/campaign";
 import Empty from "../../components/Empty";
 import { CampaignOperations } from "./CampaignListMenu";
 import CampaignListRow from "./CampaignListRow";
 
 interface Props extends CampaignOperations {
   organizationId: string;
-  campaigns: Campaign[];
+  campaigns: CampaignListEntryFragment[];
   isAdmin: boolean;
 }
 

--- a/src/containers/CampaignList/CampaignListMenu.tsx
+++ b/src/containers/CampaignList/CampaignListMenu.tsx
@@ -2,18 +2,17 @@ import IconButton from "@material-ui/core/IconButton";
 import ArchiveIcon from "@material-ui/icons/Archive";
 import MoreVertIcon from "@material-ui/icons/MoreVert";
 import UnarchiveIcon from "@material-ui/icons/Unarchive";
+import type { CampaignListEntryFragment } from "@spoke/spoke-codegen";
 import IconMenu from "material-ui/IconMenu";
 import MenuItem from "material-ui/MenuItem";
 import React from "react";
-
-import { Campaign } from "../../api/campaign";
 
 type ClickHandler = () => void | Promise<void>;
 
 export interface CampaignOperations {
   startOperation: (
     action: string,
-    campaign: Campaign,
+    campaign: CampaignListEntryFragment,
     payload?: any
   ) => ClickHandler;
   archiveCampaign: (campaignId: string) => ClickHandler;
@@ -21,7 +20,7 @@ export interface CampaignOperations {
 }
 
 interface Props extends CampaignOperations {
-  campaign: Campaign;
+  campaign: CampaignListEntryFragment;
 }
 
 export const CampaignListMenu: React.FC<Props> = (props) => {

--- a/src/containers/CampaignList/CampaignListRow.tsx
+++ b/src/containers/CampaignList/CampaignListRow.tsx
@@ -8,13 +8,14 @@ import ListItemSecondaryAction from "@material-ui/core/ListItemSecondaryAction";
 import ListItemText from "@material-ui/core/ListItemText";
 import { useTheme } from "@material-ui/core/styles";
 import WarningIcon from "@material-ui/icons/Warning";
+import type { CampaignListEntryFragment } from "@spoke/spoke-codegen";
 import React from "react";
 import { useHistory } from "react-router-dom";
 
-import { Campaign } from "../../api/campaign";
 import { dataTest } from "../../lib/attributes";
 import { DateTime } from "../../lib/datetime";
-import CampaignListMenu, { CampaignOperations } from "./CampaignListMenu";
+import type { CampaignOperations } from "./CampaignListMenu";
+import CampaignListMenu from "./CampaignListMenu";
 
 const inlineStyles = {
   chipWrapper: {
@@ -34,7 +35,7 @@ const inlineStyles = {
 interface Props extends CampaignOperations {
   organizationId: string;
   isAdmin: boolean;
-  campaign: Campaign;
+  campaign: CampaignListEntryFragment;
 }
 
 export const CampaignListRow: React.FC<Props> = (props) => {

--- a/src/containers/CampaignList/index.jsx
+++ b/src/containers/CampaignList/index.jsx
@@ -230,7 +230,7 @@ const mutations = {
 const queries = {
   data: {
     query: gql`
-      query adminGetCampaigns($organizationId: String!) {
+      query GetAdminAssignmentTargets($organizationId: String!) {
         organization(id: $organizationId) {
           id
           currentAssignmentTargets {

--- a/src/containers/Settings/components/General.jsx
+++ b/src/containers/Settings/components/General.jsx
@@ -552,7 +552,7 @@ const mutations = {
 const queries = {
   data: {
     query: gql`
-      query adminGetCampaigns($organizationId: String!) {
+      query GetGeneralSettings($organizationId: String!) {
         organization(id: $organizationId) {
           id
           name

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -594,7 +594,7 @@ type Campaign {
   primaryColor: String
   logoImageUrl: String
   editors: String
-  teams: [Team]!
+  teams: [Team!]!
   campaignGroups: CampaignGroupPage
   textingHoursStart: Int
   textingHoursEnd: Int

--- a/yarn.lock
+++ b/yarn.lock
@@ -4459,6 +4459,11 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
+"@rooks/use-intersection-observer-ref@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@rooks/use-intersection-observer-ref/-/use-intersection-observer-ref-4.11.2.tgz#d83a9279c1192d7aae221388985457f7491c6333"
+  integrity sha512-9RJYT21Fll1b1oiiMAc6oUOyH5bS1P+nKTIpUUGeQO6+AOP7OflVaPAoULxe+rMnu9ue8LxYZJ6N/pbEcFQu7A==
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz#a21117b19ee9be70c379ec1877537ef2e1c63301"


### PR DESCRIPTION
## Description

This removes the intermediate React state layer between the Apollo cache and the component. It also refactors as a functional component and simplifies infinite scrolling.

## Motivation and Context

The intermediate React state layer renders Apollo cache side effects useless and leaves a full page refresh as the only option for updating campaign list data.

Part 3 of 4 for #1181.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
