### PR TITLE
ci(release): mark GH prereleases appropriately

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,12 @@ jobs:
           input_string: "4.33.0-rc.3"
       - name: Use parsed semver
         run: |
-          echo "major: v${{ steps.semver_parser_prerelease.outputs.major }}"
-          echo "minor: v${{ steps.semver_parser_prerelease.outputs.minor }}"
-          echo "patch: v${{ steps.semver_parser_prerelease.outputs.patch }}"
-          echo "prerelease: v${{ steps.semver_parser_prerelease.outputs.prerelease }}"
-          echo "build: v${{ steps.semver_parser_prerelease.outputs.build }}"
-          echo "fullversion: v${{ steps.semver_parser_prerelease.outputs.fullversion }}"
+          echo "major: ${{ steps.semver_parser_prerelease.outputs.major }}"
+          echo "minor: ${{ steps.semver_parser_prerelease.outputs.minor }}"
+          echo "patch: ${{ steps.semver_parser_prerelease.outputs.patch }}"
+          echo "prerelease: ${{ steps.semver_parser_prerelease.outputs.prerelease }}"
+          echo "build: ${{ steps.semver_parser_prerelease.outputs.build }}"
+          echo "fullversion: ${{ steps.semver_parser_prerelease.outputs.fullversion }}"
           echo "Pre-release boolean: ${{ !!steps.semver_parser_prerelease.outputs.prerelease }}"
       - name: Parse semver string
         id: semver_parser
@@ -36,15 +36,15 @@ jobs:
         with:
           # input_string: ${{ github.ref }}
           # version_extractor_regex: '\/v(.*)$'
-          input_string: "4.33.0-rc.3"
+          input_string: "4.33.0"
       - name: Use parsed semver
         run: |
-          echo "major: v${{ steps.semver_parser.outputs.major }}"
-          echo "minor: v${{ steps.semver_parser.outputs.minor }}"
-          echo "patch: v${{ steps.semver_parser.outputs.patch }}"
-          echo "prerelease: v${{ steps.semver_parser.outputs.prerelease }}"
-          echo "build: v${{ steps.semver_parser.outputs.build }}"
-          echo "fullversion: v${{ steps.semver_parser.outputs.fullversion }}"
+          echo "major: ${{ steps.semver_parser.outputs.major }}"
+          echo "minor: ${{ steps.semver_parser.outputs.minor }}"
+          echo "patch: ${{ steps.semver_parser.outputs.patch }}"
+          echo "prerelease: ${{ steps.semver_parser.outputs.prerelease }}"
+          echo "build: ${{ steps.semver_parser.outputs.build }}"
+          echo "fullversion: ${{ steps.semver_parser.outputs.fullversion }}"
           echo "Pre-release boolean: ${{ !!steps.semver_parser.outputs.prerelease }}"
 
       # - name: Generate Docker image tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    tags:
-      - "v*"
+    # tags:
+    #   - "v*"
 
 jobs:
   cut-gh-release:
@@ -14,19 +14,50 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set output
-        id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/tags/} && echo ::set-output name=version::${GITHUB_REF#refs/tags/v}
-      - name: Generate Docker image tag
-        run: 'echo "Docker image: \`$DOCKER_IMAGE:${{ steps.vars.outputs.version }}\`" > $BODY_PATH'
-      - name: Generate Changelog
-        run: awk "/[#]{2,3} \[${{ steps.vars.outputs.version }}/{flag=1; next} /[#]{2,3} \[/{flag=0} flag" CHANGELOG.md >> $BODY_PATH
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Parse pre-release semver string
+        id: semver_parser_prerelease
+        uses: booxmedialtd/ws-action-parse-semver@v1
         with:
-          name: Version ${{ steps.vars.outputs.version }}
-          tag_name: ${{ steps.vars.outputs.tag }}
-          body_path: ${{ env.BODY_PATH }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # input_string: ${{ github.ref }}
+          # version_extractor_regex: '\/v(.*)$'
+          input_string: "4.33.0-rc.3"
+      - name: Use parsed semver
+        run: |
+          echo "major: v${{ steps.semver_parser_prerelease.outputs.major }}"
+          echo "minor: v${{ steps.semver_parser_prerelease.outputs.minor }}"
+          echo "patch: v${{ steps.semver_parser_prerelease.outputs.patch }}"
+          echo "prerelease: v${{ steps.semver_parser_prerelease.outputs.prerelease }}"
+          echo "build: v${{ steps.semver_parser_prerelease.outputs.build }}"
+          echo "fullversion: v${{ steps.semver_parser_prerelease.outputs.fullversion }}"
+          echo "Pre-release boolean: ${{ !!steps.semver_parser_prerelease.outputs.prerelease }}"
+      - name: Parse semver string
+        id: semver_parser
+        uses: booxmedialtd/ws-action-parse-semver@v1
+        with:
+          # input_string: ${{ github.ref }}
+          # version_extractor_regex: '\/v(.*)$'
+          input_string: "4.33.0-rc.3"
+      - name: Use parsed semver
+        run: |
+          echo "major: v${{ steps.semver_parser.outputs.major }}"
+          echo "minor: v${{ steps.semver_parser.outputs.minor }}"
+          echo "patch: v${{ steps.semver_parser.outputs.patch }}"
+          echo "prerelease: v${{ steps.semver_parser.outputs.prerelease }}"
+          echo "build: v${{ steps.semver_parser.outputs.build }}"
+          echo "fullversion: v${{ steps.semver_parser.outputs.fullversion }}"
+          echo "Pre-release boolean: ${{ !!steps.semver_parser.outputs.prerelease }}"
+
+      # - name: Generate Docker image tag
+      #   run: 'echo "Docker image: \`$DOCKER_IMAGE:${{ steps.semver_parser.outputs.fullversion }}\`" > $BODY_PATH'
+      # - name: Generate Changelog
+      #   run: awk "/[#]{2,3} \[${{ steps.semver_parser.outputs.fullversion }}/{flag=1; next} /[#]{2,3} \[/{flag=0} flag" CHANGELOG.md >> $BODY_PATH
+      # - name: Release
+      #   uses: softprops/action-gh-release@v1
+      #   if: startsWith(github.ref, 'refs/tags/v')
+      #   with:
+      #     name: Version ${{ steps.semver_parser.outputs.fullversion }}
+      #     tag_name: v${{ steps.semver_parser.outputs.fullversion }}
+      #     body_path: ${{ env.BODY_PATH }}
+      #     prerelease: ${{ steps.semver_parser.outputs.fullversion }}
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    # tags:
-    #   - "v*"
+    tags:
+      - "v*"
 
 jobs:
   cut-gh-release:
@@ -18,46 +18,19 @@ jobs:
         id: semver_parser_prerelease
         uses: booxmedialtd/ws-action-parse-semver@v1
         with:
-          # input_string: ${{ github.ref }}
-          # version_extractor_regex: '\/v(.*)$'
-          input_string: "4.33.0-rc.3"
-      - name: Use parsed semver
-        run: |
-          echo "major: ${{ steps.semver_parser_prerelease.outputs.major }}"
-          echo "minor: ${{ steps.semver_parser_prerelease.outputs.minor }}"
-          echo "patch: ${{ steps.semver_parser_prerelease.outputs.patch }}"
-          echo "prerelease: ${{ steps.semver_parser_prerelease.outputs.prerelease }}"
-          echo "build: ${{ steps.semver_parser_prerelease.outputs.build }}"
-          echo "fullversion: ${{ steps.semver_parser_prerelease.outputs.fullversion }}"
-          echo "Pre-release boolean: ${{ !!steps.semver_parser_prerelease.outputs.prerelease }}"
-      - name: Parse semver string
-        id: semver_parser
-        uses: booxmedialtd/ws-action-parse-semver@v1
+          input_string: ${{ github.ref }}
+          version_extractor_regex: '\/v(.*)$'
+      - name: Generate Docker image tag
+        run: 'echo "Docker image: \`$DOCKER_IMAGE:${{ steps.semver_parser.outputs.fullversion }}\`" > $BODY_PATH'
+      - name: Generate Changelog
+        run: awk "/[#]{2,3} \[${{ steps.semver_parser.outputs.fullversion }}/{flag=1; next} /[#]{2,3} \[/{flag=0} flag" CHANGELOG.md >> $BODY_PATH
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/v')
         with:
-          # input_string: ${{ github.ref }}
-          # version_extractor_regex: '\/v(.*)$'
-          input_string: "4.33.0"
-      - name: Use parsed semver
-        run: |
-          echo "major: ${{ steps.semver_parser.outputs.major }}"
-          echo "minor: ${{ steps.semver_parser.outputs.minor }}"
-          echo "patch: ${{ steps.semver_parser.outputs.patch }}"
-          echo "prerelease: ${{ steps.semver_parser.outputs.prerelease }}"
-          echo "build: ${{ steps.semver_parser.outputs.build }}"
-          echo "fullversion: ${{ steps.semver_parser.outputs.fullversion }}"
-          echo "Pre-release boolean: ${{ !!steps.semver_parser.outputs.prerelease }}"
-
-      # - name: Generate Docker image tag
-      #   run: 'echo "Docker image: \`$DOCKER_IMAGE:${{ steps.semver_parser.outputs.fullversion }}\`" > $BODY_PATH'
-      # - name: Generate Changelog
-      #   run: awk "/[#]{2,3} \[${{ steps.semver_parser.outputs.fullversion }}/{flag=1; next} /[#]{2,3} \[/{flag=0} flag" CHANGELOG.md >> $BODY_PATH
-      # - name: Release
-      #   uses: softprops/action-gh-release@v1
-      #   if: startsWith(github.ref, 'refs/tags/v')
-      #   with:
-      #     name: Version ${{ steps.semver_parser.outputs.fullversion }}
-      #     tag_name: v${{ steps.semver_parser.outputs.fullversion }}
-      #     body_path: ${{ env.BODY_PATH }}
-      #     prerelease: ${{ steps.semver_parser.outputs.fullversion }}
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: Version ${{ steps.semver_parser.outputs.fullversion }}
+          tag_name: v${{ steps.semver_parser.outputs.fullversion }}
+          body_path: ${{ env.BODY_PATH }}
+          prerelease: ${{ !!steps.semver_parser.outputs.prerelease }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Parse pre-release semver string
-        id: semver_parser_prerelease
+        id: semver_parser
         uses: booxmedialtd/ws-action-parse-semver@v1
         with:
           input_string: ${{ github.ref }}


### PR DESCRIPTION
## Description

This checks if the semver release is a prerelease and flags the GitHub release as such.

## Motivation and Context

General best practices.

Also, some customers have GitHub alerts set up for releases and GitHub adds helpful disclaimer language to these when the release is marked as a prerelease.

## How Has This Been Tested?

See actions run for these commits:

![Screen Shot 2022-06-26 at 9 02 44 AM](https://user-images.githubusercontent.com/2145526/175815599-97591e49-8727-491c-b081-40c0d086a95d.png)

## Screenshots (if appropriate):

N/A

## Documentation Changes

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
