### PR TITLE
feat: allow campaign to pick messaging service

### DIFF
--- a/__test__/testbed-preparation/core.ts
+++ b/__test__/testbed-preparation/core.ts
@@ -369,6 +369,32 @@ export const createCompleteCampaign = async (
   return { organization, campaign, texters, assignments, contacts };
 };
 
+export type CreateMessagingServiceOptions = {
+  organizationId: number;
+  active: boolean;
+};
+
+export const createMessagingService = async (
+  client: PoolClient,
+  options: CreateMessagingServiceOptions
+) =>
+  client.query(
+    `
+insert into public.messaging_service (messaging_service_sid, organization_id, account_sid, encrypted_auth_token, service_type, name, active)
+values ($1, $2, $3, $4, $5, $6, $7)
+returning *;
+`,
+    [
+      faker.random.uuid(),
+      options.organizationId,
+      faker.random.alphaNumeric(15),
+      faker.random.alphaNumeric(15),
+      "assemble-numbers",
+      faker.name.firstName(),
+      options.active
+    ]
+  );
+
 export type CreateInteractionStepOptions = {
   campaignId: number;
 } & Partial<

--- a/migrations/20220605032850_add_messaging_service_names.js
+++ b/migrations/20220605032850_add_messaging_service_names.js
@@ -1,0 +1,17 @@
+exports.up = function up(knex) {
+  return knex.schema.alterTable("messaging_service", (table) => {
+    table.string("name").notNullable().default("");
+    table.boolean("active").notNullable().default(true);
+
+    table.index("active");
+  });
+};
+
+exports.down = function down(knex) {
+  return knex.schema.alterTable("messaging_service", (table) => {
+    table.dropIndex("active");
+
+    table.dropColumn("active");
+    table.dropColumn("name");
+  });
+};

--- a/migrations/20220605033846_add_messaging_service_to_campaign.js
+++ b/migrations/20220605033846_add_messaging_service_to_campaign.js
@@ -1,0 +1,84 @@
+exports.up = function up(knex) {
+  return knex.schema
+    .alterTable("all_campaign", (table) => {
+      table.text("messaging_service_sid");
+
+      table
+        .foreign("messaging_service_sid")
+        .references("messaging_service.messaging_service_sid");
+    })
+    .then(() => {
+      return knex.schema.raw(`
+    create or replace view campaign as
+      select
+        id,
+        organization_id,
+        title,
+        description,
+        is_started,
+        due_by,
+        created_at,
+        is_archived,
+        use_dynamic_assignment,
+        logo_image_url,
+        intro_html,
+        primary_color,
+        texting_hours_start,
+        texting_hours_end,
+        timezone,
+        creator_id,
+        is_autoassign_enabled,
+        limit_assignment_to_teams,
+        updated_at,
+        replies_stale_after_minutes,
+        landlines_filtered,
+        external_system_id,
+        is_approved,
+        autosend_status,
+        autosend_user_id,
+        messaging_service_sid
+      from all_campaign
+      where is_template = false;
+`);
+    });
+};
+
+exports.down = function down(knex) {
+  return knex.schema
+    .alterTable("all_campaign", (table) => {
+      table.dropColumn("messaging_service_sid");
+    })
+    .then(() => {
+      return knex.schema.raw(`
+    create or replace view campaign as
+      select
+        id,
+        organization_id,
+        title,
+        description,
+        is_started,
+        due_by,
+        created_at,
+        is_archived,
+        use_dynamic_assignment,
+        logo_image_url,
+        intro_html,
+        primary_color,
+        texting_hours_start,
+        texting_hours_end,
+        timezone,
+        creator_id,
+        is_autoassign_enabled,
+        limit_assignment_to_teams,
+        updated_at,
+        replies_stale_after_minutes,
+        landlines_filtered,
+        external_system_id,
+        is_approved,
+        autosend_status,
+        autosend_user_id
+      from all_campaign
+      where is_template = false;
+`);
+    });
+};

--- a/migrations/20220605033846_add_messaging_service_to_campaign.js
+++ b/migrations/20220605033846_add_messaging_service_to_campaign.js
@@ -45,12 +45,11 @@ exports.up = function up(knex) {
 
 exports.down = function down(knex) {
   return knex.schema
-    .alterTable("all_campaign", (table) => {
-      table.dropColumn("messaging_service_sid");
-    })
-    .then(() => {
-      return knex.schema.raw(`
-    create or replace view campaign as
+    .raw(
+      `
+    drop view campaign cascade;
+
+    create view campaign as
       select
         id,
         organization_id,
@@ -79,6 +78,157 @@ exports.down = function down(knex) {
         autosend_user_id
       from all_campaign
       where is_template = false;
-`);
+
+   create or replace view assignable_campaigns as (
+     select id, title, organization_id, limit_assignment_to_teams
+     from campaign
+     where is_started = true
+       and is_archived = false
+       and is_autoassign_enabled = true
+   );
+
+    create or replace view assignable_campaign_contacts as (
+      select
+        campaign_contact.id, campaign_contact.campaign_id,
+        campaign_contact.message_status, campaign.texting_hours_end,
+        campaign_contact.timezone::text as contact_timezone
+      from campaign_contact
+      join campaign on campaign_contact.campaign_id = campaign.id
+      where assignment_id is null
+        and is_opted_out = false
+        and archived = false
+        and not exists (
+          select 1
+          from campaign_contact_tag
+          join tag on campaign_contact_tag.tag_id = tag.id
+          where tag.is_assignable = false
+            and campaign_contact_tag.campaign_contact_id = campaign_contact.id
+        )
+    );
+
+    create or replace view assignable_needs_message as (
+      select acc.id, acc.campaign_id, acc.message_status
+      from assignable_campaign_contacts as acc
+      join campaign on campaign.id = acc.campaign_id
+      where message_status = 'needsMessage'
+        and (
+            ( acc.contact_timezone is null
+              and extract(hour from CURRENT_TIMESTAMP at time zone campaign.timezone) < campaign.texting_hours_end
+              and extract(hour from CURRENT_TIMESTAMP at time zone campaign.timezone) >= campaign.texting_hours_start
+            )
+          or
+            ( campaign.texting_hours_end > extract(hour from (CURRENT_TIMESTAMP at time zone acc.contact_timezone) + interval '10 minutes')
+              and campaign.texting_hours_start <= extract(hour from (CURRENT_TIMESTAMP at time zone acc.contact_timezone))
+            )
+        )
+    );
+
+    create or replace view assignable_campaigns_with_needs_message as (
+      select *
+      from assignable_campaigns
+      where
+        exists (
+          select 1
+          from assignable_needs_message
+          where campaign_id = assignable_campaigns.id
+        )
+        and not exists (
+          select 1
+          from campaign
+          where campaign.id = assignable_campaigns.id
+            and now() > date_trunc('day', (due_by + interval '24 hours') at time zone campaign.timezone)
+        )
+    );
+
+    create or replace view assignable_needs_reply as (
+      select acc.id, acc.campaign_id, acc.message_status
+      from assignable_campaign_contacts as acc
+      join campaign on campaign.id = acc.campaign_id
+      where message_status = 'needsResponse'
+        and (
+            ( acc.contact_timezone is null
+              and extract(hour from CURRENT_TIMESTAMP at time zone campaign.timezone) < campaign.texting_hours_end
+              and extract(hour from CURRENT_TIMESTAMP at time zone campaign.timezone) >= campaign.texting_hours_start
+            )
+          or
+            ( campaign.texting_hours_end > extract(hour from (CURRENT_TIMESTAMP at time zone acc.contact_timezone) + interval '2 minutes')
+              and campaign.texting_hours_start <= extract(hour from (CURRENT_TIMESTAMP at time zone acc.contact_timezone))
+            )
+        )
+    );
+
+   create or replace view assignable_campaigns_with_needs_reply as (
+     select *
+     from assignable_campaigns
+     where exists (
+       select 1
+       from assignable_needs_reply
+       where campaign_id = assignable_campaigns.id
+     )
+   );
+
+    create or replace view assignable_needs_reply_with_escalation_tags as (
+      select acc.id, acc.campaign_id, acc.message_status, acc.applied_escalation_tags
+      from assignable_campaign_contacts_with_escalation_tags as acc
+      join campaign on campaign.id = acc.campaign_id
+      where message_status = 'needsResponse'
+        and (
+            ( acc.contact_timezone is null
+              and extract(hour from CURRENT_TIMESTAMP at time zone campaign.timezone) < campaign.texting_hours_end
+              and extract(hour from CURRENT_TIMESTAMP at time zone campaign.timezone) >= campaign.texting_hours_start
+            )
+          or
+            ( campaign.texting_hours_end > extract(hour from (CURRENT_TIMESTAMP at time zone acc.contact_timezone) + interval '2 minutes')
+              and campaign.texting_hours_start <= extract(hour from (CURRENT_TIMESTAMP at time zone acc.contact_timezone))
+            )
+        )
+    );
+
+    create or replace view public.missing_external_sync_question_response_configuration as
+      select
+        all_values.*,
+        external_system.id as system_id
+      from (
+        select
+          istep.campaign_id,
+          istep.parent_interaction_id as interaction_step_id,
+          istep.answer_option as value,
+          exists (
+            select 1
+            from public.question_response as istep_qr
+            where
+              istep_qr.interaction_step_id = istep.parent_interaction_id
+              and istep_qr.value = istep.answer_option
+          ) as is_required
+        from public.interaction_step istep
+        where istep.parent_interaction_id is not null
+        union
+        select
+          qr_istep.campaign_id,
+          qr.interaction_step_id,
+          qr.value,
+          true as is_required
+        from public.question_response as qr
+        join public.interaction_step qr_istep on qr_istep.id = qr.interaction_step_id
+      ) all_values
+      join campaign on campaign.id = all_values.campaign_id
+      join external_system
+        on external_system.organization_id = campaign.organization_id
+      where
+        not exists (
+          select 1
+          from public.all_external_sync_question_response_configuration aqrc
+          where
+            all_values.campaign_id = aqrc.campaign_id
+            and external_system.id = aqrc.system_id
+            and all_values.interaction_step_id = aqrc.interaction_step_id
+            and all_values.value = aqrc.question_response_value
+        );
+`
+    )
+    .then(() => {
+      return knex.schema.alterTable("all_campaign", (table) => {
+        table.dropColumn("messaging_service_sid");
+      });
     });
 };

--- a/src/api/campaign.ts
+++ b/src/api/campaign.ts
@@ -124,6 +124,7 @@ export interface Campaign {
   creator?: User | null;
   deliverabilityStats: CampaignDeliverabilityStats;
   previewUrl?: string | null;
+  messagingServiceSid?: string | null;
 }
 
 export interface PaginatedCampaigns {
@@ -258,6 +259,7 @@ export const schema = `
     externalSyncConfigurations(after: Cursor, first: Int): ExternalSyncQuestionResponseConfigPage!
     deliverabilityStats(filter: CampaignDeliverabilityStatsFilter): CampaignDeliverabilityStats!
     autosendStatus: String!
+    messagingServiceSid: String
   }
 
   type CampaignEdge {

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -614,6 +614,7 @@ type Campaign {
   externalSyncConfigurations(after: Cursor, first: Int): ExternalSyncQuestionResponseConfigPage!
   deliverabilityStats(filter: CampaignDeliverabilityStatsFilter): CampaignDeliverabilityStats!
   autosendStatus: String!
+  messagingServiceSid: String
 }
 
 type CampaignEdge {

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -407,7 +407,8 @@ export const resolvers = {
       "isAutoassignEnabled",
       "createdAt",
       "landlinesFiltered",
-      "autosendStatus"
+      "autosendStatus",
+      "messagingServiceSid"
     ]),
     isApproved: (campaign) =>
       isNil(campaign.is_approved) ? false : campaign.is_approved,

--- a/src/server/api/lib/campaign.spec.ts
+++ b/src/server/api/lib/campaign.spec.ts
@@ -9,6 +9,7 @@ import {
   createCampaign,
   createCompleteCampaign,
   createMessage,
+  createMessagingService,
   createOrganization,
   createUser,
   createUserOrganization
@@ -134,6 +135,11 @@ describe("create / edit campaign", () => {
         userId: user.id,
         organizationId: organization.id,
         role: UserRoleType.OWNER
+      });
+
+      await createMessagingService(client, {
+        organizationId: organization.id,
+        active: true
       });
       cookies = await createSession({ agent, email: user.email, password });
     });

--- a/src/server/api/lib/campaign.ts
+++ b/src/server/api/lib/campaign.ts
@@ -215,12 +215,15 @@ export const copyCampaign = async (options: CopyCampaignOptions) => {
           .knex("messaging_service")
           .where({ organization_id: campaign.organization_id, active: true })
           .first();
-        messagingServiceSid = messagingService.messaging_service_sid;
+        messagingServiceSid = messagingService?.messaging_service_sid;
       }
 
-      await trx("campaign")
-        .update({ messaging_service_sid: messagingServiceSid })
-        .where({ id: newCampaign.id });
+      // Can't find a valid messaging service to use
+      if (messagingServiceSid) {
+        await trx("campaign")
+          .update({ messaging_service_sid: messagingServiceSid })
+          .where({ id: newCampaign.id });
+      }
 
       // Copy interactions
       const interactions = await trx<InteractionStepRecord>("interaction_step")

--- a/src/server/api/lib/message-sending.js
+++ b/src/server/api/lib/message-sending.js
@@ -122,6 +122,21 @@ export const getContactMessagingService = async (
   if (config.DEFAULT_SERVICE === "fakeservice")
     return { service_type: "fakeservice" };
 
+  const campaignData = await r
+    .reader("campaign")
+    .join(
+      "campaign_contact",
+      "campaign.id",
+      "=",
+      "campaign_contact.campaign_id"
+    )
+    .where({ "campaign_contact.id": campaignContactId })
+    .first();
+
+  if (campaignData.messaging_service_sid) {
+    return getMessagingServiceById(campaignData.messaging_service_sid);
+  }
+
   const {
     rows: [existingMessagingService]
   } = await r.reader.raw(

--- a/src/server/api/lib/message-sending.js
+++ b/src/server/api/lib/message-sending.js
@@ -354,9 +354,13 @@ export async function getCampaignContactAndAssignmentForIncomingMessage({
       on message.campaign_contact_id = campaign_contact_option.id
     where
       message.is_from_contact = false
+      and (
+        campaign.messaging_service_sid IS NULL
+        or campaign.messaging_service_sid = ?
+      )
     order by created_at desc
     limit 1`,
-    [messaging_service_sid, contactNumber]
+    [messaging_service_sid, contactNumber, messaging_service_sid]
   );
 
   return rows[0];

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -802,6 +802,11 @@ const rootMutations = {
         features
       );
 
+      const messagingService = await r
+        .knex("messaging_service")
+        .where({ organization_id: campaign.organizationId, active: true })
+        .first();
+
       await memoizer.invalidate(cacheOpts.CampaignsList.key, {
         organizationId: campaign.organizationId
       });
@@ -816,7 +821,8 @@ const rootMutations = {
           due_by: campaign.dueBy,
           is_started: false,
           is_archived: false,
-          is_approved: false
+          is_approved: false,
+          messaging_service_sid: messagingService.messaging_service_sid
         })
         .returning("*");
 

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -802,10 +802,13 @@ const rootMutations = {
         features
       );
 
-      const messagingService = await r
+      const messagingServices = await r
         .knex("messaging_service")
-        .where({ organization_id: campaign.organizationId, active: true })
-        .first();
+        .where({ organization_id: campaign.organizationId, active: true });
+
+      if (messagingServices.length === 0) {
+        throw new Error("No active messaging services found");
+      }
 
       await memoizer.invalidate(cacheOpts.CampaignsList.key, {
         organizationId: campaign.organizationId
@@ -822,7 +825,7 @@ const rootMutations = {
           is_started: false,
           is_archived: false,
           is_approved: false,
-          messaging_service_sid: messagingService?.messaging_service_sid
+          messaging_service_sid: messagingServices[0].messaging_service_sid
         })
         .returning("*");
 

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -822,7 +822,7 @@ const rootMutations = {
           is_started: false,
           is_archived: false,
           is_approved: false,
-          messaging_service_sid: messagingService.messaging_service_sid
+          messaging_service_sid: messagingService?.messaging_service_sid
         })
         .returning("*");
 


### PR DESCRIPTION
## Description

Part 1 of 3 allowing campaigns to pick their own messaging service for that campaign

## Motivation and Context

Part 1 of #1232 

## How Has This Been Tested?

Tested Locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
