### PR TITLE
fix(replies): messaging_service_sid check in the incorrect section

### DIFF
--- a/src/server/api/lib/message-sending.js
+++ b/src/server/api/lib/message-sending.js
@@ -346,6 +346,10 @@ export async function getCampaignContactAndAssignmentForIncomingMessage({
         campaign.organization_id in (
           select organization_id from chosen_organization
         )
+        and (
+          campaign.messaging_service_sid IS NULL
+          or campaign.messaging_service_sid = ?
+        )
         and campaign_contact.cell = ?
     )
     select campaign_contact_id, assignment_id
@@ -354,13 +358,9 @@ export async function getCampaignContactAndAssignmentForIncomingMessage({
       on message.campaign_contact_id = campaign_contact_option.id
     where
       message.is_from_contact = false
-      and (
-        campaign.messaging_service_sid IS NULL
-        or campaign.messaging_service_sid = ?
-      )
     order by created_at desc
     limit 1`,
-    [messaging_service_sid, contactNumber, messaging_service_sid]
+    [messaging_service_sid, messaging_service_sid, contactNumber]
   );
 
   return rows[0];


### PR DESCRIPTION
## Description

The check for the profileId / messaging service sid on campaign happened when `campaign` was not available

## Motivation and Context

This fixes reply handling currently broken in main

## How Has This Been Tested?

Tested locally using OpenPhone Number + ngrok setup. 

Tested for both old campaigns with no messaging_service_sid set, and new campaign with messaging_service_sid set. 

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
