### PR TITLE
refactor: extract script preview button

### DIFF
--- a/libs/spoke-codegen/src/graphql/campaign-builder.graphql
+++ b/libs/spoke-codegen/src/graphql/campaign-builder.graphql
@@ -6,6 +6,13 @@ query GetCampaignStatus($campaignId: String!) {
   }
 }
 
+query GetCampaignScriptPreview($campaignId: String!) {
+  campaign(id: $campaignId) {
+    id
+    previewUrl
+  }
+}
+
 mutation SetCampaignApproved($campaignId: String!, $approved: Boolean!) {
   setCampaignApproved(id: $campaignId, approved: $approved) {
     id

--- a/libs/spoke-codegen/src/graphql/message-review.graphql
+++ b/libs/spoke-codegen/src/graphql/message-review.graphql
@@ -30,7 +30,6 @@ fragment ConversationInfo on Conversation {
   campaign {
     id
     title
-    previewUrl
   }
 }
 

--- a/src/components/ScriptPreviewButton.tsx
+++ b/src/components/ScriptPreviewButton.tsx
@@ -17,13 +17,15 @@ export const ScriptPreviewButton: React.FC<ScriptPreviewButtonProps> = (
   const { orgSettings } = useSpokeContext();
   const { isAdmin } = useAuthzContext();
 
-  const showScriptPreview =
-    isAdmin || orgSettings?.scriptPreviewForSupervolunteers;
-
   const { data } = useGetCampaignScriptPreviewQuery({
-    variables: { campaignId }
+    variables: { campaignId },
+    skip: campaignId === undefined
   });
   const previewUrl = data?.campaign?.previewUrl;
+
+  const showScriptPreview =
+    (isAdmin || orgSettings?.scriptPreviewForSupervolunteers) &&
+    previewUrl !== undefined;
 
   return showScriptPreview ? (
     <Tooltip title="View an outline of your script" placement="top">

--- a/src/components/ScriptPreviewButton.tsx
+++ b/src/components/ScriptPreviewButton.tsx
@@ -1,0 +1,43 @@
+import Button from "@material-ui/core/Button";
+import Tooltip from "@material-ui/core/Tooltip";
+import { useGetCampaignScriptPreviewQuery } from "@spoke/spoke-codegen";
+import React from "react";
+
+import { useSpokeContext } from "../client/spoke-context";
+import { useAuthzContext } from "./AuthzProvider";
+
+export interface ScriptPreviewButtonProps {
+  campaignId: string;
+}
+
+export const ScriptPreviewButton: React.FC<ScriptPreviewButtonProps> = (
+  props
+) => {
+  const { campaignId } = props;
+  const { orgSettings } = useSpokeContext();
+  const { isAdmin } = useAuthzContext();
+
+  const showScriptPreview =
+    isAdmin || orgSettings?.scriptPreviewForSupervolunteers;
+
+  const { data } = useGetCampaignScriptPreviewQuery({
+    variables: { campaignId }
+  });
+  const previewUrl = data?.campaign?.previewUrl;
+
+  return showScriptPreview ? (
+    <Tooltip title="View an outline of your script" placement="top">
+      <Button
+        key="open-script-preview"
+        variant="contained"
+        onClick={() => {
+          window.open(`/preview/${previewUrl}`, "_blank");
+        }}
+      >
+        Open Script Preview
+      </Button>
+    </Tooltip>
+  ) : null;
+};
+
+export default ScriptPreviewButton;

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
@@ -6,7 +6,6 @@ import isEqual from "lodash/isEqual";
 import { Dialog } from "material-ui";
 import React, { useEffect, useState } from "react";
 import { compose } from "recompose";
-import ScriptPreviewButton from "src/components/ScriptPreviewButton";
 
 import { Campaign } from "../../../../api/campaign";
 import {
@@ -15,6 +14,7 @@ import {
 } from "../../../../api/interaction-step";
 import { Action } from "../../../../api/types";
 import { readClipboardText, writeClipboardText } from "../../../../client/lib";
+import ScriptPreviewButton from "../../../../components/ScriptPreviewButton";
 import { dataTest } from "../../../../lib/attributes";
 import { DateTime } from "../../../../lib/datetime";
 import { makeTree } from "../../../../lib/interaction-step-helpers";

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/resolvers.ts
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/resolvers.ts
@@ -36,7 +36,6 @@ export const GET_CAMPAIGN_INTERACTIONS = gql`
       externalSystem {
         id
       }
-      previewUrl
     }
   }
   ${EditInteractionStepFragment}

--- a/src/containers/AdminCampaignStats/index.jsx
+++ b/src/containers/AdminCampaignStats/index.jsx
@@ -10,9 +10,9 @@ import React from "react";
 import { Helmet } from "react-helmet";
 import { withRouter } from "react-router-dom";
 import { compose } from "recompose";
-import ScriptPreviewButton from "src/components/ScriptPreviewButton";
 
 import CampaignNavigation from "../../components/CampaignNavigation";
+import ScriptPreviewButton from "../../components/ScriptPreviewButton";
 import { dataTest } from "../../lib/attributes";
 import { DateTime } from "../../lib/datetime";
 import theme from "../../styles/theme";

--- a/src/containers/AdminCampaignStats/index.jsx
+++ b/src/containers/AdminCampaignStats/index.jsx
@@ -2,7 +2,6 @@ import { gql } from "@apollo/client";
 import Button from "@material-ui/core/Button";
 import { red } from "@material-ui/core/colors";
 import Grid from "@material-ui/core/Grid";
-import Tooltip from "@material-ui/core/Tooltip";
 import { css, StyleSheet } from "aphrodite";
 import Divider from "material-ui/Divider";
 import Snackbar from "material-ui/Snackbar";
@@ -11,9 +10,8 @@ import React from "react";
 import { Helmet } from "react-helmet";
 import { withRouter } from "react-router-dom";
 import { compose } from "recompose";
+import ScriptPreviewButton from "src/components/ScriptPreviewButton";
 
-import { withSpokeContext } from "../../client/spoke-context";
-import { withAuthzContext } from "../../components/AuthzProvider";
 import CampaignNavigation from "../../components/CampaignNavigation";
 import { dataTest } from "../../lib/attributes";
 import { DateTime } from "../../lib/datetime";
@@ -138,7 +136,7 @@ class AdminCampaignStats extends React.Component {
       disableVanExportButton,
       disableVanSyncButton
     } = this.state;
-    const { data, match, isAdmin, orgSettings } = this.props;
+    const { data, match, isAdmin } = this.props;
     const { organizationId, campaignId } = match.params;
     const { campaign } = data;
     const { pendingJobs } = campaign;
@@ -175,10 +173,7 @@ class AdminCampaignStats extends React.Component {
       ? DateTime.fromISO(campaign.dueBy).toFormat("DD")
       : "No Due Date";
     const isOverdue = DateTime.local() >= DateTime.fromISO(campaign.dueBy);
-
     const newTitle = `${this.props.organizationData.organization.name} - Campaigns - ${campaignId}: ${campaign.title}`;
-    const showScriptPreview =
-      isAdmin || orgSettings?.scriptPreviewForSupervolunteers;
 
     return (
       <div>
@@ -228,26 +223,8 @@ class AdminCampaignStats extends React.Component {
                       Edit
                     </Button>
                   ) : null}
-                  {showScriptPreview ? (
-                    // Open script preview
-                    <Tooltip
-                      title="View an outline of your script"
-                      placement="top"
-                    >
-                      <Button
-                        key="open-script-preview"
-                        variant="contained"
-                        onClick={() => {
-                          window.open(
-                            `/preview/${campaign.previewUrl}`,
-                            "_blank"
-                          );
-                        }}
-                      >
-                        Open Script Preview
-                      </Button>
-                    </Tooltip>
-                  ) : null}
+                  <ScriptPreviewButton campaignId={campaignId} />
+
                   {isAdmin
                     ? [
                         // Buttons for Admins (and not Supervolunteers)
@@ -473,8 +450,6 @@ const mutations = {
 
 export default compose(
   withRouter,
-  withAuthzContext,
-  withSpokeContext,
   loadData({
     queries,
     mutations

--- a/src/containers/AdminCampaignStats/queries.ts
+++ b/src/containers/AdminCampaignStats/queries.ts
@@ -14,7 +14,6 @@ export const GET_CAMPAIGN = gql`
         assigned
         status
       }
-      previewUrl
     }
   }
 `;

--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageList/SurveyColumn/index.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageList/SurveyColumn/index.tsx
@@ -1,13 +1,11 @@
 import Button from "@material-ui/core/Button";
 import IconButton from "@material-ui/core/IconButton";
 import Snackbar from "@material-ui/core/Snackbar";
-import Tooltip from "@material-ui/core/Tooltip";
 import CloseIcon from "@material-ui/icons/Close";
 import { useCloseConversationMutation } from "@spoke/spoke-codegen";
 import React, { useCallback, useState } from "react";
+import ScriptPreviewButton from "src/components/ScriptPreviewButton";
 
-import { useSpokeContext } from "../../../../../client/spoke-context";
-import { useAuthzContext } from "../../../../../components/AuthzProvider";
 import ManageSurveyResponses from "./ManageSurveyResponses";
 import ManageTags from "./ManageTags";
 
@@ -33,8 +31,6 @@ const SurveyColumn: React.FC<Props> = (props) => {
   const [errorMessage, setErrorMessage] = useState<string | undefined>(
     undefined
   );
-  const { orgSettings } = useSpokeContext();
-  const { isAdmin } = useAuthzContext();
 
   const [closeConversation] = useCloseConversationMutation({
     refetchQueries: ["getContactTags"]
@@ -58,29 +54,13 @@ const SurveyColumn: React.FC<Props> = (props) => {
     setErrorMessage
   ]);
 
-  const showScriptPreview =
-    isAdmin || orgSettings?.scriptPreviewForSupervolunteers;
-
   return (
     <div style={styles.container}>
       <ManageSurveyResponses contact={contact} campaign={campaign} />
       <div style={styles.spacer} />
       <div style={{ display: "flex" }}>
         <div style={styles.spacer} />
-        {showScriptPreview ? (
-          <Tooltip title="View an outline of your script" placement="top">
-            <Button
-              key="open-script-preview"
-              variant="contained"
-              style={{ marginRight: "10px" }}
-              onClick={() => {
-                window.open(`/preview/${campaign.previewUrl}`, "_blank");
-              }}
-            >
-              Open Script Preview
-            </Button>
-          </Tooltip>
-        ) : null}
+        <ScriptPreviewButton campaignId={campaign.id} />
         <Button
           variant="contained"
           disabled={isWorking}

--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageList/SurveyColumn/index.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageList/SurveyColumn/index.tsx
@@ -4,8 +4,8 @@ import Snackbar from "@material-ui/core/Snackbar";
 import CloseIcon from "@material-ui/icons/Close";
 import { useCloseConversationMutation } from "@spoke/spoke-codegen";
 import React, { useCallback, useState } from "react";
-import ScriptPreviewButton from "src/components/ScriptPreviewButton";
 
+import ScriptPreviewButton from "../../../../../components/ScriptPreviewButton";
 import ManageSurveyResponses from "./ManageSurveyResponses";
 import ManageTags from "./ManageTags";
 

--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageList/index.jsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageList/index.jsx
@@ -346,7 +346,6 @@ const queries = {
             campaign {
               id
               title
-              previewUrl
             }
           }
         }


### PR DESCRIPTION
## Description 
This creates a reusable component for script preview.
## Motivation and Context
Closes #1251

## How Has This Been Tested?
This has been tested locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
