### PR TITLE
feat: add interaction step badge

### DIFF
--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/components/InteractionStepCard.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/components/InteractionStepCard.tsx
@@ -1,4 +1,5 @@
 import { useTheme } from "@material-ui/core";
+import Badge from "@material-ui/core/Badge";
 import Button from "@material-ui/core/Button";
 import Card from "@material-ui/core/Card";
 import CardActions from "@material-ui/core/CardActions";
@@ -107,6 +108,7 @@ export const InteractionStepCard: React.FC<Props> = (props) => {
   const stepCanHaveChildren = isRootStep || answerOption;
   const isAbleToAddResponse =
     stepHasQuestion && stepHasScript && stepCanHaveChildren;
+  const childStepsLength = childSteps?.length;
 
   const clipboardEnabled = supportsClipboard();
 
@@ -145,10 +147,17 @@ export const InteractionStepCard: React.FC<Props> = (props) => {
               : "Enter a script for your texter along with the question you want the texter be able to answer on behalf of the contact."
           }
           action={
-            childSteps?.length > 0 && (
-              <IconButton onClick={handleToggleExpanded}>
-                {expanded ? <ExpandLess /> : <ExpandMore />}
-              </IconButton>
+            childStepsLength > 0 && (
+              <Badge
+                badgeContent={childStepsLength}
+                color="primary"
+                overlap="circular"
+                invisible={expanded}
+              >
+                <IconButton onClick={handleToggleExpanded}>
+                  {expanded ? <ExpandLess /> : <ExpandMore />}
+                </IconButton>
+              </Badge>
             )
           }
         />


### PR DESCRIPTION
## Description
This adds a badge with a count of child interaction steps to the collapsed interaction step card.
## Motivation and Context
Collapsed interactions steps don't clearly indicate how large the tree below them is. This also supports future work to simplify the basic campaign builder.

## How Has This Been Tested?
This has been tested locally.

## Screenshots (if appropriate):
<table>
<tr>
<th>Collapsed</th>
<th>Unfurled</th>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/76596635/169943548-fb851c44-be88-45e8-bc00-c5fb76334798.png"/></td>
<td><img src="https://user-images.githubusercontent.com/76596635/169943552-e56c143f-94d4-47d2-b100-529031940d9b.png"/></td>
</tr>
</table>

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
