### PR TITLE
fix: fix post-login redirect behavior for local auth

### DIFF
--- a/src/containers/UserEdit.jsx
+++ b/src/containers/UserEdit.jsx
@@ -12,6 +12,8 @@ import PropTypes from "prop-types";
 import queryString from "query-string";
 import React from "react";
 import Form from "react-formal";
+import { withRouter } from "react-router-dom";
+import { compose } from "recompose";
 import * as yup from "yup";
 
 import { NotificationFrequencyType } from "../api/user";
@@ -138,9 +140,9 @@ class UserEdit extends React.Component {
           body: JSON.stringify(allData),
           headers: { "Content-Type": "application/json" }
         });
-        const { redirected, headers, status, url } = loginRes;
-        if (redirected && status === 200) {
-          window.location = url;
+        const { headers, status } = loginRes;
+        if (loginRes.ok) {
+          this.props.history.push(this.props.nextUrl || "");
         } else if (status === 401) {
           throw new Error(headers.get("www-authenticate") || "");
         } else if (status === 400) {
@@ -490,7 +492,10 @@ const mutations = {
   })
 };
 
-export default loadData({
-  queries,
-  mutations
-})(UserEdit);
+export default compose(
+  withRouter,
+  loadData({
+    queries,
+    mutations
+  })
+)(UserEdit);


### PR DESCRIPTION
## Description

This fixes post-login redirect behavior for local passport strategy.

## Motivation and Context

The standardized post-login redirect handler only looks at state preserved during oauth flow, not the nextUrl query param.

Local auth login is an async client request so a redirect response doesn’t even make sense as the way to handle successful login. Instead we can just use browser history.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
