### PR TITLE
fix: advance from conversation on unassignable tag

### DIFF
--- a/src/containers/AssignmentTexterContact/ApplyTagDialog.jsx
+++ b/src/containers/AssignmentTexterContact/ApplyTagDialog.jsx
@@ -8,6 +8,7 @@ import React, { Component } from "react";
 
 import ApplyTagConfirmationDialog from "../../components/ApplyTagConfirmationDialog";
 import TagSelector from "../../components/TagSelector";
+import theme from "../../styles/theme";
 
 const isEscalateTag = (t) => t.title === "Escalated" || t.title === "Escalate";
 const isNonAssignableTagApplied = (appliedTags) =>
@@ -95,10 +96,19 @@ class ApplyTagDialog extends Component {
     const escalateTag = allTags.find(isEscalateTag);
     const tagsWithoutEscalated = allTags.filter((t) => !isEscalateTag(t));
 
-    const shouldAllowUserToMoveOn = isNonAssignableTagApplied(selectedTags);
+    const hasNonAssignableTag = isNonAssignableTagApplied(selectedTags);
 
-    const saveActions = shouldAllowUserToMoveOn
+    const saveActions = hasNonAssignableTag
       ? [
+          <Button
+            key="save-without-message"
+            color="primary"
+            onClick={this.handleApplyTagsAndMoveOn}
+          >
+            Save and Move On Without a Message
+          </Button>
+        ]
+      : [
           <Button
             key="save-with-message"
             color="primary"
@@ -112,11 +122,6 @@ class ApplyTagDialog extends Component {
             onClick={this.handleApplyTagsAndMoveOn}
           >
             Save and Move On Without a Message
-          </Button>
-        ]
-      : [
-          <Button key="save" color="primary" onClick={this.handleApplyTags}>
-            Save
           </Button>
         ];
 
@@ -146,6 +151,12 @@ class ApplyTagDialog extends Component {
                 Escalate Conversation
               </Button>
             )}
+            {hasNonAssignableTag ? (
+              <p style={{ color: theme.colors.red }}>
+                You've selected a tag that will cause the conversation to become
+                unassigned, and you will not be able to send a follow up.
+              </p>
+            ) : null}
             <TagSelector
               value={selectedTags}
               dataSource={tagsWithoutEscalated}


### PR DESCRIPTION
## Description

Advance from conversation when an unassignable tag is selected, like Escalated, etc, and show the user a warning message.

## Motivation and Context

Fixes #950 

## How Has This Been Tested?

Tested Locally with 3 different scenarios.

## Screenshots (if appropriate):
<img width="1919" alt="Screenshot 2022-07-06 at 9 41 15 PM" src="https://user-images.githubusercontent.com/367605/177596412-f3071841-e932-4b83-9805-8f4a5015ff84.png">
<img width="1900" alt="Screenshot 2022-07-06 at 9 41 20 PM" src="https://user-images.githubusercontent.com/367605/177596414-65e898c9-c451-4529-82fc-9ccf46ca4498.png">

<img width="1904" alt="Screenshot 2022-07-06 at 9 41 06 PM" src="https://user-images.githubusercontent.com/367605/177596399-4f0cc14d-c743-40ff-888b-9ceb08f0bca0.png">



## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
