### PR TITLE
feat: add script preview to interactions section

### DIFF
--- a/libs/spoke-codegen/src/graphql/general-settings.graphql
+++ b/libs/spoke-codegen/src/graphql/general-settings.graphql
@@ -31,7 +31,7 @@ mutation UpdateCampaignBuilderSettings(
   }
 }
 
-query GetMessageReviewSettings($organizationId: String!) {
+query GetScriptPreviewSettings($organizationId: String!) {
   organization(id: $organizationId) {
     id
     settings {
@@ -41,7 +41,7 @@ query GetMessageReviewSettings($organizationId: String!) {
   }
 }
 
-mutation UpdateMessageReviewSettings(
+mutation UpdateScriptPreviewSettings(
   $organizationId: String!
   $forSupervols: Boolean
 ) {

--- a/src/api/campaign.ts
+++ b/src/api/campaign.ts
@@ -117,6 +117,7 @@ export interface Campaign {
   externalSystem?: ExternalSystem | null;
   creator?: User | null;
   deliverabilityStats: CampaignDeliverabilityStats;
+  previewUrl?: string | null;
 }
 
 export interface PaginatedCampaigns {

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
@@ -14,6 +14,8 @@ import {
 } from "../../../../api/interaction-step";
 import { Action } from "../../../../api/types";
 import { readClipboardText, writeClipboardText } from "../../../../client/lib";
+import { useSpokeContext } from "../../../../client/spoke-context";
+import { useAuthzContext } from "../../../../components/AuthzProvider";
 import { dataTest } from "../../../../lib/attributes";
 import { DateTime } from "../../../../lib/datetime";
 import { makeTree } from "../../../../lib/interaction-step-helpers";
@@ -75,6 +77,9 @@ const CampaignInteractionStepsForm: React.FC<InnerProps> = (props) => {
   const [isWorking, setIsWorking] = useState(false);
   const [hasBlockCopied, setHasBlockCopied] = useState(false);
   const [confirmingRootPaste, setConfirmingRootPaste] = useState(false);
+
+  const { orgSettings } = useSpokeContext();
+  const { isAdmin } = useAuthzContext();
 
   const updateClipboardHasBlock = async () => {
     const clipboardText = await readClipboardText();
@@ -287,6 +292,9 @@ const CampaignInteractionStepsForm: React.FC<InnerProps> = (props) => {
     isWorking || hasEmptyScripts || (!isNew && !hasPendingChanges);
   const finalSaveLabel = isWorking ? "Working..." : saveLabel;
 
+  const showScriptPreview =
+    isAdmin || orgSettings?.scriptPreviewForSupervolunteers;
+
   const tree = makeTree(interactionSteps);
   const finalFree: InteractionStepWithChildren = isEqual(tree, {
     interactionSteps: []
@@ -329,16 +337,20 @@ const CampaignInteractionStepsForm: React.FC<InnerProps> = (props) => {
         title="What do you want to discuss?"
         subtitle="You can add scripts and questions and your texters can indicate responses from your contacts. For example, you might want to collect RSVPs to an event or find out whether to follow up about a different volunteer activity. Click the Script Preview button below to view an outline of your script."
       />
-      <Box m={2}>
-        <Button
-          variant="contained"
-          onClick={() => {
-            window.open(`/preview/${previewUrl}`, "_blank");
-          }}
-        >
-          Script Preview
-        </Button>
-      </Box>
+      {showScriptPreview ? (
+        // Open script preview
+        <Box m={2}>
+          <Button
+            key="open-script-preview"
+            variant="contained"
+            onClick={() => {
+              window.open(`/preview/${previewUrl}`, "_blank");
+            }}
+          >
+            Open Script Preview
+          </Button>
+        </Box>
+      ) : null}
       <InteractionStepCard
         interactionStep={finalFree}
         customFields={customFields}

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
@@ -1,4 +1,5 @@
 import { ApolloQueryResult, gql } from "@apollo/client";
+import Box from "@material-ui/core/Box";
 import Button from "@material-ui/core/Button";
 import produce from "immer";
 import isEqual from "lodash/isEqual";
@@ -58,7 +59,7 @@ interface HocProps {
   data: {
     campaign: Pick<
       Campaign,
-      "id" | "isStarted" | "customFields" | "externalSystem"
+      "id" | "isStarted" | "customFields" | "externalSystem" | "previewUrl"
     > & {
       interactionSteps: InteractionStepWithLocalState[];
     };
@@ -264,9 +265,10 @@ const CampaignInteractionStepsForm: React.FC<InnerProps> = (props) => {
     isNew,
     saveLabel,
     data: {
-      campaign: { customFields, externalSystem } = {
+      campaign: { customFields, externalSystem, previewUrl } = {
         customFields: [],
-        externalSystem: null
+        externalSystem: null,
+        previewUrl: null
       }
     },
     availableActions: { availableActions }
@@ -325,8 +327,18 @@ const CampaignInteractionStepsForm: React.FC<InnerProps> = (props) => {
       </Dialog>
       <CampaignFormSectionHeading
         title="What do you want to discuss?"
-        subtitle="You can add scripts and questions and your texters can indicate responses from your contacts. For example, you might want to collect RSVPs to an event or find out whether to follow up about a different volunteer activity."
+        subtitle="You can add scripts and questions and your texters can indicate responses from your contacts. For example, you might want to collect RSVPs to an event or find out whether to follow up about a different volunteer activity. Click the Script Preview button below to view an outline of your script."
       />
+      <Box m={2}>
+        <Button
+          variant="contained"
+          onClick={() => {
+            window.open(`/preview/${previewUrl}`, "_blank");
+          }}
+        >
+          Script Preview
+        </Button>
+      </Box>
       <InteractionStepCard
         interactionStep={finalFree}
         customFields={customFields}
@@ -404,6 +416,7 @@ const mutations: MutationMap<FullComponentProps> = {
             id
             interactions
           }
+          previewUrl
         }
       }
       ${EditInteractionStepFragment}

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
@@ -416,7 +416,6 @@ const mutations: MutationMap<FullComponentProps> = {
             id
             interactions
           }
-          previewUrl
         }
       }
       ${EditInteractionStepFragment}

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
@@ -1,6 +1,7 @@
 import { ApolloQueryResult, gql } from "@apollo/client";
 import Box from "@material-ui/core/Box";
 import Button from "@material-ui/core/Button";
+import Tooltip from "@material-ui/core/Tooltip";
 import produce from "immer";
 import isEqual from "lodash/isEqual";
 import { Dialog } from "material-ui";
@@ -335,20 +336,22 @@ const CampaignInteractionStepsForm: React.FC<InnerProps> = (props) => {
       </Dialog>
       <CampaignFormSectionHeading
         title="What do you want to discuss?"
-        subtitle="You can add scripts and questions and your texters can indicate responses from your contacts. For example, you might want to collect RSVPs to an event or find out whether to follow up about a different volunteer activity. Click the Script Preview button below to view an outline of your script."
+        subtitle="You can add scripts and questions and your texters can indicate responses from your contacts. For example, you might want to collect RSVPs to an event or find out whether to follow up about a different volunteer activity."
       />
       {showScriptPreview ? (
         // Open script preview
         <Box m={2}>
-          <Button
-            key="open-script-preview"
-            variant="contained"
-            onClick={() => {
-              window.open(`/preview/${previewUrl}`, "_blank");
-            }}
-          >
-            Open Script Preview
-          </Button>
+          <Tooltip title="View an outline of your script" placement="top">
+            <Button
+              key="open-script-preview"
+              variant="contained"
+              onClick={() => {
+                window.open(`/preview/${previewUrl}`, "_blank");
+              }}
+            >
+              Open Script Preview
+            </Button>
+          </Tooltip>
         </Box>
       ) : null}
       <InteractionStepCard

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/resolvers.ts
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/resolvers.ts
@@ -36,6 +36,7 @@ export const GET_CAMPAIGN_INTERACTIONS = gql`
       externalSystem {
         id
       }
+      previewUrl
     }
   }
   ${EditInteractionStepFragment}

--- a/src/containers/AdminCampaignStats/index.jsx
+++ b/src/containers/AdminCampaignStats/index.jsx
@@ -2,6 +2,7 @@ import { gql } from "@apollo/client";
 import Button from "@material-ui/core/Button";
 import { red } from "@material-ui/core/colors";
 import Grid from "@material-ui/core/Grid";
+import Tooltip from "@material-ui/core/Tooltip";
 import { css, StyleSheet } from "aphrodite";
 import Divider from "material-ui/Divider";
 import Snackbar from "material-ui/Snackbar";
@@ -229,18 +230,23 @@ class AdminCampaignStats extends React.Component {
                   ) : null}
                   {showScriptPreview ? (
                     // Open script preview
-                    <Button
-                      key="open-script-preview"
-                      variant="contained"
-                      onClick={() => {
-                        window.open(
-                          `/preview/${campaign.previewUrl}`,
-                          "_blank"
-                        );
-                      }}
+                    <Tooltip
+                      title="View an outline of your script"
+                      placement="top"
                     >
-                      Open Script Preview
-                    </Button>
+                      <Button
+                        key="open-script-preview"
+                        variant="contained"
+                        onClick={() => {
+                          window.open(
+                            `/preview/${campaign.previewUrl}`,
+                            "_blank"
+                          );
+                        }}
+                      >
+                        Open Script Preview
+                      </Button>
+                    </Tooltip>
                   ) : null}
                   {isAdmin
                     ? [

--- a/src/containers/AdminCampaignStats/index.jsx
+++ b/src/containers/AdminCampaignStats/index.jsx
@@ -11,6 +11,7 @@ import { Helmet } from "react-helmet";
 import { withRouter } from "react-router-dom";
 import { compose } from "recompose";
 
+import { withSpokeContext } from "../../client/spoke-context";
 import { withAuthzContext } from "../../components/AuthzProvider";
 import CampaignNavigation from "../../components/CampaignNavigation";
 import { dataTest } from "../../lib/attributes";
@@ -136,7 +137,7 @@ class AdminCampaignStats extends React.Component {
       disableVanExportButton,
       disableVanSyncButton
     } = this.state;
-    const { data, match, isAdmin } = this.props;
+    const { data, match, isAdmin, orgSettings } = this.props;
     const { organizationId, campaignId } = match.params;
     const { campaign } = data;
     const { pendingJobs } = campaign;
@@ -175,6 +176,8 @@ class AdminCampaignStats extends React.Component {
     const isOverdue = DateTime.local() >= DateTime.fromISO(campaign.dueBy);
 
     const newTitle = `${this.props.organizationData.organization.name} - Campaigns - ${campaignId}: ${campaign.title}`;
+    const showScriptPreview =
+      isAdmin || orgSettings?.scriptPreviewForSupervolunteers;
 
     return (
       <div>
@@ -222,6 +225,21 @@ class AdminCampaignStats extends React.Component {
                       onClick={this.handleNavigateToEdit}
                     >
                       Edit
+                    </Button>
+                  ) : null}
+                  {showScriptPreview ? (
+                    // Open script preview
+                    <Button
+                      key="open-script-preview"
+                      variant="contained"
+                      onClick={() => {
+                        window.open(
+                          `/preview/${campaign.previewUrl}`,
+                          "_blank"
+                        );
+                      }}
+                    >
+                      Open Script Preview
                     </Button>
                   ) : null}
                   {isAdmin
@@ -277,19 +295,6 @@ class AdminCampaignStats extends React.Component {
                             Archive
                           </Button>
                         ) : null,
-                        // Open script preview
-                        <Button
-                          key="open-script-preview"
-                          variant="contained"
-                          onClick={() => {
-                            window.open(
-                              `/preview/${campaign.previewUrl}`,
-                              "_blank"
-                            );
-                          }}
-                        >
-                          Open Script Preview
-                        </Button>,
                         // Copy
                         <Button
                           key="copy"
@@ -463,6 +468,7 @@ const mutations = {
 export default compose(
   withRouter,
   withAuthzContext,
+  withSpokeContext,
   loadData({
     queries,
     mutations

--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageList/SurveyColumn/index.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageList/SurveyColumn/index.tsx
@@ -1,6 +1,7 @@
 import Button from "@material-ui/core/Button";
 import IconButton from "@material-ui/core/IconButton";
 import Snackbar from "@material-ui/core/Snackbar";
+import Tooltip from "@material-ui/core/Tooltip";
 import CloseIcon from "@material-ui/icons/Close";
 import { useCloseConversationMutation } from "@spoke/spoke-codegen";
 import React, { useCallback, useState } from "react";
@@ -67,16 +68,18 @@ const SurveyColumn: React.FC<Props> = (props) => {
       <div style={{ display: "flex" }}>
         <div style={styles.spacer} />
         {showScriptPreview ? (
-          <Button
-            key="open-script-preview"
-            variant="contained"
-            style={{ marginRight: "10px" }}
-            onClick={() => {
-              window.open(`/preview/${campaign.previewUrl}`, "_blank");
-            }}
-          >
-            Open Script Preview
-          </Button>
+          <Tooltip title="View an outline of your script" placement="top">
+            <Button
+              key="open-script-preview"
+              variant="contained"
+              style={{ marginRight: "10px" }}
+              onClick={() => {
+                window.open(`/preview/${campaign.previewUrl}`, "_blank");
+              }}
+            >
+              Open Script Preview
+            </Button>
+          </Tooltip>
         ) : null}
         <Button
           variant="contained"

--- a/src/containers/Settings/components/General.jsx
+++ b/src/containers/Settings/components/General.jsx
@@ -23,8 +23,8 @@ import { DateTime } from "../../../lib/datetime";
 import { loadData } from "../../hoc/with-operations";
 import CampaignBuilderSettingsCard from "./CampaignBuilderSettingsCard";
 import EditName from "./EditName";
-import MessageReviewSettingsCard from "./MessageReviewSettingsCard";
 import Review10DlcInfo from "./Review10DlcInfo";
+import ScriptPreviewSettingsCard from "./ScriptPreviewSettingsCard";
 
 const styles = StyleSheet.create({
   sectionCard: {
@@ -420,7 +420,7 @@ class Settings extends React.Component {
           style={{ marginBottom: 20 }}
         />
 
-        <MessageReviewSettingsCard
+        <ScriptPreviewSettingsCard
           organizationId={organization.id}
           style={{ marginBottom: 20 }}
         />

--- a/src/containers/Settings/components/ScriptPreviewSettingsCard.tsx
+++ b/src/containers/Settings/components/ScriptPreviewSettingsCard.tsx
@@ -7,29 +7,29 @@ import Switch from "@material-ui/core/Switch";
 import React from "react";
 
 import {
-  useGetMessageReviewSettingsQuery,
-  useUpdateMessageReviewSettingsMutation
+  useGetScriptPreviewSettingsQuery,
+  useUpdateScriptPreviewSettingsMutation
 } from "../../../../libs/spoke-codegen/src";
 
-export interface MessageReviewSettingsCardProps {
+export interface ScriptPreviewSettingsCardProps {
   organizationId: string;
   style?: React.CSSProperties;
 }
 
-export const MessageReviewSettingsCard: React.FC<MessageReviewSettingsCardProps> = (
+export const ScriptPreviewSettingsCard: React.FC<ScriptPreviewSettingsCardProps> = (
   props
 ) => {
   const { organizationId, style } = props;
 
-  const getSettingsState = useGetMessageReviewSettingsQuery({
+  const getSettingsState = useGetScriptPreviewSettingsQuery({
     variables: { organizationId }
   });
   const settings = getSettingsState?.data?.organization?.settings;
 
   const [
-    setScriptPreview,
+    setForSupervols,
     updateState
-  ] = useUpdateMessageReviewSettingsMutation();
+  ] = useUpdateScriptPreviewSettingsMutation();
 
   const working = getSettingsState.loading || updateState.loading;
   const errorMsg =
@@ -41,7 +41,7 @@ export const MessageReviewSettingsCard: React.FC<MessageReviewSettingsCardProps>
   ) => {
     if (working) return;
 
-    await setScriptPreview({
+    await setForSupervols({
       variables: {
         organizationId,
         forSupervols
@@ -51,7 +51,7 @@ export const MessageReviewSettingsCard: React.FC<MessageReviewSettingsCardProps>
 
   return (
     <Card style={style}>
-      <CardHeader title="Message Review Settings" disableTypography />
+      <CardHeader title="Script Preview Settings" disableTypography />
       <CardContent>
         {errorMsg && <p>Error: {errorMsg}</p>}
         <FormGroup row>
@@ -62,7 +62,7 @@ export const MessageReviewSettingsCard: React.FC<MessageReviewSettingsCardProps>
                 onChange={handleToggleScriptPreviewClick}
               />
             }
-            label="Allow Supervolunteers to see Script Preview in Message Review?"
+            label="Allow Supervolunteers to see Script Preview?"
           />
         </FormGroup>
       </CardContent>
@@ -70,4 +70,4 @@ export const MessageReviewSettingsCard: React.FC<MessageReviewSettingsCardProps>
   );
 };
 
-export default MessageReviewSettingsCard;
+export default ScriptPreviewSettingsCard;


### PR DESCRIPTION
## Description
This adds a button to view script preview to the interactions section.
<!--- Describe your changes in detail -->

## Motivation and Context
Users may want to view an outline of the script while building campaigns rather than having to scroll through the entire interaction step tree, particularly when they are using basic mode for campaign building.

## How Has This Been Tested?
This has been tested locally.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/76596635/170810220-122b48f0-39de-4186-b5ad-b278ef73224f.png)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
