### PR TITLE
fix: fix assignment control layout

### DIFF
--- a/src/containers/AdminAssignmentControl/AssignmentRow.tsx
+++ b/src/containers/AdminAssignmentControl/AssignmentRow.tsx
@@ -1,4 +1,5 @@
 import Chip from "@material-ui/core/Chip";
+import Grid from "@material-ui/core/Grid";
 import uniqBy from "lodash/uniqBy";
 import ChipInput from "material-ui-chip-input";
 import MenuItem from "material-ui/MenuItem";
@@ -98,63 +99,61 @@ const AssignmentRow: React.FC<Props> = (props) => {
     isRowDisabled || !isAssignmentEnabled || id === "general";
 
   return (
-    <div style={{ display: "flex", alignItems: "center" }}>
-      <div style={{ minWidth: "200px" }}>
-        <Chip
-          label={title}
-          style={{ display: "inline-block", color: textColor, backgroundColor }}
-        />
-      </div>
-      <div>
+    <Grid container spacing={2} wrap="nowrap" alignItems="center">
+      <Grid item>
+        <Chip label={title} style={{ color: textColor, backgroundColor }} />
+      </Grid>
+      <Grid item>
         <Toggle
           label="Enable assignment?"
           labelPosition="right"
           toggled={isAssignmentEnabled}
           disabled={isRowDisabled}
-          style={{ display: "inline-block" }}
           onToggle={handleToggleIsEnabled}
         />
-      </div>
-      <div style={{ flex: 1 }} />
-      <SelectField
-        style={{ marginLeft: "20px" }}
-        floatingLabelText="Assignment Type"
-        value={assignmentType}
-        disabled={isRowDisabled || !isAssignmentEnabled}
-        onChange={handleChangeAssignmentType}
-      >
-        <MenuItem
-          value={TextRequestType.UNSENT}
-          primaryText="Unsent Initial Messages"
+      </Grid>
+      <Grid item>
+        <SelectField
+          floatingLabelText="Assignment Type"
+          value={assignmentType}
+          disabled={isRowDisabled || !isAssignmentEnabled}
+          onChange={handleChangeAssignmentType}
+        >
+          <MenuItem
+            value={TextRequestType.UNSENT}
+            primaryText="Unsent Initial Messages"
+          />
+          <MenuItem
+            value={TextRequestType.UNREPLIED}
+            primaryText="Unhandled Replies"
+          />
+        </SelectField>
+      </Grid>
+      <Grid item>
+        <TextField
+          floatingLabelText="Max to request at once"
+          type="number"
+          value={maxRequestCount}
+          disabled={isRowDisabled || !isAssignmentEnabled}
+          onChange={handleChangeMaxCount}
         />
-        <MenuItem
-          value={TextRequestType.UNREPLIED}
-          primaryText="Unhandled Replies"
+      </Grid>
+      <Grid item>
+        <ChipInput
+          floatingLabelText={
+            id === "general" ? "N/A" : "Custom escalation tags"
+          }
+          openOnFocus
+          dataSource={escalationTagList}
+          dataSourceConfig={{ text: "title", value: "id" }}
+          value={escalationTags}
+          onBeforeRequestAdd={handleCheckEscalationTag}
+          onRequestAdd={handleAddEscalationTag}
+          onRequestDelete={handleRemoveEscalationTag}
+          disabled={isSaveDisabled}
         />
-      </SelectField>
-      <TextField
-        style={{ marginLeft: "10px" }}
-        floatingLabelText="Max to request at once"
-        type="number"
-        value={maxRequestCount}
-        disabled={isRowDisabled || !isAssignmentEnabled}
-        onChange={handleChangeMaxCount}
-      />
-      <ChipInput
-        style={{
-          marginLeft: "10px"
-        }}
-        floatingLabelText={id === "general" ? "N/A" : "Custom escalation tags"}
-        openOnFocus
-        dataSource={escalationTagList}
-        dataSourceConfig={{ text: "title", value: "id" }}
-        value={escalationTags}
-        onBeforeRequestAdd={handleCheckEscalationTag}
-        onRequestAdd={handleAddEscalationTag}
-        onRequestDelete={handleRemoveEscalationTag}
-        disabled={isSaveDisabled}
-      />
-    </div>
+      </Grid>
+    </Grid>
   );
 };
 


### PR DESCRIPTION
## Description
This updates the MUI v4 chips upgraded in #1166 to the previous centered styling. This also removes inline styles and replaces them with Grid component layout.

## Motivation and Context
Users were thrown off by the non centered styling introduced in #1166.

## How Has This Been Tested?
This has been tested locally.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/76596635/169939305-8ba89257-b476-46d2-ac0f-7eb71035ed55.png)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
