### PR TITLE
feat: support overriding van contact type

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -740,6 +740,11 @@ const validators = {
       "The numeric coding of the VAN list export type. The default is the Hustle format.",
     default: 8
   }),
+  VAN_CONTACT_TYPE_ID: num({
+    desc:
+      "The numeric coding of the contact type to use for syncing VAN canvass results. Default is 'SMS Text'.",
+    default: 37
+  }),
   WAREHOUSE_DB_TYPE: str({
     desc:
       "Enables ability to load contacts directly from a SQL query from a separate data-warehouse db -- only is_superadmin-marked users will see the interface",

--- a/src/server/tasks/sync-campaign-contact-to-van.ts
+++ b/src/server/tasks/sync-campaign-contact-to-van.ts
@@ -3,6 +3,7 @@ import { PoolClient } from "pg";
 import { Task } from "pg-compose";
 import { post } from "superagent";
 
+import { config } from "../../config";
 import { VanAuthPayload, withVan } from "../lib/external-systems";
 
 class VANSyncError extends Error {
@@ -18,8 +19,6 @@ class VANSyncError extends Error {
 }
 
 export const CANVASSED_TAG_NAME = "Canvassed";
-
-export const VAN_SMS_TEXT_CONTACT_TYPE_ID = 37;
 
 export interface VANCanvassContextPhone {
   dialingPrefix: "1";
@@ -290,7 +289,7 @@ export const formatCanvassResponsePayload = ({
       canvassContext: {
         phoneId,
         phone: formatPhone(phoneNumber),
-        contactTypeId: VAN_SMS_TEXT_CONTACT_TYPE_ID,
+        contactTypeId: config.VAN_CONTACT_TYPE_ID,
         dateCanvassed
       },
       resultCodeId: mappedResultCodeId,
@@ -303,7 +302,7 @@ export const formatCanvassResponsePayload = ({
       canvassContext: {
         phoneId,
         phone: formatPhone(phoneNumber),
-        contactTypeId: VAN_SMS_TEXT_CONTACT_TYPE_ID,
+        contactTypeId: config.VAN_CONTACT_TYPE_ID,
         dateCanvassed
       },
       resultCodeId: optOutResultCode,


### PR DESCRIPTION
## Description

This adds support for overriding the van contact type (ex. to use "Paid SMS" instead of "SMS Text").

## Motivation and Context

This partially addresses #1277.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
