### PR TITLE
fix: editing question response should update value in UI

### DIFF
--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageList/SurveyColumn/ManageSurveyResponses.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageList/SurveyColumn/ManageSurveyResponses.tsx
@@ -106,6 +106,9 @@ export const ManageSurveyResponses: React.FC<ManageSurveyResponsesProps> = (
       const { contact } = props;
       const affectedSteps = getResponsesFrom(iStepId);
 
+      const initialQuestionResponses = questionResponses;
+      let updatedQuestionResponses;
+
       try {
         // Delete response for this and all children (unless this is a single question change)
         if (affectedSteps.length > 1 || !value) {
@@ -115,13 +118,12 @@ export const ManageSurveyResponses: React.FC<ManageSurveyResponsesProps> = (
             contact.id
           );
           if (response.errors) throw response.errors;
-          setQuestionResponses(
-            Object.fromEntries(
-              Object.entries(questionResponses).filter(
-                ([stepId]) => !affectedIStepIds.includes(stepId)
-              )
+          updatedQuestionResponses = Object.fromEntries(
+            Object.entries(questionResponses).filter(
+              ([stepId]) => !affectedIStepIds.includes(stepId)
             )
           );
+          setQuestionResponses(updatedQuestionResponses);
         }
 
         if (value) {
@@ -132,13 +134,18 @@ export const ManageSurveyResponses: React.FC<ManageSurveyResponsesProps> = (
           };
           const response = await updateQuestionResponses([input], contact.id);
           if (response.errors) throw response.errors;
-          setQuestionResponses({ ...questionResponses, [iStepId]: value });
+          updatedQuestionResponses =
+            updatedQuestionResponses ?? questionResponses;
+          setQuestionResponses({
+            ...updatedQuestionResponses,
+            [iStepId]: value
+          });
         }
       } catch (error) {
         setRequestError(formatErrorMessage(error.message));
+        setQuestionResponses(initialQuestionResponses);
       } finally {
         setIsMakingRequest(false);
-        setQuestionResponses(questionResponses);
       }
     };
   };


### PR DESCRIPTION
## Description

Trying to update the state, while the state is updating causes an unwanted override.

## Motivation and Context

Fixes #1004 

## How Has This Been Tested?

Tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
