### PR TITLE
feat: display tailored message for do not assign texters

### DIFF
--- a/src/api/organization-settings.ts
+++ b/src/api/organization-settings.ts
@@ -10,6 +10,8 @@ export interface OrganizationSettingsInput {
   numbersApiKey: string | null;
   trollbotWebhookUrl: string | null;
   scriptPreviewForSupervolunteers: boolean | null;
+  showDoNotAssignMessage: boolean | null;
+  doNotAssignMessage: string | null;
 
   // Superadmin
   startCampaignRequiresApproval: boolean | null;
@@ -23,6 +25,8 @@ export interface OrganizationSettings {
   showContactLastName: boolean;
   showContactCell: boolean;
   confirmationClickForScriptLinks: boolean;
+  showDoNotAssignMessage: boolean;
+  doNotAssignMessage: string;
 
   // Supervolunteer
   startCampaignRequiresApproval: boolean | null;
@@ -46,6 +50,8 @@ export const schema = `
     trollbotWebhookUrl: String
     scriptPreviewForSupervolunteers: Boolean
     defaultCampaignBuilderMode: CampaignBuilderMode
+    showDoNotAssignMessage: Boolean
+    doNotAssignMessage: String
 
     # Superadmin
     startCampaignRequiresApproval: Boolean
@@ -59,6 +65,8 @@ export const schema = `
     showContactLastName: Boolean!
     showContactCell: Boolean!
     confirmationClickForScriptLinks: Boolean!
+    showDoNotAssignMessage: Boolean!
+    doNotAssignMessage: String!
 
     # Supervolunteer
     startCampaignRequiresApproval: Boolean

--- a/src/components/TexterRequest.jsx
+++ b/src/components/TexterRequest.jsx
@@ -99,7 +99,10 @@ class TexterRequest extends React.Component {
   };
 
   userCanRequest = (memberships) => {
-    const membership = memberships.edges[0].node;
+    const { organizationId } = this.props;
+    const membership = memberships.edges.find(
+      ({ node }) => node.id === organizationId
+    ).node;
     return (
       membership.requestAutoApprove !== RequestAutoApproveType.DO_NOT_APPROVE
     );
@@ -140,7 +143,7 @@ class TexterRequest extends React.Component {
       return (
         <Paper>
           <div style={{ padding: "20px" }}>
-            <h3>Not allowed to request</h3>
+            <h3>Assignment Request Disabled</h3>
             <p>{settings.doNotAssignMessage}</p>
           </div>
         </Paper>

--- a/src/containers/Settings/components/General.jsx
+++ b/src/containers/Settings/components/General.jsx
@@ -66,7 +66,8 @@ class Settings extends React.Component {
     approvalLevel: undefined,
     trollbotWebhookUrl: undefined,
     isWorking: false,
-    error: undefined
+    error: undefined,
+    doNotAssignMessage: undefined
   };
 
   editSettings = async (name, input) => {
@@ -124,6 +125,11 @@ class Settings extends React.Component {
     this.editSettings("Opt Out Message", { optOutMessage });
   };
 
+  handleSaveDoNotAssignMessage = () => {
+    const { doNotAssignMessage } = this.state;
+    this.editSettings("Do Not Assign Message", { doNotAssignMessage });
+  };
+
   handleSaveTrollbotUrl = () => {
     const { trollbotWebhookUrl } = this.state;
     this.editSettings("TrollBot Webhook URL", { trollbotWebhookUrl });
@@ -140,6 +146,11 @@ class Settings extends React.Component {
     });
 
   handleDismissError = () => this.setState({ error: undefined });
+
+  handleToggleShowDoNotAssignMessage = async (event, isToggled) =>
+    this.editSettings("Do Not Assign Message Toggle", {
+      showDoNotAssignMessage: isToggled
+    });
 
   renderTextingHoursForm() {
     const { organization } = this.props.data;
@@ -203,6 +214,7 @@ class Settings extends React.Component {
     const { isWorking, error } = this.state;
     const { organization } = this.props.data;
     const {
+      showDoNotAssignMessage,
       defaulTexterApprovalStatus,
       showContactLastName,
       showContactCell
@@ -210,6 +222,10 @@ class Settings extends React.Component {
 
     const formSchema = yup.object({
       optOutMessage: yup.string().required()
+    });
+
+    const doNotAssignSchema = yup.object({
+      doNotAssignMessage: yup.string().required()
     });
 
     const numbersApiKeySchema = yup.object({
@@ -226,6 +242,10 @@ class Settings extends React.Component {
 
     const optOutMessage =
       this.state.optOutMessage || organization.settings.optOutMessage;
+
+    const doNotAssignMessage =
+      this.state.doNotAssignMessage || organization.settings.doNotAssignMessage;
+
     const noMessageChange =
       optOutMessage === organization.settings.optOutMessage;
     const isOptOutSaveDisabled = isWorking || noMessageChange;
@@ -289,6 +309,49 @@ class Settings extends React.Component {
             </Button>
           </CardActions>
         </Card>
+
+        <Card className={css(styles.sectionCard)}>
+          <CardHeader title="Rejected Texters Message" />
+          <CardText>
+            <Toggle
+              toggled={showDoNotAssignMessage}
+              label="Show different message when user has do not assign?"
+              onToggle={this.handleToggleShowDoNotAssignMessage}
+            />
+            {showDoNotAssignMessage ? (
+              <GSForm
+                schema={doNotAssignSchema}
+                value={{
+                  doNotAssignMessage
+                }}
+                onChange={({ doNotAssignMessage: newValue }) =>
+                  this.setState({
+                    doNotAssignMessage: newValue
+                  })
+                }
+              >
+                <CardHeader title="Do Not Assign Message" />
+                <CardText>
+                  <SpokeFormField
+                    label="Do Not Assign Message"
+                    name="doNotAssignMessage"
+                    fullWidth
+                  />
+                </CardText>
+                <CardActions>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={this.handleSaveDoNotAssignMessage}
+                  >
+                    Save Do Not Assign Message
+                  </Button>
+                </CardActions>
+              </GSForm>
+            ) : null}
+          </CardText>
+        </Card>
+
         <Card className={css(styles.sectionCard)}>
           <GSForm
             schema={formSchema}
@@ -539,6 +602,8 @@ const mutations = {
           defaulTexterApprovalStatus
           showContactLastName
           showContactCell
+          showDoNotAssignMessage
+          doNotAssignMessage
         }
       }
     `,
@@ -563,6 +628,8 @@ const queries = {
             id
             optOutMessage
             numbersApiKey
+            showDoNotAssignMessage
+            doNotAssignMessage
             trollbotWebhookUrl
             defaulTexterApprovalStatus
             showContactLastName

--- a/src/containers/Settings/components/General.jsx
+++ b/src/containers/Settings/components/General.jsx
@@ -23,6 +23,7 @@ import { DateTime } from "../../../lib/datetime";
 import { loadData } from "../../hoc/with-operations";
 import CampaignBuilderSettingsCard from "./CampaignBuilderSettingsCard";
 import EditName from "./EditName";
+import RejectedTextersMessageCard from "./RejectedTextersMessageCard";
 import Review10DlcInfo from "./Review10DlcInfo";
 import ScriptPreviewSettingsCard from "./ScriptPreviewSettingsCard";
 
@@ -125,10 +126,8 @@ class Settings extends React.Component {
     this.editSettings("Opt Out Message", { optOutMessage });
   };
 
-  handleSaveDoNotAssignMessage = () => {
-    const { doNotAssignMessage } = this.state;
+  handleSaveDoNotAssignMessage = (doNotAssignMessage) =>
     this.editSettings("Do Not Assign Message", { doNotAssignMessage });
-  };
 
   handleSaveTrollbotUrl = () => {
     const { trollbotWebhookUrl } = this.state;
@@ -224,10 +223,6 @@ class Settings extends React.Component {
       optOutMessage: yup.string().required()
     });
 
-    const doNotAssignSchema = yup.object({
-      doNotAssignMessage: yup.string().required()
-    });
-
     const numbersApiKeySchema = yup.object({
       numbersApiKey: yup.string().nullable()
     });
@@ -310,47 +305,13 @@ class Settings extends React.Component {
           </CardActions>
         </Card>
 
-        <Card className={css(styles.sectionCard)}>
-          <CardHeader title="Rejected Texters Message" />
-          <CardText>
-            <Toggle
-              toggled={showDoNotAssignMessage}
-              label="Show different message when user has do not assign?"
-              onToggle={this.handleToggleShowDoNotAssignMessage}
-            />
-            {showDoNotAssignMessage ? (
-              <GSForm
-                schema={doNotAssignSchema}
-                value={{
-                  doNotAssignMessage
-                }}
-                onChange={({ doNotAssignMessage: newValue }) =>
-                  this.setState({
-                    doNotAssignMessage: newValue
-                  })
-                }
-              >
-                <CardHeader title="Do Not Assign Message" />
-                <CardText>
-                  <SpokeFormField
-                    label="Do Not Assign Message"
-                    name="doNotAssignMessage"
-                    fullWidth
-                  />
-                </CardText>
-                <CardActions>
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={this.handleSaveDoNotAssignMessage}
-                  >
-                    Save Do Not Assign Message
-                  </Button>
-                </CardActions>
-              </GSForm>
-            ) : null}
-          </CardText>
-        </Card>
+        <RejectedTextersMessageCard
+          showDoNotAssignMessage={showDoNotAssignMessage}
+          doNotAssignMessage={doNotAssignMessage}
+          onToggleShowDoNotAssign={this.handleToggleShowDoNotAssignMessage}
+          onSaveDoNotAssignMessage={this.handleSaveDoNotAssignMessage}
+          style={{ marginBottom: 20 }}
+        />
 
         <Card className={css(styles.sectionCard)}>
           <GSForm

--- a/src/containers/Settings/components/RejectedTextersMessageCard.tsx
+++ b/src/containers/Settings/components/RejectedTextersMessageCard.tsx
@@ -1,0 +1,86 @@
+import Button from "@material-ui/core/Button";
+import Card from "@material-ui/core/Card";
+import CardActions from "@material-ui/core/CardActions";
+import CardContent from "@material-ui/core/CardContent";
+import CardHeader from "@material-ui/core/CardHeader";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Switch from "@material-ui/core/Switch";
+import React, { useState } from "react";
+import * as yup from "yup";
+
+import GSForm from "../../../components/forms/GSForm";
+import SpokeFormField from "../../../components/forms/SpokeFormField";
+
+interface RejectedTextersMessageProps {
+  showDoNotAssignMessage: boolean;
+  doNotAssignMessage: string;
+  onToggleShowDoNotAssign(event: React.ChangeEvent, toggled: boolean): void;
+  onSaveDoNotAssignMessage(message: string): void;
+  style?: React.CSSProperties;
+}
+
+const RejectedTextersMessageCard: React.FC<RejectedTextersMessageProps> = (
+  props
+) => {
+  const [doNotAssignMessage, setDoNotAssignMessage] = useState<string>(
+    props.doNotAssignMessage
+  );
+
+  const doNotAssignSchema = yup.object({
+    doNotAssignMessage: yup.string().required()
+  });
+
+  const handleSaveDoNotAssignMessage = () =>
+    props.onSaveDoNotAssignMessage(doNotAssignMessage);
+
+  const { style, showDoNotAssignMessage, onToggleShowDoNotAssign } = props;
+
+  return (
+    <Card style={style}>
+      <CardHeader
+        titleTypographyProps={{ variant: "body1" }}
+        title="Rejected Texters Message"
+      />
+      <CardContent>
+        <FormControlLabel
+          label="Show different message when user has do not assign?"
+          labelPlacement="start"
+          control={
+            <Switch
+              checked={showDoNotAssignMessage}
+              onChange={onToggleShowDoNotAssign}
+            />
+          }
+        />
+        {showDoNotAssignMessage ? (
+          <GSForm
+            schema={doNotAssignSchema}
+            value={{
+              doNotAssignMessage
+            }}
+            onChange={({ doNotAssignMessage: newValue }) =>
+              setDoNotAssignMessage(newValue)
+            }
+          >
+            <SpokeFormField
+              label="Do Not Assign Message"
+              name="doNotAssignMessage"
+              fullWidth
+            />
+            <CardActions>
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={handleSaveDoNotAssignMessage}
+              >
+                Save Do Not Assign Message
+              </Button>
+            </CardActions>
+          </GSForm>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default RejectedTextersMessageCard;

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -430,6 +430,8 @@ input OrganizationSettingsInput {
   trollbotWebhookUrl: String
   scriptPreviewForSupervolunteers: Boolean
   defaultCampaignBuilderMode: CampaignBuilderMode
+  showDoNotAssignMessage: Boolean
+  doNotAssignMessage: String
 
   # Superadmin
   startCampaignRequiresApproval: Boolean
@@ -443,6 +445,8 @@ type OrganizationSettings {
   showContactLastName: Boolean!
   showContactCell: Boolean!
   confirmationClickForScriptLinks: Boolean!
+  showDoNotAssignMessage: Boolean!
+  doNotAssignMessage: String!
 
   # Supervolunteer
   startCampaignRequiresApproval: Boolean

--- a/src/server/api/organization-settings.ts
+++ b/src/server/api/organization-settings.ts
@@ -80,7 +80,7 @@ const SETTINGS_DEFAULTS: IOrganizationSettings = {
   scriptPreviewForSupervolunteers: false,
   showDoNotAssignMessage: false,
   doNotAssignMessage:
-  "Your ability to request texts has been put on hold. Please a contact a text team leader for more information.",
+    "Your ability to request texts has been put on hold. Please a contact a text team leader for more information.",
   defaultCampaignBuilderMode: CampaignBuilderMode.Advanced
 };
 

--- a/src/server/api/organization-settings.ts
+++ b/src/server/api/organization-settings.ts
@@ -80,7 +80,7 @@ const SETTINGS_DEFAULTS: IOrganizationSettings = {
   scriptPreviewForSupervolunteers: false,
   showDoNotAssignMessage: false,
   doNotAssignMessage:
-    "Your ability to request texts has been put on hold. Please contact a text team leader.",
+  "Your ability to request texts has been put on hold. Please a contact a text team leader for more information.",
   defaultCampaignBuilderMode: CampaignBuilderMode.Advanced
 };
 

--- a/src/server/api/organization-settings.ts
+++ b/src/server/api/organization-settings.ts
@@ -23,6 +23,8 @@ interface IOrganizationSettings {
   confirmationClickForScriptLinks: boolean;
   startCampaignRequiresApproval: boolean;
   scriptPreviewForSupervolunteers: boolean;
+  showDoNotAssignMessage: boolean;
+  doNotAssignMessage: string;
   defaultCampaignBuilderMode: CampaignBuilderMode;
 }
 
@@ -33,6 +35,8 @@ const SETTINGS_PERMISSIONS: {
   showContactLastName: UserRoleType.TEXTER,
   showContactCell: UserRoleType.TEXTER,
   confirmationClickForScriptLinks: UserRoleType.TEXTER,
+  showDoNotAssignMessage: UserRoleType.TEXTER,
+  doNotAssignMessage: UserRoleType.TEXTER,
   startCampaignRequiresApproval: UserRoleType.SUPERVOLUNTEER,
   scriptPreviewForSupervolunteers: UserRoleType.SUPERVOLUNTEER,
   defaultCampaignBuilderMode: UserRoleType.SUPERVOLUNTEER,
@@ -53,6 +57,8 @@ const SETTINGS_WRITE_PERMISSIONS: {
   trollbotWebhookUrl: UserRoleType.OWNER,
   scriptPreviewForSupervolunteers: UserRoleType.OWNER,
   defaultCampaignBuilderMode: UserRoleType.OWNER,
+  showDoNotAssignMessage: UserRoleType.OWNER,
+  doNotAssignMessage: UserRoleType.OWNER,
   startCampaignRequiresApproval: UserRoleType.SUPERADMIN
 };
 
@@ -72,6 +78,9 @@ const SETTINGS_DEFAULTS: IOrganizationSettings = {
   confirmationClickForScriptLinks: true,
   startCampaignRequiresApproval: false,
   scriptPreviewForSupervolunteers: false,
+  showDoNotAssignMessage: false,
+  doNotAssignMessage:
+    "Your ability to request texts has been put on hold. Please contact a text team leader.",
   defaultCampaignBuilderMode: CampaignBuilderMode.Advanced
 };
 
@@ -166,7 +175,9 @@ export const resolvers = {
       "confirmationClickForScriptLinks",
       "startCampaignRequiresApproval",
       "scriptPreviewForSupervolunteers",
-      "defaultCampaignBuilderMode"
+      "defaultCampaignBuilderMode",
+      "showDoNotAssignMessage",
+      "doNotAssignMessage"
     ])
   }
 };


### PR DESCRIPTION
## Description

Display tailored message in texter todos for users with assignment status Do Not Assign. 

Before merging will need new copy from @kohlee and @bchrobot 

## Motivation and Context

Fixes #828

## How Has This Been Tested?

Tested Locally

## Screenshots (if appropriate):

<img width="972" alt="Screenshot 2022-06-20 at 3 04 52 PM" src="https://user-images.githubusercontent.com/367605/174572671-3a6663f9-351c-4be7-80e3-eb207cb29dd3.png">
<img width="2525" alt="Screenshot 2022-06-20 at 3 05 06 PM" src="https://user-images.githubusercontent.com/367605/174572680-7ed67c16-585f-4c77-bcb6-1403d66a4688.png">


## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
