### PR TITLE
fix: fix return type in campaign group functions

### DIFF
--- a/migrations/20220608035530_campaign-group-functions.js
+++ b/migrations/20220608035530_campaign-group-functions.js
@@ -1,0 +1,73 @@
+exports.up = function up(knex) {
+  return knex.schema.raw(
+    `
+      drop function campaigns_in_group(group_name text);
+      drop function campaigns_in_group(group_id integer);
+      
+      create or replace function campaigns_in_group(group_name text)
+      returns setof all_campaign
+      as $$
+        select *
+        from all_campaign
+        where exists (
+          select 1
+          from campaign_group_campaign
+          join campaign_group on campaign_group.id = campaign_group_campaign.campaign_group_id
+          where campaign_group_campaign.campaign_id = all_campaign.id
+            and campaign_group.name = campaigns_in_group.group_name
+        )
+      $$ language sql stable;
+
+      create or replace function campaigns_in_group(group_id integer)
+      returns setof all_campaign
+      as $$
+        select *
+        from all_campaign
+        where exists (
+          select 1
+          from campaign_group_campaign
+          join campaign_group on campaign_group.id = campaign_group_campaign.campaign_group_id
+          where campaign_group_campaign.campaign_id = all_campaign.id
+            and campaign_group.id = campaigns_in_group.group_id
+        )
+      $$ language sql stable;
+    `
+  );
+};
+
+exports.down = function down(knex) {
+  return knex.schema.raw(
+    `
+      drop function campaigns_in_group(group_name text);
+      drop function campaigns_in_group(group_id integer);
+
+      create or replace function campaigns_in_group(group_name text)
+      returns setof campaign
+      as $$
+        select *
+        from campaign
+        where exists (
+          select 1
+          from campaign_group_campaign
+          join campaign_group on campaign_group.id = campaign_group_campaign.campaign_group_id
+          where campaign_group_campaign.campaign_id = campaign.id
+            and campaign_group.name = campaigns_in_group.group_name
+        )
+      $$ language sql stable;
+
+      create or replace function campaigns_in_group(group_id integer)
+      returns setof campaign
+      as $$
+        select *
+        from campaign
+        where exists (
+          select 1
+          from campaign_group_campaign
+          join campaign_group on campaign_group.id = campaign_group_campaign.campaign_group_id
+          where campaign_group_campaign.campaign_id = campaign.id
+            and campaign_group.id = campaigns_in_group.group_id
+        )
+      $$ language sql stable;
+    `
+  );
+};

--- a/schema-dump.sql
+++ b/schema-dump.sql
@@ -235,16 +235,16 @@ ALTER TABLE public.all_campaign OWNER TO postgres;
 CREATE FUNCTION public.campaigns_in_group(group_id integer) RETURNS SETOF public.all_campaign
     LANGUAGE sql STABLE
     AS $$
-      select *
-      from campaign
-      where exists (
-        select 1
-        from campaign_group_campaign
-        join campaign_group on campaign_group.id = campaign_group_campaign.campaign_group_id
-        where campaign_group_campaign.campaign_id = campaign.id
-          and campaign_group.id = campaigns_in_group.group_id
-      )
-    $$;
+        select *
+        from all_campaign
+        where exists (
+          select 1
+          from campaign_group_campaign
+          join campaign_group on campaign_group.id = campaign_group_campaign.campaign_group_id
+          where campaign_group_campaign.campaign_id = all_campaign.id
+            and campaign_group.id = campaigns_in_group.group_id
+        )
+      $$;
 
 
 ALTER FUNCTION public.campaigns_in_group(group_id integer) OWNER TO postgres;
@@ -256,16 +256,16 @@ ALTER FUNCTION public.campaigns_in_group(group_id integer) OWNER TO postgres;
 CREATE FUNCTION public.campaigns_in_group(group_name text) RETURNS SETOF public.all_campaign
     LANGUAGE sql STABLE
     AS $$
-      select *
-      from campaign
-      where exists (
-        select 1
-        from campaign_group_campaign
-        join campaign_group on campaign_group.id = campaign_group_campaign.campaign_group_id
-        where campaign_group_campaign.campaign_id = campaign.id
-          and campaign_group.name = campaigns_in_group.group_name
-      )
-    $$;
+        select *
+        from all_campaign
+        where exists (
+          select 1
+          from campaign_group_campaign
+          join campaign_group on campaign_group.id = campaign_group_campaign.campaign_group_id
+          where campaign_group_campaign.campaign_id = all_campaign.id
+            and campaign_group.name = campaigns_in_group.group_name
+        )
+      $$;
 
 
 ALTER FUNCTION public.campaigns_in_group(group_name text) OWNER TO postgres;


### PR DESCRIPTION
## Description
This updates the functions `campaigns_in_group` to return records from `all_campaign`
## Motivation and Context
These functions previously had a return type error due to the schema changes in #1211

## How Has This Been Tested?
This has been tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
