### PR TITLE
fix(authz): handle supervol permission errors

### DIFF
--- a/src/containers/CampaignList/CampaignListLoader.tsx
+++ b/src/containers/CampaignList/CampaignListLoader.tsx
@@ -77,16 +77,18 @@ const CampaignListLoader: React.FC<Props> = (props) => {
 
   // authz.isSupervol will be true for owner and admin so check NOT admin instead
   const isOnlySupervol = !authz.isAdmin;
-  const unexpectedErrors =
-    error?.graphQLErrors.filter(
+  const unexpectedErrors = [
+    ...(error?.graphQLErrors.filter(
       (gqlError) => !(isOnlySupervol && isSupervolPermissionError(gqlError))
-    ) ?? [];
-
+    ) ?? []),
+    ...(error?.clientErrors ?? []),
+    ...(error?.networkError ? [error?.networkError] : [])
+  ];
   return (
     <div>
       {unexpectedErrors.length > 0 && (
         <div>
-          <p>Errors fetching campaigns:</p>
+          <p>Error(s) fetching campaigns:</p>
           <ul>
             {unexpectedErrors.map((err, i) => (
               // eslint-disable-next-line react/no-array-index-key

--- a/src/containers/CampaignList/CampaignListLoader.tsx
+++ b/src/containers/CampaignList/CampaignListLoader.tsx
@@ -10,7 +10,7 @@ import { CampaignsFilter } from "../../api/campaign";
 import { useAuthzContext } from "../../components/AuthzProvider";
 import LoadingIndicator from "../../components/LoadingIndicator";
 import CampaignList from "./CampaignList";
-import { isSupervolPermissionError } from "./utils";
+import { isCampaignGroupsPermissionError } from "./utils";
 
 interface Props {
   organizationId: string;
@@ -79,7 +79,8 @@ const CampaignListLoader: React.FC<Props> = (props) => {
   const isOnlySupervol = !authz.isAdmin;
   const unexpectedErrors = [
     ...(error?.graphQLErrors.filter(
-      (gqlError) => !(isOnlySupervol && isSupervolPermissionError(gqlError))
+      (gqlError) =>
+        !(isOnlySupervol && isCampaignGroupsPermissionError(gqlError))
     ) ?? []),
     ...(error?.clientErrors ?? []),
     ...(error?.networkError ? [error?.networkError] : [])

--- a/src/containers/CampaignList/utils.ts
+++ b/src/containers/CampaignList/utils.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 import { GraphQLError } from "graphql";
 
-export const isSupervolPermissionError = (gqlError: GraphQLError) => {
+export const isCampaignGroupsPermissionError = (gqlError: GraphQLError) => {
   return (
     gqlError.path &&
     gqlError.path[gqlError.path.length - 1] === "campaignGroups" &&

--- a/src/containers/CampaignList/utils.ts
+++ b/src/containers/CampaignList/utils.ts
@@ -1,0 +1,10 @@
+/* eslint-disable import/prefer-default-export */
+import { GraphQLError } from "graphql";
+
+export const isSupervolPermissionError = (gqlError: GraphQLError) => {
+  return (
+    gqlError.path &&
+    gqlError.path[gqlError.path.length - 1] === "campaignGroups" &&
+    gqlError.extensions.code === "FORBIDDEN"
+  );
+};


### PR DESCRIPTION
## Description

This PR fixes error handling for anticipated "Forbidden" errors for supervolunteers.

## Motivation and Context

Supervolunteers do not have permission to query campaign groups on a campaign. This results in expected "Forbidden" errors alongside the rest of the campaign list data.

Previously, we tried to print the `error` object itself and React complained about `object` being an invalid child element.

This PR fixes two things:
1. Filters out anticipated permission errors to only show unexpected errors
2. Displays errors using valid React children (e.g. `string`)

I went down a little rabbit hole looking into best practices for error handling in GraphQL but created #1270 rather than trying to address in this PR.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
