### PR TITLE
fix: require returning non null campaign stats

### DIFF
--- a/src/api/campaign.ts
+++ b/src/api/campaign.ts
@@ -146,9 +146,9 @@ export const schema = `
   }
 
   type CampaignStats {
-    sentMessagesCount: Int
-    receivedMessagesCount: Int
-    optOutsCount: Int
+    sentMessagesCount: Int!
+    receivedMessagesCount: Int!
+    optOutsCount: Int!
     needsMessageOptOutsCount: Int!
     percentUnhandledReplies: Float!
     countMessagedContacts: Int!

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -508,9 +508,9 @@ input CampaignsFilter {
 }
 
 type CampaignStats {
-  sentMessagesCount: Int
-  receivedMessagesCount: Int
-  optOutsCount: Int
+  sentMessagesCount: Int!
+  receivedMessagesCount: Int!
+  optOutsCount: Int!
   needsMessageOptOutsCount: Int!
   percentUnhandledReplies: Float!
   countMessagedContacts: Int!


### PR DESCRIPTION
## Description
This changes the campaign stats type to have only non null fields.
## Motivation and Context
All of these stats should be valid numbers and not null.

## How Has This Been Tested?
This has been tested locally.
## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
