### PR TITLE
feat: add option to create campaign(s) from template

### DIFF
--- a/libs/spoke-codegen/src/graphql/template-campaigns.graphql
+++ b/libs/spoke-codegen/src/graphql/template-campaigns.graphql
@@ -45,3 +45,10 @@ mutation CreateTemplateCampaign($organizationId: String!) {
     ...TemplateCampaign
   }
 }
+
+mutation CreateCampaignFromTemplate($templateId: String!, $quantity: Int!) {
+  copyCampaigns(sourceCampaignId: $templateId, quantity: $quantity) {
+    id
+    title
+  }
+}

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -251,6 +251,7 @@ const rootSchema = `
     bulkUpdateScript(organizationId:String!, findAndReplace: BulkUpdateScriptInput!): [ScriptUpdateResult]
     deleteJob(campaignId:String!, id:String!): JobRequest
     copyCampaign(id: String!): Campaign
+    copyCampaigns(sourceCampaignId: String!, quantity: Int!): [Campaign!]!
     exportCampaign(options: CampaignExportInput!): JobRequest
     createCannedResponse(cannedResponse:CannedResponseInput!): CannedResponse
     createOrganization(name: String!, userId: String!, inviteId: String!): Organization

--- a/src/components/CreateCampaignFromTemplateDialog.tsx
+++ b/src/components/CreateCampaignFromTemplateDialog.tsx
@@ -7,6 +7,7 @@ import DialogTitle from "@material-ui/core/DialogTitle";
 import TextField from "@material-ui/core/TextField";
 import Autocomplete from "@material-ui/lab/Autocomplete";
 import {
+  GetAdminCampaignsDocument,
   TemplateCampaignFragment,
   useCreateCampaignFromTemplateMutation,
   useGetTemplateCampaignsQuery
@@ -33,7 +34,9 @@ export const CreateCampaignFromTemplateDialog: React.FC<CreateCampaignFromTempla
   const [
     createFromTemplate,
     { loading: working }
-  ] = useCreateCampaignFromTemplateMutation();
+  ] = useCreateCampaignFromTemplateMutation({
+    refetchQueries: [GetAdminCampaignsDocument]
+  });
 
   const templates =
     data?.organization?.templateCampaigns?.edges?.map(({ node }) => node) ?? [];
@@ -74,8 +77,7 @@ export const CreateCampaignFromTemplateDialog: React.FC<CreateCampaignFromTempla
     if (!(quantity !== null && selectedTemplate !== null && !working)) return;
 
     await createFromTemplate({
-      variables: { templateId: selectedTemplate.id, quantity },
-      refetchQueries: ["adminGetCampaigns"]
+      variables: { templateId: selectedTemplate.id, quantity }
     });
     props.onClose?.();
   }, [quantity, selectedTemplate, createFromTemplate, props.onClose]);

--- a/src/components/CreateCampaignFromTemplateDialog.tsx
+++ b/src/components/CreateCampaignFromTemplateDialog.tsx
@@ -1,0 +1,135 @@
+import Button from "@material-ui/core/Button";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import TextField from "@material-ui/core/TextField";
+import Autocomplete from "@material-ui/lab/Autocomplete";
+import {
+  TemplateCampaignFragment,
+  useCreateCampaignFromTemplateMutation,
+  useGetTemplateCampaignsQuery
+} from "@spoke/spoke-codegen";
+import React, { useCallback, useMemo, useState } from "react";
+
+export interface CreateCampaignFromTemplateDialogProps {
+  organizationId: string;
+  open: boolean;
+  onClose?: () => Promise<void> | void;
+}
+
+export const CreateCampaignFromTemplateDialog: React.FC<CreateCampaignFromTemplateDialogProps> = (
+  props
+) => {
+  const [
+    selectedTemplate,
+    setSelectedTemplate
+  ] = useState<TemplateCampaignFragment | null>(null);
+  const [quantity, setQuantity] = useState<number | null>(1);
+  const { data, error } = useGetTemplateCampaignsQuery({
+    variables: { organizationId: props.organizationId }
+  });
+  const [
+    createFromTemplate,
+    { loading: working }
+  ] = useCreateCampaignFromTemplateMutation();
+
+  const templates =
+    data?.organization?.templateCampaigns?.edges?.map(({ node }) => node) ?? [];
+
+  const handleChangeTemplate = useCallback(
+    (
+      _event: React.ChangeEvent<unknown>,
+      value: TemplateCampaignFragment | null
+    ) => {
+      setSelectedTemplate(value);
+    },
+    [setSelectedTemplate]
+  );
+
+  const handleKeyDown: React.KeyboardEventHandler = useCallback((event) => {
+    const badKey = event.keyCode === 69 || event.keyCode === 101;
+    if (badKey) event.preventDefault();
+  }, []);
+
+  const handleChangeQuantity: React.ChangeEventHandler<
+    HTMLInputElement | HTMLTextAreaElement
+  > = useCallback(
+    (event) => {
+      const textValue = event.target.value.replace(/\D/g, "");
+      const intValue = parseInt(textValue, 10);
+      const finalValue = Number.isNaN(intValue) ? null : Math.max(1, intValue);
+      setQuantity(finalValue);
+    },
+    [setQuantity]
+  );
+
+  const canCreate = useMemo(
+    () => quantity !== null && selectedTemplate !== null && !working,
+    [quantity, selectedTemplate, working]
+  );
+
+  const handleClickCreate = useCallback(async () => {
+    if (!(quantity !== null && selectedTemplate !== null && !working)) return;
+
+    await createFromTemplate({
+      variables: { templateId: selectedTemplate.id, quantity },
+      refetchQueries: ["adminGetCampaigns"]
+    });
+    props.onClose?.();
+  }, [quantity, selectedTemplate, createFromTemplate, props.onClose]);
+
+  return (
+    <Dialog
+      onClose={props.onClose}
+      aria-labelledby="create-from-template-dialog-title"
+      open={props.open}
+    >
+      <DialogTitle id="create-from-template-dialog-title">
+        Create Campaign from Template
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          Select a campaign template to create from
+        </DialogContentText>
+        {error && (
+          <DialogContentText>
+            Error fetching templates: {error.message}
+          </DialogContentText>
+        )}
+        <Autocomplete
+          options={templates}
+          getOptionLabel={(template) => template.title}
+          value={selectedTemplate}
+          onChange={handleChangeTemplate}
+          style={{ width: 300 }}
+          renderInput={(params) => (
+            <TextField {...params} label="Template campaign name" />
+          )}
+        />
+        <br />
+        <TextField
+          fullWidth
+          label="Quantity"
+          type="number"
+          value={quantity ?? ""}
+          onChange={handleChangeQuantity}
+          onKeyDown={handleKeyDown}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={props.onClose}>Cancel</Button>
+        <Button
+          color="primary"
+          disabled={!canCreate}
+          onClick={handleClickCreate}
+        >
+          Create
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default CreateCampaignFromTemplateDialog;

--- a/src/containers/AdminCampaignList.jsx
+++ b/src/containers/AdminCampaignList.jsx
@@ -4,10 +4,13 @@ import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
 import DialogTitle from "@material-ui/core/DialogTitle";
-import AddIcon from "@material-ui/icons/Add";
+import CreateIcon from "@material-ui/icons/Create";
+import FileCopyIcon from "@material-ui/icons/FileCopyOutlined";
+import SpeedDial from "@material-ui/lab/SpeedDial";
+import SpeedDialAction from "@material-ui/lab/SpeedDialAction";
+import SpeedDialIcon from "@material-ui/lab/SpeedDialIcon";
 import { TextField, Toggle } from "material-ui";
 import DropDownMenu from "material-ui/DropDownMenu";
-import FloatingActionButton from "material-ui/FloatingActionButton";
 import { MenuItem } from "material-ui/Menu";
 import PropTypes from "prop-types";
 import React from "react";
@@ -15,8 +18,8 @@ import { withRouter } from "react-router-dom";
 import { compose } from "recompose";
 
 import { withAuthzContext } from "../components/AuthzProvider";
+import CreateCampaignFromTemplateDialog from "../components/CreateCampaignFromTemplateDialog";
 import LoadingIndicator from "../components/LoadingIndicator";
-import { dataTest } from "../lib/attributes";
 import theme from "../styles/theme";
 import CampaignList from "./CampaignList";
 import { loadData } from "./hoc/with-operations";
@@ -35,6 +38,8 @@ const DEFAULT_PAGE_SIZE = 10;
 
 class AdminCampaignList extends React.Component {
   state = {
+    speedDialOpen: false,
+    createFromTemplateOpen: false,
     isCreating: false,
     campaignsFilter: {
       isArchived: false
@@ -260,14 +265,32 @@ class AdminCampaignList extends React.Component {
         )}
 
         {isAdmin ? (
-          <FloatingActionButton
-            {...dataTest("addCampaign")}
+          <SpeedDial
+            ariaLabel="SpeedDial example"
             style={theme.components.floatingButton}
-            onClick={this.handleClickNewButton}
+            icon={<SpeedDialIcon />}
+            onClose={() => this.setState({ speedDialOpen: false })}
+            onOpen={() => this.setState({ speedDialOpen: true })}
+            open={this.state.speedDialOpen}
+            direction="up"
           >
-            <AddIcon />
-          </FloatingActionButton>
+            <SpeedDialAction
+              icon={<CreateIcon />}
+              tooltipTitle="Create Blank"
+              onClick={this.handleClickNewButton}
+            />
+            <SpeedDialAction
+              icon={<FileCopyIcon />}
+              tooltipTitle="Create from Template"
+              onClick={() => this.setState({ createFromTemplateOpen: true })}
+            />
+          </SpeedDial>
         ) : null}
+        <CreateCampaignFromTemplateDialog
+          organizationId={organizationId}
+          open={this.state.createFromTemplateOpen}
+          onClose={() => this.setState({ createFromTemplateOpen: false })}
+        />
       </div>
     );
   }

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -219,6 +219,7 @@ type RootMutation {
   bulkUpdateScript(organizationId:String!, findAndReplace: BulkUpdateScriptInput!): [ScriptUpdateResult]
   deleteJob(campaignId:String!, id:String!): JobRequest
   copyCampaign(id: String!): Campaign
+  copyCampaigns(sourceCampaignId: String!, quantity: Int!): [Campaign!]!
   exportCampaign(options: CampaignExportInput!): JobRequest
   createCannedResponse(cannedResponse:CannedResponseInput!): CannedResponse
   createOrganization(name: String!, userId: String!, inviteId: String!): Organization

--- a/src/server/api/lib/campaign.ts
+++ b/src/server/api/lib/campaign.ts
@@ -225,12 +225,14 @@ export const copyCampaign = async (options: CopyCampaignOptions) => {
           )
         );
 
-      await persistInteractionStepTree(
-        newCampaign.id,
-        makeTree(interactions, null /* id */),
-        { is_started: false },
-        trx
-      );
+      if (interactions.length > 0) {
+        await persistInteractionStepTree(
+          newCampaign.id,
+          makeTree(interactions, null /* id */),
+          { is_started: false },
+          trx
+        );
+      }
 
       // Copy canned responses
       await trx.raw(

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -834,7 +834,7 @@ const rootMutations = {
       const campaign = await loaders.campaign.load(campaignId);
       await accessRequired(user, campaign.organization_id, "ADMIN");
 
-      const result = await copyCampaign({
+      const [result] = await copyCampaign({
         db,
         campaignId,
         userId: parseInt(user.id, 10)
@@ -845,6 +845,29 @@ const rootMutations = {
       });
 
       return result;
+    },
+
+    copyCampaigns: async (
+      _root,
+      { sourceCampaignId, quantity },
+      { user, loaders, db }
+    ) => {
+      const campaignId = parseInt(sourceCampaignId, 10);
+      const campaign = await loaders.campaign.load(campaignId);
+      await accessRequired(user, campaign.organization_id, "ADMIN");
+
+      const newCampaigns = await copyCampaign({
+        db,
+        campaignId,
+        userId: parseInt(user.id, 10),
+        quantity
+      });
+
+      await memoizer.invalidate(cacheOpts.CampaignsList.key, {
+        organizationId: newCampaigns[0].organization_id
+      });
+
+      return newCampaigns;
     },
 
     unarchiveCampaign: async (_root, { id }, { user, loaders }) => {


### PR DESCRIPTION
## Description

This adds the ability to create a campaign (or campaigns) from a template campaign.

## Motivation and Context

Closes #1181.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<table>
<tr><td>

![Screen Shot 2022-05-16 at 8 04 41 AM](https://user-images.githubusercontent.com/2145526/169569342-7c5cbe11-e484-4c38-bd24-a718e5724baf.png)

Create from Template

</td>
<td>

![Screen Shot 2022-05-16 at 8 05 02 AM](https://user-images.githubusercontent.com/2145526/169569385-64edb425-0cc0-4eb6-8ee1-e76e5d651d30.png)

Create blank

</td></tr>
<tr><td colspan="2">

![Screen Shot 2022-05-16 at 9 42 33 AM](https://user-images.githubusercontent.com/2145526/169569547-614b3f8b-131c-4714-aa8e-b7ad176e83ae.png)

Creating many from template

</td></tr>
</table>

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

This feature will need to be documented.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
