### PR TITLE
feat: add campaign variable management

### DIFF
--- a/libs/spoke-codegen/src/graphql/campaign-variables.graphql
+++ b/libs/spoke-codegen/src/graphql/campaign-variables.graphql
@@ -1,6 +1,6 @@
 fragment CampaignVariableInfo on CampaignVariable {
   id
-  order
+  displayOrder
   name
   value
 }

--- a/libs/spoke-codegen/src/graphql/campaign-variables.graphql
+++ b/libs/spoke-codegen/src/graphql/campaign-variables.graphql
@@ -1,0 +1,60 @@
+fragment CampaignVariableInfo on CampaignVariable {
+  id
+  order
+  name
+  value
+}
+
+query GetCampaignVariables($campaignId: String!) {
+  campaign(id: $campaignId) {
+    id
+    campaignVariables {
+      edges {
+        node {
+          ...CampaignVariableInfo
+        }
+      }
+    }
+  }
+}
+
+query GetAssignmentCampaignVariables($assignmentId: String!) {
+  assignment(id: $assignmentId) {
+    campaign {
+      id
+      campaignVariables {
+        edges {
+          node {
+            ...CampaignVariableInfo
+          }
+        }
+      }
+    }
+  }
+}
+
+mutation EditCampaignVariables(
+  $campaignId: String!
+  $campaignVariables: [CampaignVariableInput!]!
+) {
+  editCampaign(
+    id: $campaignId
+    campaign: { campaignVariables: $campaignVariables }
+  ) {
+    id
+    campaignVariables {
+      edges {
+        node {
+          ...CampaignVariableInfo
+        }
+      }
+    }
+    isStarted
+    isApproved
+    readiness {
+      id
+      campaignVariables
+      interactions
+    }
+  }
+}

--- a/libs/spoke-codegen/src/graphql/campaign-variables.graphql
+++ b/libs/spoke-codegen/src/graphql/campaign-variables.graphql
@@ -8,6 +8,7 @@ fragment CampaignVariableInfo on CampaignVariable {
 query GetCampaignVariables($campaignId: String!) {
   campaign(id: $campaignId) {
     id
+    isTemplate
     campaignVariables {
       edges {
         node {

--- a/migrations/20220519111425_add-campaign-variables.js
+++ b/migrations/20220519111425_add-campaign-variables.js
@@ -1,0 +1,35 @@
+exports.up = function up(knex) {
+  return knex.schema.raw(
+    `
+      create table campaign_variable (
+        id serial primary key,
+        campaign_id int not null references all_campaign (id),
+        display_order integer not null,
+        name text not null,
+        value text,
+        created_at timestamptz not null default now(),
+        updated_at timestamptz not null default now(),
+        deleted_at timestamptz,
+        constraint check_name check (name ~ '^[a-zA-Z0-9 \\-_]+$')
+      );
+
+      create unique index campaign_variable_unique_name_per_campaign
+        on campaign_variable (campaign_id, name)
+        where deleted_at is null;
+
+      create trigger _500_campaign_variable_updated_at
+        before update
+        on public.campaign_variable
+        for each row
+        execute procedure universal_updated_at();
+    `
+  );
+};
+
+exports.down = function down(knex) {
+  return knex.schema.raw(
+    `
+      drop table campaign_variable;
+    `
+  );
+};

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "react-file-drop": "^3.1.4",
     "react-formal": "^2.2.2",
     "react-helmet": "^6.1.0",
+    "react-hook-form": "^7.31.1",
     "react-markdown": "^8.0.3",
     "react-portal": "^4.2.1",
     "react-router-dom": "^5.2.0",

--- a/schema-dump.sql
+++ b/schema-dump.sql
@@ -1912,6 +1912,47 @@ ALTER SEQUENCE public.campaign_team_id_seq OWNED BY public.campaign_team.id;
 
 
 --
+-- Name: campaign_variable; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.campaign_variable (
+    id integer NOT NULL,
+    campaign_id integer NOT NULL,
+    display_order integer NOT NULL,
+    name text NOT NULL,
+    value text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    deleted_at timestamp with time zone,
+    CONSTRAINT check_name CHECK ((name ~ '^[a-zA-Z0-9 \-_]+$'::text))
+);
+
+
+ALTER TABLE public.campaign_variable OWNER TO postgres;
+
+--
+-- Name: campaign_variable_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.campaign_variable_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.campaign_variable_id_seq OWNER TO postgres;
+
+--
+-- Name: campaign_variable_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.campaign_variable_id_seq OWNED BY public.campaign_variable.id;
+
+
+--
 -- Name: canned_response; Type: TABLE; Schema: public; Owner: postgres
 --
 
@@ -3316,6 +3357,13 @@ ALTER TABLE ONLY public.campaign_team ALTER COLUMN id SET DEFAULT nextval('publi
 
 
 --
+-- Name: campaign_variable id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.campaign_variable ALTER COLUMN id SET DEFAULT nextval('public.campaign_variable_id_seq'::regclass);
+
+
+--
 -- Name: canned_response id; Type: DEFAULT; Schema: public; Owner: postgres
 --
 
@@ -3594,6 +3642,14 @@ ALTER TABLE ONLY public.campaign_team
 
 ALTER TABLE ONLY public.campaign_team
     ADD CONSTRAINT campaign_team_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: campaign_variable campaign_variable_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.campaign_variable
+    ADD CONSTRAINT campaign_variable_pkey PRIMARY KEY (id);
 
 
 --
@@ -4130,6 +4186,13 @@ CREATE INDEX campaign_organization_id_index ON public.all_campaign USING btree (
 
 
 --
+-- Name: campaign_variable_unique_name_per_campaign; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX campaign_variable_unique_name_per_campaign ON public.campaign_variable USING btree (campaign_id, name) WHERE (deleted_at IS NULL);
+
+
+--
 -- Name: canned_response_campaign_id_index; Type: INDEX; Schema: public; Owner: postgres
 --
 
@@ -4606,6 +4669,13 @@ CREATE TRIGGER _500_campaign_updated_at BEFORE UPDATE ON public.all_campaign FOR
 
 
 --
+-- Name: campaign_variable _500_campaign_variable_updated_at; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER _500_campaign_variable_updated_at BEFORE UPDATE ON public.campaign_variable FOR EACH ROW EXECUTE FUNCTION public.universal_updated_at();
+
+
+--
 -- Name: canned_response _500_canned_response_updated_at; Type: TRIGGER; Schema: public; Owner: postgres
 --
 
@@ -4986,6 +5056,14 @@ ALTER TABLE ONLY public.campaign_team
 
 ALTER TABLE ONLY public.campaign_team
     ADD CONSTRAINT campaign_team_team_id_foreign FOREIGN KEY (team_id) REFERENCES public.team(id) ON DELETE CASCADE;
+
+
+--
+-- Name: campaign_variable campaign_variable_campaign_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.campaign_variable
+    ADD CONSTRAINT campaign_variable_campaign_id_fkey FOREIGN KEY (campaign_id) REFERENCES public.all_campaign(id);
 
 
 --

--- a/src/api/campaign-variable.ts
+++ b/src/api/campaign-variable.ts
@@ -1,7 +1,7 @@
 import type { RelayEdge, RelayPaginatedResponse } from "./pagination";
 
 export interface CampaignVariableInput {
-  order: number;
+  displayOrder: number;
   name: string;
   value?: string | null;
 }
@@ -9,6 +9,7 @@ export interface CampaignVariableInput {
 export interface CampaignVariable {
   id: string;
   organization_id: string;
+  displayOrder: number;
   name: string;
   description: string;
   created_at: string;
@@ -21,14 +22,14 @@ export type CampaignVariablePage = RelayPaginatedResponse<CampaignVariable>;
 
 export const schema = `
   input CampaignVariableInput {
-    order: Int!
+    displayOrder: Int!
     name: String!
     value: String
   }
 
   type CampaignVariable {
     id: ID!
-    order: Int!
+    displayOrder: Int!
     name: String!
     value: String
     createdAt: String!

--- a/src/api/campaign-variable.ts
+++ b/src/api/campaign-variable.ts
@@ -1,0 +1,49 @@
+import type { RelayEdge, RelayPaginatedResponse } from "./pagination";
+
+export interface CampaignVariableInput {
+  order: number;
+  name: string;
+  value?: string | null;
+}
+
+export interface CampaignVariable {
+  id: string;
+  organization_id: string;
+  name: string;
+  description: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export type CampaignVariableEdge = RelayEdge<CampaignVariable>;
+
+export type CampaignVariablePage = RelayPaginatedResponse<CampaignVariable>;
+
+export const schema = `
+  input CampaignVariableInput {
+    order: Int!
+    name: String!
+    value: String
+  }
+
+  type CampaignVariable {
+    id: ID!
+    order: Int!
+    name: String!
+    value: String
+    createdAt: String!
+    updatedAt: String!
+  }
+
+  type CampaignVariableEdge {
+    cursor: Cursor!
+    node: CampaignVariable!
+  }
+
+  type CampaignVariablePage {
+    edges: [CampaignVariableEdge!]!
+    pageInfo: RelayPageInfo!
+  }
+`;
+
+export default schema;

--- a/src/api/campaign.ts
+++ b/src/api/campaign.ts
@@ -1,6 +1,10 @@
 /* eslint-disable no-unused-vars */
 import type { CampaignContactInput } from "./campaign-contact";
 import type { CampaignGroupPage } from "./campaign-group";
+import type {
+  CampaignVariableInput,
+  CampaignVariablePage
+} from "./campaign-variable";
 import type { CannedResponseInput } from "./canned-response";
 import type { ExternalSystem } from "./external-system";
 import type {
@@ -77,6 +81,7 @@ export interface CampaignInput {
   teamIds: string[];
   campaignGroupIds: string[] | null;
   texters: TexterInput | null;
+  campaignVariables: CampaignVariableInput[] | null;
   interactionSteps: InteractionStepWithChildren;
   cannedResponses: CannedResponseInput[];
   textingHoursStart: number | null;
@@ -114,6 +119,7 @@ export interface Campaign {
   hasUnhandledMessages?: boolean | null;
   teams: Team[];
   campaignGroups?: CampaignGroupPage | null;
+  campaignVariables: CampaignVariablePage;
   externalSystem?: ExternalSystem | null;
   creator?: User | null;
   deliverabilityStats: CampaignDeliverabilityStats;
@@ -191,6 +197,7 @@ export const schema = `
     autoassign: Boolean!
     cannedResponses: Boolean!
     campaignGroups: Boolean!
+    campaignVariables: Boolean!
     interactions: Boolean!
     texters: Boolean!
   }
@@ -234,6 +241,7 @@ export const schema = `
     editors: String
     teams: [Team!]!
     campaignGroups: CampaignGroupPage
+    campaignVariables: CampaignVariablePage!
     textingHoursStart: Int
     textingHoursEnd: Int
     isAutoassignEnabled: Boolean!
@@ -305,6 +313,7 @@ export const schema = `
     isAssignmentLimitedToTeams: Boolean
     teamIds: [ID]
     campaignGroupIds: [String!]
+    campaignVariables: [CampaignVariableInput!]
     texters: TexterInput
     interactionSteps: InteractionStepInput
     cannedResponses: [CannedResponseInput]

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -3,6 +3,7 @@ import { schema as assignmentRequestSchema } from "./assignment-request";
 import { schema as campaignSchema } from "./campaign";
 import { schema as campaignContactSchema } from "./campaign-contact";
 import { schema as campaignGroupSchema } from "./campaign-group";
+import { schema as campaignVariableSchema } from "./campaign-variable";
 import { schema as cannedResponseSchema } from "./canned-response";
 import { schema as conversationSchema } from "./conversations";
 import { schema as externalActivistCodeSchema } from "./external-activist-code";
@@ -358,6 +359,7 @@ export const schema = [
   noticeSchema,
   campaignContactSchema,
   campaignGroupSchema,
+  campaignVariableSchema,
   cannedResponseSchema,
   questionResponseSchema,
   questionSchema,

--- a/src/containers/AdminCampaignEdit/components/SectionWrapper.tsx
+++ b/src/containers/AdminCampaignEdit/components/SectionWrapper.tsx
@@ -239,6 +239,7 @@ const makeQueries = (jobTypes: string[]) => ({
             interactions
             texters
             campaignGroups
+            campaignVariables
           }
         }
       }

--- a/src/containers/AdminCampaignEdit/index.jsx
+++ b/src/containers/AdminCampaignEdit/index.jsx
@@ -59,6 +59,7 @@ import CampaignOverlapManager from "./sections/CampaignOverlapManager";
 import CampaignTeamsForm from "./sections/CampaignTeamsForm";
 import CampaignTextersForm from "./sections/CampaignTextersForm";
 import CampaignTextingHoursForm from "./sections/CampaignTextingHoursForm";
+import CampaignVariablesForm from "./sections/CampaignVariablesForm";
 
 const extractStageAndStatus = (percentComplete) => {
   if (percentComplete > 100) {
@@ -512,6 +513,22 @@ class AdminCampaignEdit extends React.Component {
         blocksStarting: false,
         expandAfterCampaignStarts: true,
         expandableBySuperVolunteers: true
+      },
+      {
+        title: "Campaign Variables",
+        content: CampaignVariablesForm,
+        isStandalone: true,
+        showForModes: [
+          CampaignBuilderMode.Basic,
+          CampaignBuilderMode.Advanced,
+          CampaignBuilderMode.Template
+        ],
+        keys: ["campaignVariables"],
+        checkCompleted: () => true,
+        blocksStarting: false,
+        expandAfterCampaignStarts: true,
+        expandableBySuperVolunteers: false,
+        extraProps: {}
       },
       {
         title: "Interactions",

--- a/src/containers/AdminCampaignEdit/sections/CampaignVariablesForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignVariablesForm.tsx
@@ -74,12 +74,11 @@ const CampaignVariablesForm: React.FC<FullComponentProps> = (props) => {
       const nodes =
         data?.campaign?.campaignVariables.edges.map(({ node }) => node) ?? [];
       const campaignVariables = sortBy(
-        nodes.map((thing) => ({
-          order: thing.order,
-          name: thing.name,
-          value: thing.value ?? ""
+        nodes.map((campaignVariable) => ({
+          ...campaignVariable,
+          value: campaignVariable.value ?? ""
         })),
-        ["order"]
+        ["displayOrder"]
       );
 
       // Wait for useForm's subscription to be ready before reset() sends a signal to flush form state update
@@ -121,7 +120,7 @@ const CampaignVariablesForm: React.FC<FullComponentProps> = (props) => {
     async (formValues: FormValues) => {
       const payload = formValues.campaignVariables
         .filter(({ name }) => !!name)
-        .map((variable, index) => ({ ...variable, order: index }));
+        .map((variable, index) => ({ ...variable, displayOrder: index }));
       await editVariables({
         variables: { campaignId, campaignVariables: payload }
       });

--- a/src/containers/AdminCampaignEdit/sections/CampaignVariablesForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignVariablesForm.tsx
@@ -16,7 +16,7 @@ import {
   useGetCampaignVariablesQuery
 } from "@spoke/spoke-codegen";
 import sortBy from "lodash/sortBy";
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { Controller, useFieldArray, useForm } from "react-hook-form";
 
 import { allScriptFields, VARIABLE_NAME_REGEXP } from "../../../lib/scripts";
@@ -66,6 +66,7 @@ const CampaignVariablesForm: React.FC<FullComponentProps> = (props) => {
 
   // Apollo
   const {
+    data: campaignData,
     loading: fetchLoading,
     error: fetchError
   } = useGetCampaignVariablesQuery({
@@ -95,6 +96,10 @@ const CampaignVariablesForm: React.FC<FullComponentProps> = (props) => {
       { query: GetCampaignVariablesDocument, variables: { campaignId } }
     ]
   });
+
+  const isTemplate = useMemo(() => campaignData?.campaign?.isTemplate, [
+    campaignData
+  ]);
 
   // UX
   const classes = useStyles();
@@ -201,8 +206,13 @@ const CampaignVariablesForm: React.FC<FullComponentProps> = (props) => {
                           <TextField
                             {...field}
                             label="Variable value"
-                            error={error !== undefined}
-                            helperText={error?.message}
+                            error={error !== undefined && isTemplate !== true}
+                            helperText={
+                              isTemplate
+                                ? "Cannot set values on template campaigns"
+                                : error?.message
+                            }
+                            disabled={isTemplate}
                             fullWidth
                             multiline
                           />

--- a/src/containers/AdminCampaignEdit/sections/CampaignVariablesForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignVariablesForm.tsx
@@ -1,0 +1,276 @@
+import Button from "@material-ui/core/Button";
+import CircularProgress from "@material-ui/core/CircularProgress";
+import { green } from "@material-ui/core/colors";
+import Grid from "@material-ui/core/Grid";
+import IconButton from "@material-ui/core/IconButton";
+import { makeStyles } from "@material-ui/core/styles";
+import TextField from "@material-ui/core/TextField";
+import AddBoxIcon from "@material-ui/icons/AddBox";
+import DeleteIcon from "@material-ui/icons/Delete";
+import Alert from "@material-ui/lab/Alert";
+import AlertTitle from "@material-ui/lab/AlertTitle";
+import Skeleton from "@material-ui/lab/Skeleton";
+import {
+  GetCampaignVariablesDocument,
+  useEditCampaignVariablesMutation,
+  useGetCampaignVariablesQuery
+} from "@spoke/spoke-codegen";
+import sortBy from "lodash/sortBy";
+import React, { useCallback } from "react";
+import { Controller, useFieldArray, useForm } from "react-hook-form";
+
+import { allScriptFields, VARIABLE_NAME_REGEXP } from "../../../lib/scripts";
+import CampaignFormSectionHeading from "../components/CampaignFormSectionHeading";
+import { asSection, FullComponentProps } from "../components/SectionWrapper";
+
+const useStyles = makeStyles((theme) => ({
+  wrapper: {
+    margin: theme.spacing(1),
+    position: "relative",
+    display: "inline-block"
+  },
+  buttonProgress: {
+    color: green[500],
+    position: "absolute",
+    top: "50%",
+    left: "50%",
+    marginTop: -12,
+    marginLeft: -12
+  }
+}));
+
+type FormValues = {
+  campaignVariables: { name: string; value: string | null }[];
+};
+
+const CampaignVariablesForm: React.FC<FullComponentProps> = (props) => {
+  const { campaignId } = props;
+
+  // Form
+  const { handleSubmit, watch, control, formState, reset, trigger } = useForm<
+    FormValues
+  >({
+    defaultValues: { campaignVariables: [] }
+  });
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "campaignVariables"
+  });
+  const watchFieldArray = watch("campaignVariables");
+  const controlledFields = fields.map((field, index) => {
+    return {
+      ...field,
+      ...watchFieldArray[index]
+    };
+  });
+
+  // Apollo
+  const {
+    loading: fetchLoading,
+    error: fetchError
+  } = useGetCampaignVariablesQuery({
+    variables: { campaignId },
+    onCompleted: (data) => {
+      const nodes =
+        data?.campaign?.campaignVariables.edges.map(({ node }) => node) ?? [];
+      const campaignVariables = sortBy(
+        nodes.map((thing) => ({
+          order: thing.order,
+          name: thing.name,
+          value: thing.value ?? ""
+        })),
+        ["order"]
+      );
+
+      // Wait for useForm's subscription to be ready before reset() sends a signal to flush form state update
+      setTimeout(() => {
+        reset({ campaignVariables });
+      }, 1);
+    }
+  });
+  const [
+    editVariables,
+    { loading: saveLoading, error: saveError }
+  ] = useEditCampaignVariablesMutation({
+    refetchQueries: [
+      { query: GetCampaignVariablesDocument, variables: { campaignId } }
+    ]
+  });
+
+  // UX
+  const classes = useStyles();
+
+  const handleAddVariable = useCallback(
+    () =>
+      append({
+        name: "",
+        value: ""
+      }),
+    [append]
+  );
+
+  const handleRemoveVariable = useCallback(
+    (index: number) => {
+      remove(index);
+      trigger("campaignVariables");
+    },
+    [remove, trigger]
+  );
+
+  const handleSave = useCallback(
+    async (formValues: FormValues) => {
+      const payload = formValues.campaignVariables
+        .filter(({ name }) => !!name)
+        .map((variable, index) => ({ ...variable, order: index }));
+      await editVariables({
+        variables: { campaignId, campaignVariables: payload }
+      });
+    },
+    [editVariables]
+  );
+
+  // formState.isDirty is not capturing arrayFields.remove so we use dirtyFields instead
+  const isDirty = (formState.dirtyFields.campaignVariables?.length ?? 0) > 0;
+
+  return (
+    <>
+      <CampaignFormSectionHeading
+        title="Campaign Variables"
+        subtitle="These variables may be used in interaction steps and canned responses. This can be especially useful when using Template Campaign."
+      />
+      {fetchLoading && (
+        <Grid container spacing={3}>
+          <Grid item xs={2}>
+            <Skeleton variant="rect" animation="wave" height={40} />
+          </Grid>
+          <Grid item xs={10}>
+            <Skeleton variant="rect" animation="wave" height={40} />
+          </Grid>
+        </Grid>
+      )}
+      {fetchError && (
+        <Alert severity="error">
+          <AlertTitle>Error fetching Campaign Variables</AlertTitle>
+          {fetchError.message}
+        </Alert>
+      )}
+      {saveError && (
+        <Alert severity="error">
+          <AlertTitle>Error saving Campaign Variables</AlertTitle>
+          {saveError.message}
+        </Alert>
+      )}
+      <form onSubmit={handleSubmit(handleSave)}>
+        {!fetchLoading && !fetchError && (
+          <>
+            <Grid container spacing={1}>
+              {controlledFields.map((arrayField, index) => {
+                return (
+                  <Grid key={arrayField.id} container item xs={12} spacing={3}>
+                    <Grid item xs={2}>
+                      <Controller
+                        name={`campaignVariables.${index}.name`}
+                        control={control}
+                        rules={{
+                          required: "Variable name is required!",
+                          validate: (value) => {
+                            if (allScriptFields([]).includes(value)) {
+                              return "Required CSV field names cannot be used for variable names!";
+                            }
+                            if (!VARIABLE_NAME_REGEXP.test(value)) {
+                              return "Special characters cannot be used for variable names!";
+                            }
+                            return true;
+                          }
+                        }}
+                        render={({ field, fieldState: { error } }) => (
+                          <TextField
+                            {...field}
+                            label="Variable name"
+                            error={error !== undefined}
+                            helperText={error?.message}
+                            fullWidth
+                          />
+                        )}
+                      />
+                    </Grid>
+                    <Grid item xs={9}>
+                      <Controller
+                        name={`campaignVariables.${index}.value`}
+                        control={control}
+                        render={({ field, fieldState: { error } }) => (
+                          <TextField
+                            {...field}
+                            label="Variable value"
+                            error={error !== undefined}
+                            helperText={error?.message}
+                            fullWidth
+                            multiline
+                          />
+                        )}
+                      />
+                    </Grid>
+                    <Grid item xs={1}>
+                      <IconButton onClick={() => handleRemoveVariable(index)}>
+                        <DeleteIcon />
+                      </IconButton>
+                    </Grid>
+                  </Grid>
+                );
+              })}
+              {controlledFields.length === 0 && (
+                <Grid container item xs={12} spacing={3}>
+                  <Grid item xs={12}>
+                    <p style={{ textAlign: "center" }}>No campaign variables</p>
+                  </Grid>
+                </Grid>
+              )}
+            </Grid>
+            <Grid container spacing={1}>
+              <Grid item xs style={{ flexGrow: 1 }} />
+              <Grid item xs={2}>
+                <Button
+                  variant="contained"
+                  endIcon={<AddBoxIcon />}
+                  onClick={handleAddVariable}
+                >
+                  Add Variable
+                </Button>
+              </Grid>
+            </Grid>
+          </>
+        )}
+        <Grid container spacing={1}>
+          <Grid item xs={12}>
+            <div className={classes.wrapper}>
+              <Button
+                variant="contained"
+                color="primary"
+                disabled={fetchLoading || saveLoading || !isDirty}
+                type="submit"
+              >
+                {props.saveLabel}
+              </Button>
+              {saveLoading && (
+                <CircularProgress
+                  size={24}
+                  className={classes.buttonProgress}
+                />
+              )}
+            </div>
+          </Grid>
+        </Grid>
+      </form>
+    </>
+  );
+};
+
+const CampaignVariablesSection = asSection({
+  title: "Campaign Variables",
+  readinessName: "campaignVariables",
+  jobQueueNames: [],
+  expandAfterCampaignStarts: true,
+  expandableBySuperVolunteers: false
+})(CampaignVariablesForm);
+
+export default CampaignVariablesSection;

--- a/src/containers/AdminCampaignEdit/types.ts
+++ b/src/containers/AdminCampaignEdit/types.ts
@@ -7,4 +7,5 @@ export interface CampaignReadinessType {
   cannedResponses: boolean;
   interactions: boolean;
   texters: boolean;
+  campaignVariables: boolean;
 }

--- a/src/lib/scripts.ts
+++ b/src/lib/scripts.ts
@@ -14,6 +14,8 @@ export const delimit = (text: string) => {
   return `${startDelimiter}${text}${endDelimiter}`;
 };
 
+export const VARIABLE_NAME_REGEXP = /^[a-zA-Z0-9 \-_]+$/;
+
 // const REQUIRED_UPLOAD_FIELDS = ['firstName', 'lastName', 'cell']
 const TOP_LEVEL_UPLOAD_FIELDS = [
   "firstName",

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -877,14 +877,14 @@ type CampaignGroupPage {
 
 
 input CampaignVariableInput {
-  order: Int!
+  displayOrder: Int!
   name: String!
   value: String
 }
 
 type CampaignVariable {
   id: ID!
-  order: Int!
+  displayOrder: Int!
   name: String!
   value: String
   createdAt: String!

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -554,6 +554,7 @@ type CampaignReadiness {
   autoassign: Boolean!
   cannedResponses: Boolean!
   campaignGroups: Boolean!
+  campaignVariables: Boolean!
   interactions: Boolean!
   texters: Boolean!
 }
@@ -597,6 +598,7 @@ type Campaign {
   editors: String
   teams: [Team!]!
   campaignGroups: CampaignGroupPage
+  campaignVariables: CampaignVariablePage!
   textingHoursStart: Int
   textingHoursEnd: Int
   isAutoassignEnabled: Boolean!
@@ -668,6 +670,7 @@ input CampaignInput {
   isAssignmentLimitedToTeams: Boolean
   teamIds: [ID]
   campaignGroupIds: [String!]
+  campaignVariables: [CampaignVariableInput!]
   texters: TexterInput
   interactionSteps: InteractionStepInput
   cannedResponses: [CannedResponseInput]
@@ -868,6 +871,33 @@ type CampaignGroupEdge {
 
 type CampaignGroupPage {
   edges: [CampaignGroupEdge!]!
+  pageInfo: RelayPageInfo!
+}
+
+
+
+input CampaignVariableInput {
+  order: Int!
+  name: String!
+  value: String
+}
+
+type CampaignVariable {
+  id: ID!
+  order: Int!
+  name: String!
+  value: String
+  createdAt: String!
+  updatedAt: String!
+}
+
+type CampaignVariableEdge {
+  cursor: Cursor!
+  node: CampaignVariable!
+}
+
+type CampaignVariablePage {
+  edges: [CampaignVariableEdge!]!
   pageInfo: RelayPageInfo!
 }
 

--- a/src/server/api/campaign-variable.ts
+++ b/src/server/api/campaign-variable.ts
@@ -1,11 +1,15 @@
 import { sqlResolvers } from "./lib/utils";
-import { CampaignVariableRecord } from "./types";
 
 export const resolvers = {
   CampaignVariable: {
-    ...sqlResolvers(["id", "name", "value", "createdAt", "updatedAt"]),
-    order: (campaignVariable: CampaignVariableRecord) =>
-      campaignVariable.display_order
+    ...sqlResolvers([
+      "id",
+      "displayOrder",
+      "name",
+      "value",
+      "createdAt",
+      "updatedAt"
+    ])
   }
 };
 

--- a/src/server/api/campaign-variable.ts
+++ b/src/server/api/campaign-variable.ts
@@ -1,0 +1,12 @@
+import { sqlResolvers } from "./lib/utils";
+import { CampaignVariableRecord } from "./types";
+
+export const resolvers = {
+  CampaignVariable: {
+    ...sqlResolvers(["id", "name", "value", "createdAt", "updatedAt"]),
+    order: (campaignVariable: CampaignVariableRecord) =>
+      campaignVariable.display_order
+  }
+};
+
+export default resolvers;

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -47,6 +47,7 @@ import {
   queryCampaignOverlapCount,
   queryCampaignOverlaps
 } from "./campaign-overlap";
+import { resolvers as campaignVariableResolvers } from "./campaign-variable";
 import { resolvers as cannedResponseResolvers } from "./canned-response";
 import {
   getCampaignIdMessageIdsAndCampaignIdContactIdsMapsChunked,
@@ -3792,6 +3793,7 @@ export const resolvers = {
   ...optOutResolvers,
   ...messageResolvers,
   ...campaignGroupResolvers,
+  ...campaignVariableResolvers,
   ...campaignContactResolvers,
   ...cannedResponseResolvers,
   ...questionResponseResolvers,

--- a/src/server/api/types.ts
+++ b/src/server/api/types.ts
@@ -133,6 +133,17 @@ export interface CampaignContactRecord {
   archived: boolean;
 }
 
+export interface CampaignVariableRecord {
+  id: number;
+  campaign_id: number;
+  display_order: number;
+  name: string;
+  value: string | null;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+}
+
 export interface InteractionStepRecord {
   id: number;
   campaign_id: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -21207,6 +21207,11 @@ react-helmet@^6.1.0:
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
 
+react-hook-form@^7.31.1:
+  version "7.31.1"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.31.1.tgz#16c357dd366bc226172e6acbb5a1672873bbfb28"
+  integrity sha512-QjtjZ8r8KtEBWWpcXLyQordCraTFxILtyQpaz5KLLxN2YzcC+FZ9LLtOnNGuOnzZo9gCoB+viK3ZHV9Mb2htmQ==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
## Description

This adds management of campaign variables.

## Motivation and Context

Part 1 of 2 for #1184.

## How Has This Been Tested?

This has been tested locally and in beta channel releases.

## Screenshots (if appropriate):

<img width="1135" alt="Screen Shot 2022-05-21 at 7 59 38 PM" src="https://user-images.githubusercontent.com/2145526/169672718-05559016-6c32-4c6c-b716-7cf6c9068170.png">

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

TBD

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
