### PR TITLE
feat: add script styling to interaction step

### DIFF
--- a/src/components/ScriptOptionBlock.tsx
+++ b/src/components/ScriptOptionBlock.tsx
@@ -1,0 +1,118 @@
+import { green, grey, orange, red } from "@material-ui/core/colors";
+import IconButton from "@material-ui/core/IconButton";
+import { makeStyles } from "@material-ui/core/styles";
+import Tooltip from "@material-ui/core/Tooltip";
+import DeleteIcon from "@material-ui/icons/Delete";
+import React from "react";
+
+import { ScriptToken, ScriptTokenType, scriptToTokens } from "../lib/scripts";
+
+const tokensToElems = (tokens: ScriptToken[]) =>
+  tokens.map((token, index) => {
+    const key = `${index}-${token.text}`;
+    switch (token.type) {
+      case ScriptTokenType.CustomField:
+        return (
+          <span key={key} style={{ color: green[500] }}>
+            {token.text}
+          </span>
+        );
+      case ScriptTokenType.UndefinedField:
+        return (
+          <span key={key} style={{ color: red[500] }}>
+            {token.text}
+          </span>
+        );
+      default:
+        return token.text;
+    }
+  });
+
+const useStyles = makeStyles({
+  label: {
+    fontSize: "0.8em"
+  },
+  constainer: {
+    display: "flex",
+    alignItems: "center"
+  },
+  scriptField: {
+    borderBottom: "1px solid #cccccc",
+    paddingBottom: "3px",
+    cursor: "pointer",
+    flexGrow: 1
+  },
+  warnLabel: {
+    fontSize: "0.8em",
+    color: orange[800]
+  },
+  errorLabel: {
+    fontSize: "0.8em",
+    color: red[600]
+  }
+});
+
+interface ScriptOptionBlockProps extends React.HTMLProps<HTMLDivElement> {
+  script: string;
+  customFields: string[];
+  placeholder?: string;
+  label?: string;
+  onEditScript?: () => Promise<void> | void;
+  onDelete?: () => Promise<void> | void;
+}
+
+export const ScriptOptionBlock: React.FC<ScriptOptionBlockProps> = (props) => {
+  const {
+    label,
+    script,
+    customFields,
+    placeholder = "Enter a script...",
+    onEditScript,
+    onDelete,
+    ...rest
+  } = props;
+
+  const classes = useStyles();
+
+  const emptyScript = script.trim().length === 0;
+
+  const { tokens, undefinedFieldsUsed } = scriptToTokens({
+    script,
+    customFields
+  });
+
+  const scriptElems = emptyScript ? (
+    <div style={{ color: grey[500] }}>{placeholder}</div>
+  ) : (
+    tokensToElems(tokens)
+  );
+
+  return (
+    <div {...rest}>
+      {label && <div className={classes.label}>{label}</div>}
+      <div className={classes.constainer}>
+        <div className={classes.scriptField} onClick={onEditScript}>
+          {scriptElems}
+        </div>
+        {onDelete && (
+          <Tooltip title="Deleting will not take effect until you save!">
+            <IconButton onClick={onDelete}>
+              <DeleteIcon fontSize="small" style={{ color: red[500] }} />
+            </IconButton>
+          </Tooltip>
+        )}
+      </div>
+      {emptyScript && (
+        <div className={classes.errorLabel}>Script cannot be empty</div>
+      )}
+      {undefinedFieldsUsed.length > 0 && (
+        <div className={classes.warnLabel}>
+          Script cannot use an invalid custom field:{" "}
+          {undefinedFieldsUsed.join(", ")}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ScriptOptionBlock;

--- a/src/components/forms/GSScriptOptionsField.jsx
+++ b/src/components/forms/GSScriptOptionsField.jsx
@@ -2,7 +2,6 @@ import Button from "@material-ui/core/Button";
 import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
-import IconButton from "@material-ui/core/IconButton";
 import Tooltip from "@material-ui/core/Tooltip";
 import CreateIcon from "@material-ui/icons/Create";
 import InfoIcon from "@material-ui/icons/Info";

--- a/src/components/forms/GSScriptOptionsField.jsx
+++ b/src/components/forms/GSScriptOptionsField.jsx
@@ -5,10 +5,7 @@ import DialogContent from "@material-ui/core/DialogContent";
 import IconButton from "@material-ui/core/IconButton";
 import Tooltip from "@material-ui/core/Tooltip";
 import CreateIcon from "@material-ui/icons/Create";
-import DeleteIcon from "@material-ui/icons/Delete";
 import InfoIcon from "@material-ui/icons/Info";
-import pick from "lodash/pick";
-import TextField from "material-ui/TextField";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -17,6 +14,7 @@ import { dataTest } from "../../lib/attributes";
 import { allScriptFields } from "../../lib/scripts";
 import ScriptEditor from "../ScriptEditor";
 import ScriptLinkWarningDialog from "../ScriptLinkWarningDialog";
+import ScriptOptionBlock from "../ScriptOptionBlock";
 import GSFormField from "./GSFormField";
 import { getWarningContextForScript } from "./utils";
 
@@ -176,18 +174,7 @@ class GSScriptOptionsField extends GSFormField {
 
   render() {
     // The "errors" prop is an empty object and is not mentioned in yum or react-formal documentation
-    const scriptVersions = this.props.value;
-    const passThroughProps = pick(this.props, [
-      "className",
-      "fullWidth",
-      "hintText",
-      "label",
-      "multiLine",
-      "name",
-      "data-test",
-      "onBlur"
-      // We manage onChange ourselves so don't pass it though
-    ]);
+    const { customFields, value: scriptVersions } = this.props;
 
     const canDelete = scriptVersions.length > 1;
     const emptyVersionExists =
@@ -204,36 +191,14 @@ class GSScriptOptionsField extends GSFormField {
           <InfoIcon fontSize="small" />
         </Tooltip>
         {scriptVersions.map((scriptVersion, index) => (
-          <div
+          <ScriptOptionBlock
             key={scriptVersion}
-            style={{ display: "flex", alignItems: "center" }}
-          >
-            <TextField
-              key={scriptVersion}
-              value={scriptVersion}
-              floatingLabelText={`Script Version ${index + 1}`}
-              floatingLabelStyle={{ zIndex: 0 }}
-              errorText={
-                scriptVersion.trim().length === 0
-                  ? "Script cannot be empty"
-                  : undefined
-              }
-              multiLine
-              onClick={this.createDialogHandler(scriptVersion)}
-              {...passThroughProps}
-            />
-            {canDelete && (
-              <IconButton
-                tooltip="Deleting will not take effect until you save!"
-                tooltipPosition="top-left"
-                iconStyle={{ width: 20, height: 20, color: "red" }}
-                style={{ width: 40, height: 40, padding: 10 }}
-                onClick={this.createDeleteHandler(scriptVersion)}
-              >
-                <DeleteIcon />
-              </IconButton>
-            )}
-          </div>
+            label={`Script Version ${index + 1}`}
+            customFields={customFields}
+            script={scriptVersion}
+            onEditScript={this.createDialogHandler(scriptVersion)}
+            onDelete={canDelete && this.createDeleteHandler(scriptVersion)}
+          />
         ))}
         <Button
           color="primary"

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
@@ -281,6 +281,7 @@ const CampaignInteractionStepsForm: React.FC<InnerProps> = (props) => {
     filterDeleted: true,
     stripLocals: true
   });
+
   const isSaveDisabled =
     isWorking || hasEmptyScripts || (!isNew && !hasPendingChanges);
   const finalSaveLabel = isWorking ? "Working..." : saveLabel;


### PR DESCRIPTION
## Description

This brings variable highlighting to the script field displayed on interaction step cards.

It also adds script tokenization utils to use for future work.

## Motivation and Context

Script variable highlighting was previously only available in the script draft editor.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
