### PR TITLE
fix(autosend): dont queue opted out contacts for sending

### DIFF
--- a/src/server/tasks/queue-autosend-initials.ts
+++ b/src/server/tasks/queue-autosend-initials.ts
@@ -25,6 +25,7 @@ const queueAutoSendInitials: Task = async (payload: Payload, helpers) => {
           -- contact requirements
           and cc.archived = false
           and cc.message_status = 'needsMessage'
+          and cc.is_opted_out = false
           -- campaign requirements for autosending
           and c.is_archived = false
           and c.is_started = true


### PR DESCRIPTION
## Description

Skip queueing autosends for opted out contacts.

## Motivation and Context

This was causing predictable and unnecessary errors, and resulting in lower sending speeds and earlier completion marks.

## How Has This Been Tested?

Not been tested

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
