### PR TITLE
fix: handle response errors correctly

### DIFF
--- a/src/components/AssignmentTexter.jsx
+++ b/src/components/AssignmentTexter.jsx
@@ -14,7 +14,7 @@ import { compose } from "recompose";
 
 import AssignmentTexterContact from "../containers/AssignmentTexterContact";
 import { loadData } from "../containers/hoc/with-operations";
-import { catchError } from "../network/utils";
+import { aggregateGraphQLErrors } from "../network/utils";
 import Empty from "./Empty";
 import LoadingIndicator from "./LoadingIndicator";
 
@@ -294,7 +294,7 @@ class AssignmentTexter extends React.Component {
 
     this.props.mutations
       .handleConversation(contact_id, handleConversationPayload)
-      .then(catchError)
+      .then(aggregateGraphQLErrors)
       .then((response) => {
         if (payload.message) {
           const { id, messages } = response.data.handleConversation;
@@ -312,7 +312,9 @@ class AssignmentTexter extends React.Component {
   };
 
   addTagToContact = (contact_id, tag) => {
-    this.props.mutations.tagContact(contact_id, tag).then(catchError);
+    this.props.mutations
+      .tagContact(contact_id, tag)
+      .then(aggregateGraphQLErrors);
   };
 
   goBackToTodos = () => {

--- a/src/network/utils.ts
+++ b/src/network/utils.ts
@@ -1,6 +1,7 @@
 /* eslint-disable import/prefer-default-export */
+import { FetchResult } from "@apollo/client";
 
-export const catchError = (response: any) => {
+export const aggregateGraphQLErrors = <T>(response: FetchResult<T>) => {
   const { errors } = response;
   if (errors) {
     const errorMessages = errors.map((error) => error.message).join(", ");

--- a/src/network/utils.ts
+++ b/src/network/utils.ts
@@ -1,8 +1,10 @@
 /* eslint-disable import/prefer-default-export */
 
 export const catchError = (response: any) => {
-  if (response.errors) {
-    throw new Error(response.errors);
+  const { errors } = response;
+  if (errors) {
+    const errorMessages = errors.map((error) => error.message).join(", ");
+    throw new Error(errorMessages);
   }
   return response;
 };


### PR DESCRIPTION
## Description

errors is sent out as an array, trying to throw an error of an array converts it to an `[Object object]`, instead use the message from the error objects to throw an error.

## Motivation and Context

Fixes #1155 

## How Has This Been Tested?

Test locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
