### PR TITLE
fix: fix superadmin login

### DIFF
--- a/src/server/auth-passport/index.ts
+++ b/src/server/auth-passport/index.ts
@@ -1,14 +1,6 @@
-import type { UserRecord } from "../api/types";
 import { setupAuth0Passport } from "./auth0";
 import { setupLocalAuthPassport } from "./local";
 import { setupSlackPassport } from "./slack";
-
-// Convert a Spoke user record to the type expected by passport.(de)serializeUser
-export const sessionUserMap = {
-  local: (user: UserRecord) => ({ id: user.id }),
-  auth0: (user: UserRecord) => ({ id: user.auth0_id }),
-  slack: (user: UserRecord) => ({ id: user.auth0_id })
-};
 
 export const passportSetups = {
   local: setupLocalAuthPassport,

--- a/src/server/routes/auth.js
+++ b/src/server/routes/auth.js
@@ -2,7 +2,7 @@ import express from "express";
 import rateLimit from "express-rate-limit";
 
 import { config } from "../../config";
-import authStrategies, { sessionUserMap } from "../auth-passport";
+import authStrategies from "../auth-passport";
 import { r } from "../models";
 
 const router = express.Router();
@@ -47,8 +47,7 @@ router.post(
     const user = await userQuery;
 
     if (user) {
-      const passportUser = sessionUserMap[config.PASSPORT_STRATEGY](user);
-      return req.login(passportUser, (err) => {
+      return req.login(user, (err) => {
         if (err) return next(err);
 
         return res.status(200).send({ message: "Success" });


### PR DESCRIPTION
## Description
This fixes superadmin login for the alternate passports strategies.

## Motivation and Context
This is required for superadmin login to work with passport changes in #1215. Currently, superadmin login breaks except when using the local strategy.

## How Has This Been Tested?
This has been tested locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
