### PR TITLE
fix: fix early marking of autosend campaign as complete

### DIFF
--- a/src/server/tasks/queue-autosend-initials.ts
+++ b/src/server/tasks/queue-autosend-initials.ts
@@ -125,6 +125,7 @@ const queueAutoSendInitials: Task = async (payload: Payload, helpers) => {
         and c.is_started = true
         and c.autosend_status = 'sending'
         and message_status = 'needsMessage'
+        and is_opted_out = false
       group by 1
     `
   );


### PR DESCRIPTION
## Description
This updates autosending completion to be marked once all initials for a campaign have been sent.

## Motivation and Context
Campaigns that were autosending were marked as complete early if multiple campaigns were queued at the same time.

## How Has This Been Tested?
This has been tested locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
