### PR TITLE
fix: order autosend contacts by campaign id first

### DIFF
--- a/src/server/tasks/queue-autosend-initials.ts
+++ b/src/server/tasks/queue-autosend-initials.ts
@@ -49,7 +49,7 @@ const queueAutoSendInitials: Task = async (payload: Payload, helpers) => {
           --    and graphile_worker.jobs.key = cc.id::text
           -- )
         -- ordering by campaign id and cell should be fastest since theres a compound key on them
-        order by assignment_id nulls last, cc.campaign_id, cc.cell asc
+        order by cc.campaign_id asc, assignment_id nulls first, cc.cell asc
         limit $1
       ),
       assignments_upserted as (


### PR DESCRIPTION
## Description
This orders contacts eligible for autosend to be ordered by campaign id first. It also changes ordering to send unassigned initials first, then assigned initials. 

## Motivation and Context
Possibly a cause of marking autosent campaigns as complete before all initials have been queued.

## How Has This Been Tested?
This has been tested locally (fix for marking campaigns complete early is not confirmed).

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
