### PR TITLE
fix: disable restricting to teams when no teams added

### DIFF
--- a/src/containers/AdminCampaignEdit/sections/CampaignTeamsForm.jsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignTeamsForm.jsx
@@ -91,6 +91,9 @@ class CampaignTeamsForm extends React.Component {
 
           <Tooltip
             title="Select a team in order to restrict assignments solely to members of those teams"
+            disableFocusListener={teamsAdded}
+            disableHoverListener={teamsAdded}
+            disableTouchListener={teamsAdded}
             placement="top-start"
           >
             <span>


### PR DESCRIPTION
## Description

Restrict assignment when no teams are selected causes a soft lock on contacts if assignment is limited to teams.

## Motivation and Context

Fixes #1086 

## How Has This Been Tested?

Tested locally. Adding teams enable the toggle, removing all teams disables the toggles, and turns it off. 

## Screenshots (if appropriate):

<img width="1681" alt="Screenshot 2022-07-06 at 10 07 00 PM" src="https://user-images.githubusercontent.com/367605/177600394-6f0cb95b-8700-4e57-a607-e36d35b6919e.png">
<img width="1669" alt="Screenshot 2022-07-06 at 10 07 08 PM" src="https://user-images.githubusercontent.com/367605/177600410-29cf2f63-6eab-4019-ba1c-503e06d80441.png">

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
