### PR TITLE
fix(external-system): fix saving credentials

### DIFF
--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -3048,9 +3048,9 @@ const rootMutations = {
         username: externalSystem.username
       };
 
-      const savedSystemApiKeySecret = await getWorker().then((worker) => {
-        return worker.getSecret(savedSystem.api_key_ref);
-      });
+      const savedSystemApiKeySecret = await getWorker()
+        .then((worker) => worker.getSecret(savedSystem.api_key_ref))
+        .catch(() => undefined);
 
       const [
         savedSystemApiKey,


### PR DESCRIPTION
## Description

This fixes updating credentials for an external system when the underlying graphile secret somehow does not exist.

## Motivation and Context

graphile-secrets throws an error when the requested secret isn't found. Spoke expects an undefined value.

Ref: https://secure.helpscout.net/conversation/1905190944/6480/

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
