### PR TITLE
fix: fix texter request form

### DIFF
--- a/src/components/TexterRequest.jsx
+++ b/src/components/TexterRequest.jsx
@@ -100,9 +100,9 @@ class TexterRequest extends React.Component {
 
   userCanRequest = (memberships) => {
     const { organizationId } = this.props;
-    const membership = memberships.edges.find(
-      ({ node }) => node.id === organizationId
-    ).node;
+    const membership = memberships.edges
+      .map(({ node }) => node)
+      .find(({ organization }) => organization.id === organizationId);
     return (
       membership.requestAutoApprove !== RequestAutoApproveType.DO_NOT_APPROVE
     );
@@ -281,6 +281,9 @@ const queries = {
               node {
                 id
                 requestAutoApprove
+                organization {
+                  id
+                }
               }
             }
           }


### PR DESCRIPTION
## Description

This fixes the texter request form.

## Motivation and Context

Organization record ID was being compared to the user_organization record's ID.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
