### PR TITLE
fix(template-campaigns): add missing resolver

### DIFF
--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -829,6 +829,32 @@ const rootMutations = {
       );
     },
 
+    createTemplateCampaign: async (_root, { organizationId }, { user }) => {
+      await accessRequired(
+        user,
+        organizationId,
+        "ADMIN",
+        /* allowSuperadmin= */ true
+      );
+
+      const [templateCampaign] = await r
+        .knex("all_campaign")
+        .insert({
+          organization_id: organizationId,
+          creator_id: user.id,
+          title: "New Template Campaign",
+          description: "",
+          is_started: false,
+          is_archived: false,
+          is_approved: false,
+          is_template: true
+        })
+        .returning("*");
+
+      cacheableData.campaign.reload(templateCampaign.id);
+      return templateCampaign;
+    },
+
     copyCampaign: async (_root, { id }, { user, loaders, db }) => {
       const campaignId = parseInt(id, 10);
       const campaign = await loaders.campaign.load(campaignId);


### PR DESCRIPTION
## Description

This adds the resolver for the `createTemplateCampaign` mutation.

## Motivation and Context

I was not careful enough with my `git add --patch` scalpel in #1214.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
