### PR TITLE
fix(autosend): return on expected errors

### DIFF
--- a/src/server/api/lib/send-message.ts
+++ b/src/server/api/lib/send-message.ts
@@ -2,6 +2,10 @@
 import { GraphQLError } from "graphql/error";
 import { Knex } from "knex";
 import escapeRegExp from "lodash/escapeRegExp";
+import {
+  ContactOptedOutError,
+  OutsideTextingHoursError
+} from "src/server/send-message-errors";
 import request from "superagent";
 
 import { UserRoleType } from "../../../api/organization-membership";
@@ -236,9 +240,7 @@ export const sendMessage = async (
   }
 
   if (checkOptOut && !!record.is_opted_out) {
-    throw new GraphQLError(
-      "Skipped sending because this contact was already opted out"
-    );
+    throw new ContactOptedOutError();
   }
 
   const {
@@ -251,7 +253,7 @@ export const sendMessage = async (
   const isValidSendTime = isNowBetween(timezone, startHour, endHour);
 
   if (!isValidSendTime) {
-    throw new GraphQLError("Outside permitted texting time for this recipient");
+    throw new OutsideTextingHoursError();
   }
 
   const sendBefore = getSendBeforeUtc(timezone, endHour, DateTime.local());

--- a/src/server/send-message-errors.ts
+++ b/src/server/send-message-errors.ts
@@ -1,0 +1,16 @@
+/* eslint-disable max-classes-per-file */
+import { GraphQLError } from "graphql";
+
+export class SendTimeMessagingError extends GraphQLError {}
+
+export class OutsideTextingHoursError extends SendTimeMessagingError {
+  constructor() {
+    super("Outside permitted texting time for this recipient");
+  }
+}
+
+export class ContactOptedOutError extends SendTimeMessagingError {
+  constructor() {
+    super("Skipped sending because this contact was already opted out");
+  }
+}

--- a/src/server/tasks/retry-interaction-step.ts
+++ b/src/server/tasks/retry-interaction-step.ts
@@ -81,13 +81,17 @@ export const retryInteractionStep: Task = async (
   };
 
   await r.knex.transaction(async (trx) => {
-    await sendMessage(trx, user, `${campaignContactId}`, message);
+    try {
+      await sendMessage(trx, user, `${campaignContactId}`, message);
 
-    // if false or undefined, dont execute
-    if (payload.unassignAfterSend === true) {
-      await trx("campaign_contact")
-        .update({ assignment_id: null })
-        .where({ id: payload.campaignContactId });
+      // if false or undefined, dont execute
+      if (payload.unassignAfterSend === true) {
+        await trx("campaign_contact")
+          .update({ assignment_id: null })
+          .where({ id: payload.campaignContactId });
+      }
+    } catch (ex) {
+      console.error(ex);
     }
   });
 };

--- a/src/server/tasks/retry-interaction-step.ts
+++ b/src/server/tasks/retry-interaction-step.ts
@@ -80,6 +80,11 @@ export const retryInteractionStep: Task = async (
     versionHash: md5(script)
   };
 
+  const expectedErrors = [
+    "Skipped sending because this contact was already opted out",
+    "Outside permitted texting time for this recipient"
+  ];
+
   await r.knex.transaction(async (trx) => {
     try {
       await sendMessage(trx, user, `${campaignContactId}`, message);
@@ -91,7 +96,7 @@ export const retryInteractionStep: Task = async (
           .where({ id: payload.campaignContactId });
       }
     } catch (ex) {
-      console.error(ex);
+      if (!expectedErrors.includes(ex.message)) throw ex;
     }
   });
 };


### PR DESCRIPTION
## Description
This updates the [`retry-interaction-step.ts`](https://github.com/politics-rewired/Spoke/blob/main/src/server/tasks/retry-interaction-step.ts) job to return on the common errors thrown when sending. Only incorrectly configured jobs are marked as errored intentionally.

## Motivation and Context
Closes #1229. #1244 makes opt out errors less common, but this is still good to have for opt outs that occur after the contact has been queued for autosending on another campaign, or for contacts queued at the end of texting hours.

## How Has This Been Tested?
This has been tested locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
