### PR TITLE
fix: show notification settings alert only on user edit

### DIFF
--- a/src/containers/UserEdit.jsx
+++ b/src/containers/UserEdit.jsx
@@ -70,7 +70,10 @@ class UserEdit extends React.Component {
     switch (this.props.authType) {
       case UserEditMode.Edit: {
         const result = await this.props.mutations.editUser(formData);
-        this.setState({ user: result.data.editUser });
+        this.setState({
+          user: result.data.editUser,
+          snackbarOpen: true
+        });
         if (this.props.onRequestClose) {
           this.props.onRequestClose();
         }
@@ -153,7 +156,6 @@ class UserEdit extends React.Component {
         break;
       }
     }
-    this.setState({ snackbarOpen: true });
   };
 
   handleClick = () => this.setState({ changePasswordDialog: true });


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This changes the notification frequency save  result alert to only show after an edit user operation.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The alert was showing after all local auth methods, including those where notification settings are not touched (eg login).

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This has been tested locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
