### PR TITLE
fix: fix join link redirect

### DIFF
--- a/src/containers/UserEdit.jsx
+++ b/src/containers/UserEdit.jsx
@@ -12,8 +12,6 @@ import PropTypes from "prop-types";
 import queryString from "query-string";
 import React from "react";
 import Form from "react-formal";
-import { withRouter } from "react-router-dom";
-import { compose } from "recompose";
 import * as yup from "yup";
 
 import { NotificationFrequencyType } from "../api/user";
@@ -143,9 +141,12 @@ class UserEdit extends React.Component {
           body: JSON.stringify(allData),
           headers: { "Content-Type": "application/json" }
         });
-        const { headers, status } = loginRes;
-        if (loginRes.ok) {
-          this.props.history.push(this.props.nextUrl || "");
+        const { redirected, headers, status } = loginRes;
+        if (redirected) {
+          const { origin } = window.location;
+          const pathName = this.props.nextUrl || "";
+          const newLocation = `${origin}${pathName}`;
+          window.location = newLocation;
         } else if (status === 401) {
           throw new Error(headers.get("www-authenticate") || "");
         } else if (status === 400) {
@@ -494,10 +495,7 @@ const mutations = {
   })
 };
 
-export default compose(
-  withRouter,
-  loadData({
-    queries,
-    mutations
-  })
-)(UserEdit);
+export default loadData({
+  queries,
+  mutations
+})(UserEdit);


### PR DESCRIPTION
## Description

Fix post-login redirect to join link by doing a full page load.

## Motivation and Context

#1256 solved the problem of `nextUrl` not being respected. Using `history.push()` is problematic, however, because post-login only the browser knows about the new session. The React application still thinks `currentUser` is `null`. We do want a full page load to force reentry with the new session.

This was not an issue for `/admin` routes during local testing but is an issue for the join link.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
