### PR TITLE
fix: mark landlines as unfiltered on new contacts upload

### DIFF
--- a/src/server/api/lib/campaign.ts
+++ b/src/server/api/lib/campaign.ts
@@ -418,6 +418,10 @@ export const editCampaign = async (
     campaign.externalListId
   ) {
     await r.knex("campaign_contact").where({ campaign_id: id }).del();
+    await r
+      .knex("campaign")
+      .where({ id })
+      .update({ landlines_filtered: false });
     await r.knex.raw(
       `select * from public.queue_load_list_into_campaign(?, ?)`,
       [id, parseInt(campaign.externalListId, 10)]
@@ -442,10 +446,12 @@ export const editCampaign = async (
     await accessRequired(user, organizationId, "ADMIN", /* superadmin */ true);
 
     // Uploading contacts from a CSV invalidates external system configuration
+    // and invalidates filtered landlines
     await r
       .knex("campaign")
       .update({
-        external_system_id: null
+        external_system_id: null,
+        landlines_filtered: false
       })
       .where({ id });
 

--- a/src/server/api/lib/campaign.ts
+++ b/src/server/api/lib/campaign.ts
@@ -498,6 +498,13 @@ export const editCampaign = async (
     datawarehouse &&
     user.is_superadmin
   ) {
+    await r
+      .knex("campaign")
+      .update({
+        external_system_id: null,
+        landlines_filtered: false
+      })
+      .where({ id });
     await accessRequired(user, organizationId, "ADMIN", /* superadmin */ true);
     const [job] = await r
       .knex("job_request")

--- a/src/workers/jobs/index.js
+++ b/src/workers/jobs/index.js
@@ -152,13 +152,7 @@ export async function uploadContacts(job) {
 
   const orgFeatures = JSON.parse(organization.features || "{}");
 
-  await Promise.all([
-    r.knex("campaign_contact").where({ campaign_id: campaignId }).del(),
-    r
-      .knex("campaign")
-      .update({ landlines_filtered: false })
-      .where({ id: campaignId })
-  ]);
+  await r.knex("campaign_contact").where({ campaign_id: campaignId }).del();
 
   let jobPayload = await gunzip(Buffer.from(job.payload, "base64"));
   jobPayload = JSON.parse(jobPayload);
@@ -617,6 +611,11 @@ export async function loadContactsFromDataWarehouse(job) {
     .knex("campaign_contact")
     .where("campaign_id", job.campaign_id)
     .delete();
+
+  await r
+    .knex("campaign")
+    .where({ id: campaign.id })
+    .update({ landlines_filtered: false });
 
   await loadContactsFromDataWarehouseFragment({
     jobId: job.id,

--- a/src/workers/jobs/index.js
+++ b/src/workers/jobs/index.js
@@ -612,11 +612,6 @@ export async function loadContactsFromDataWarehouse(job) {
     .where("campaign_id", job.campaign_id)
     .delete();
 
-  await r
-    .knex("campaign")
-    .where({ id: campaign.id })
-    .update({ landlines_filtered: false });
-
   await loadContactsFromDataWarehouseFragment({
     jobId: job.id,
     query: sqlQuery,


### PR DESCRIPTION
## Description

The change to landlines being filtered can be slow depending on the load on the server, making the change earlier resets the result.

## Motivation and Context

This fixes #907 

## How Has This Been Tested?
Tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
