### PR TITLE
feat: support setting custom campaign export chunk size

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -400,6 +400,10 @@ const validators = {
     choices: ["s3", "gs-json"], // eventually add support for GCP w/ HMAC interoperability: ["gs"]
     default: "s3"
   }),
+  EXPORT_CAMPAIGN_CHUNK_SIZE: num({
+    desc: "Chunk size to use for exporting campaign contacts and messages.",
+    default: 1000
+  }),
   FIX_ORGLESS: bool({
     desc:
       "Set to true only if you want to run the job that automatically assigns the default org (see DEFAULT_ORG) to new users who have no assigned org.",

--- a/src/server/tasks/export-campaign.ts
+++ b/src/server/tasks/export-campaign.ts
@@ -2,6 +2,7 @@
 import { format } from "fast-csv";
 import _ from "lodash";
 
+import { config } from "../../config";
 import { DateTime } from "../../lib/datetime";
 import { getDownloadUrl, getUploadStream } from "../../workers/exports/upload";
 import {
@@ -17,7 +18,7 @@ import { addProgressJob, ProgressTask } from "./utils";
 
 export const TASK_IDENTIFIER = "export-campaign";
 
-const CHUNK_SIZE = 1000;
+const CHUNK_SIZE = config.EXPORT_CAMPAIGN_CHUNK_SIZE;
 
 interface ExportChunk {
   lastContactId: number;


### PR DESCRIPTION
## Description

This allows overriding the default chunk size of 1000 used to break up campaign export jobs.

## Motivation and Context

This can help for instances where campaign export jobs are consistently timing out.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
