### PR TITLE
fix: fix copy campaign mutation

### DIFF
--- a/src/server/api/lib/campaign.ts
+++ b/src/server/api/lib/campaign.ts
@@ -204,14 +204,9 @@ export const copyCampaign = async (options: CopyCampaignOptions) => {
       );
 
       // Copy Messaging Service OR use active one
-      const campaign = await r
-        .knex("campaign")
-        .where({ id: campaignId })
-        .first();
-
       const messagingServices = await r
         .knex("messaging_service")
-        .where({ organization_id: campaign.organization_id, active: true });
+        .where({ organization_id: newCampaign.organization_id, active: true });
 
       if (messagingServices.length === 0) {
         throw new Error("No active messaging services found");


### PR DESCRIPTION
## Description
This fixes setting messaging services when copying a campaign, by using the object that's returned directly.

## Motivation and Context
Creating campaigns from a template did not work after changes to this mutation in #1260 

## How Has This Been Tested?
This has been tested locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
