### PR TITLE
feat: add bandwidth error codes

### DIFF
--- a/src/containers/AdminCampaignStats/DeliverabilityStats.tsx
+++ b/src/containers/AdminCampaignStats/DeliverabilityStats.tsx
@@ -29,7 +29,22 @@ const descriptions: Record<string, string> = {
   "30005": "Unknown destination handset",
   "30006": "Landline or unreachable carrier",
   "30007": "Blocked as spam",
-  "30008": "Unknown error"
+  "30008": "Unknown error",
+  "4405": "Unreachable sending phone number", // this one shouldn't happen
+  "4406": "Unreachable phone number",
+  "4432": "Unreachable country",
+  "4434": "Unreachable toll-free number",
+  "4700": "Landline or unreachable carrier",
+  "4720": "Unreachable phone number",
+  "4730": "Unreachable phone number (recipient maybe roaming)",
+  "4740": "Unreachable sending phone number", // this one shouldn't happen, but has happening
+  "4750": "Carrier rejected (maybe spam)",
+  "4770": "Blocked as spam",
+  "4780": "Carrier rejected (sending rates exceeded)",
+  "5106": "Unroutable (can be retried)",
+  "5620": "Carrier outage",
+  "9902": "Delivery receipt expired",
+  "9999": "Unknown error"
 };
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
## Description

Add Bandwidth error codes from the docs here: https://dev.bandwidth.com/docs/messaging/errors/

In general, I tried to simplify them were complicated while preserving what the user needs to know.

## Motivation and Context

Closes #1249 

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

Change made at the bottom here: https://docs.spokerewired.com/article/90-send-status-and-error-codes

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have included updates for the documentation accordingly.
