### PR TITLE
fix(message-review): listen for clicks on entire card header

### DIFF
--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageActions.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageActions.tsx
@@ -179,6 +179,7 @@ const IncomingMessageActions: React.FC<IncomingMessageActionsProps> = (
             {showSection ? <ExpandLess /> : <ExpandMore />}
           </IconButton>
         }
+        style={{ cursor: "pointer" }}
         onClick={handleExpandChange}
       />
       <Collapse in={showSection}>

--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageActions.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageActions.tsx
@@ -175,10 +175,11 @@ const IncomingMessageActions: React.FC<IncomingMessageActionsProps> = (
       <CardHeader
         title="Message Actions"
         action={
-          <IconButton onClick={handleExpandChange}>
+          <IconButton>
             {showSection ? <ExpandLess /> : <ExpandMore />}
           </IconButton>
         }
+        onClick={handleExpandChange}
       />
       <Collapse in={showSection}>
         <CardContent>

--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageFilter.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageFilter.tsx
@@ -130,7 +130,7 @@ const IncomingMessageFilter: React.FC<IncomingMessageFilterProps> = (props) => {
   const [lastName, setLastName] = useState<string>();
   const [cellNumber, setCellNumber] = useState<string>();
   const [messageFilter, setMessageFilter] = useState<Array<any>>(["all"]);
-  const [showSection, setShowSection] = useState<boolean>(false);
+  const [showSection, setShowSection] = useState<boolean>(true);
   const [campaignSearchInput, setCampaignSearchInput] = useState<string>();
   const [campaignSearchInputDebounced] = useDebounce(campaignSearchInput, 500);
   const [texterSearchInput, setTexterSearchInput] = useState<string>();

--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageFilter.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageFilter.tsx
@@ -369,6 +369,7 @@ const IncomingMessageFilter: React.FC<IncomingMessageFilterProps> = (props) => {
             {showSection ? <ExpandLess /> : <ExpandMore />}
           </IconButton>
         }
+        style={{ cursor: "pointer" }}
         onClick={handleExpandChange}
       />
       <Collapse in={showSection}>

--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageFilter.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageFilter.tsx
@@ -365,10 +365,11 @@ const IncomingMessageFilter: React.FC<IncomingMessageFilterProps> = (props) => {
       <CardHeader
         title="Message Filter"
         action={
-          <IconButton onClick={handleExpandChange}>
+          <IconButton>
             {showSection ? <ExpandLess /> : <ExpandMore />}
           </IconButton>
         }
+        onClick={handleExpandChange}
       />
       <Collapse in={showSection}>
         <CardContent>


### PR DESCRIPTION
## Description

This adds the onClick listener to the Filters and Actions card headers rather than just the action button.

## Motivation and Context

Users expect to be able to click on the entire header (as was previously the behavior).

Initial work for addressing #1302

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202532271228785