### PR TITLE
fix: match mui v0 styling with v4 buttons

### DIFF
--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
@@ -343,7 +343,7 @@ const CampaignInteractionStepsForm: React.FC<InnerProps> = (props) => {
       />
       <Button
         {...dataTest("interactionSubmit")}
-        variant="containted"
+        variant="contained"
         color="primary"
         disabled={isSaveDisabled}
         onClick={handleSave}

--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -1,4 +1,5 @@
 /* eslint-disable react/no-unused-state */
+import Box from "@material-ui/core/Box";
 import Button from "@material-ui/core/Button";
 import { blueGrey, deepOrange, grey } from "@material-ui/core/colors";
 import IconButton from "@material-ui/core/IconButton";
@@ -580,21 +581,25 @@ export class AssignmentTexterContact extends React.Component {
     let button = null;
     if (messageStatus === "closed") {
       button = (
-        <Button
-          variant="contained"
-          onClick={() => this.handleEditMessageStatus("needsResponse")}
-        >
-          Reopen
-        </Button>
+        <Box m={2}>
+          <Button
+            variant="contained"
+            onClick={() => this.handleEditMessageStatus("needsResponse")}
+          >
+            Reopen
+          </Button>
+        </Box>
       );
     } else if (messageStatus === "needsResponse") {
       button = (
-        <Button
-          variant="contained"
-          onClick={this.handleClickCloseContactButton}
-        >
-          Skip Reply
-        </Button>
+        <Box m={2}>
+          <Button
+            variant="contained"
+            onClick={this.handleClickCloseContactButton}
+          >
+            Skip Reply
+          </Button>
+        </Box>
       );
     }
 
@@ -663,22 +668,26 @@ export class AssignmentTexterContact extends React.Component {
           }}
         >
           <Tooltip title="Opt out this contact">
-            <ColorButton
-              {...dataTest("optOut")}
-              variant="contained"
-              backgroundColor={deepOrange[500]}
-              onClick={this.handleOpenOptOutDialog}
-            >
-              Opt out
-            </ColorButton>
+            <Box m={2}>
+              <ColorButton
+                {...dataTest("optOut")}
+                variant="contained"
+                backgroundColor={deepOrange[500]}
+                onClick={this.handleOpenOptOutDialog}
+              >
+                Opt out
+              </ColorButton>
+            </Box>
           </Tooltip>
-          <Button
-            variant="contained"
-            onClick={this.handleOpenPopover}
-            disabled={!isCannedResponseEnabled}
-          >
-            Canned replies
-          </Button>
+          <Box m={2}>
+            <Button
+              variant="contained"
+              onClick={this.handleOpenPopover}
+              disabled={!isCannedResponseEnabled}
+            >
+              Canned replies
+            </Button>
+          </Box>
           {this.renderNeedsResponseToggleButton(contact)}
           <div style={{ flexGrow: 1, textAlign: "center" }}>
             {navigationToolbarChildren}
@@ -708,36 +717,44 @@ export class AssignmentTexterContact extends React.Component {
         <div>
           <Toolbar style={inlineStyles.actionToolbarFirst}>
             <ToolbarGroup>
-              <SendButton
-                threeClickEnabled={campaign.organization.threeClickEnabled}
-                onFinalTouchTap={this.handleClickSendMessageButton}
-                disabled={this.state.disabled}
-              />
+              <Box m={2}>
+                <SendButton
+                  threeClickEnabled={campaign.organization.threeClickEnabled}
+                  onFinalTouchTap={this.handleClickSendMessageButton}
+                  disabled={this.state.disabled}
+                />
+              </Box>
               {this.renderNeedsResponseToggleButton(contact)}
-              <Button
-                variant="contained"
-                onClick={this.handleOpenPopover}
-                disabled={!isCannedResponseEnabled}
-              >
-                Canned responses
-              </Button>
-              <ColorButton
-                {...dataTest("optOut")}
-                variant="contained"
-                backgroundColor={deepOrange[500]}
-                onClick={this.handleOpenOptOutDialog}
-              >
-                Opt out
-              </ColorButton>
-              <Button
-                variant="contained"
-                style={{ backgroundColor: blueGrey[100] }}
-                endIcon={<LocalOfferIcon />}
-                disabled={tags.length === 0}
-                onClick={() => this.setState({ isTagEditorOpen: true })}
-              >
-                Manage Tags
-              </Button>
+              <Box m={2}>
+                <Button
+                  variant="contained"
+                  onClick={this.handleOpenPopover}
+                  disabled={!isCannedResponseEnabled}
+                >
+                  Canned responses
+                </Button>
+              </Box>
+              <Box m={2}>
+                <ColorButton
+                  {...dataTest("optOut")}
+                  variant="contained"
+                  backgroundColor={deepOrange[500]}
+                  onClick={this.handleOpenOptOutDialog}
+                >
+                  Opt out
+                </ColorButton>
+              </Box>
+              <Box m={2}>
+                <Button
+                  variant="contained"
+                  style={{ backgroundColor: blueGrey[100] }}
+                  endIcon={<LocalOfferIcon />}
+                  disabled={tags.length === 0}
+                  onClick={() => this.setState({ isTagEditorOpen: true })}
+                >
+                  Manage Tags
+                </Button>
+              </Box>
               <div style={{ float: "right", marginLeft: 20 }}>
                 {navigationToolbarChildren}
               </div>


### PR DESCRIPTION
## Description
This updates the save button on the campaign edit page to be contained, and adds margins to buttons on the texter assignment page.

## Motivation and Context
Closes #1199

## How Has This Been Tested?
This has been tested locally.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<table>
<tr>
<th>Admin</th>
<th>Texter</th>
</tr>
<td>
<img src="https://user-images.githubusercontent.com/76596635/169459125-853afcd1-1f1a-46ef-ada1-827168c21eb3.png"/>
</td>
<td>
<img src="https://user-images.githubusercontent.com/76596635/169459074-248821b8-43fe-43dc-8f77-6610472ea128.png"
</td>
</table>
<!-- Tip: you can use a <table> to present screenshots in a better way. -->



## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
