### PR TITLE
fix(queue_sync_campaign_to_van): use run at

### DIFF
--- a/migrations/20220714022406_use-run-at-in-queue_sync_campaign_to_van.js
+++ b/migrations/20220714022406_use-run-at-in-queue_sync_campaign_to_van.js
@@ -1,0 +1,185 @@
+exports.up = (knex) => {
+  return knex.schema.raw(`
+    CREATE OR REPLACE FUNCTION public.queue_sync_campaign_to_van(campaign_id integer) RETURNS void
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public'
+    AS $$
+    declare
+      v_system_id uuid;
+      v_username text;
+      v_api_key_ref text;
+      v_missing_configs integer;
+      v_job_request_id integer;
+      v_contact_count integer;
+    begin
+      select external_system_id
+      from campaign where id = queue_sync_campaign_to_van.campaign_id
+      into v_system_id;
+
+      if v_system_id is null then
+        raise 'No external system configured for campaign with id %', queue_sync_campaign_to_van.campaign_id;
+      end if;
+
+      select username, api_key_ref
+      from external_system
+      where id = v_system_id
+      into v_username, v_api_key_ref;
+
+      if v_api_key_ref is null then
+        raise 'No API key configured for with id %', v_system_id;
+      end if;
+
+      select count(*)
+      from external_sync_question_response_configuration qrc
+      where
+        qrc.campaign_id = queue_sync_campaign_to_van.campaign_id
+        and qrc.system_id = v_system_id
+        and is_missing = true
+        and is_required = true
+      into v_missing_configs;
+
+      if v_missing_configs > 0 then
+        raise 'Campaign % is missing % required configs', queue_sync_campaign_to_van.campaign_id, v_missing_configs;
+      end if;
+
+      select count(*)
+      from campaign_contact
+      where campaign_contact.campaign_id = queue_sync_campaign_to_van.campaign_id
+      into v_contact_count;
+
+      insert into public.job_request (campaign_id, payload, result_message, queue_name, job_type, status)
+      values (
+        campaign_id,
+        json_build_object('contact_count', v_contact_count)::text,
+        json_build_object('message', 'Synced 0 of ' || v_contact_count || ' contacts to VAN')::text,
+        campaign_id::text || ':sync_campaign',
+        'sync_van_campaign',
+        0
+      )
+      returning id
+      into v_job_request_id;
+
+      perform
+        graphile_worker.add_job(
+          'van-sync-campaign-contact',
+          payload,
+          run_at => now() + (interval '1 second' / 30) * n,
+          priority => 10
+        )
+      from (
+        select 
+          json_build_object(
+            'username', v_username,
+            'api_key', json_build_object('__secret', v_api_key_ref),
+            'system_id', v_system_id,
+            'cc_created_at', cc.created_at,
+            'campaign_id', cc.campaign_id,
+            'contact_id', cc.id,
+            'external_id', cc.external_id,
+            'phone_id', ((cc.custom_fields)::json->>'phone_id')::integer,
+            'phone_number', cc.cell,
+            '__context', json_build_object(
+              'job_request_id', v_job_request_id,
+              'contact_count', v_contact_count
+            )
+          ) as payload,
+          row_number() over (partition by 1) as n
+        from public.campaign_contact cc
+        where
+          cc.campaign_id = queue_sync_campaign_to_van.campaign_id
+      ) payloads;
+    end;
+    $$;
+  `);
+};
+
+exports.down = (knex) => {
+  return knex.schema.raw(`
+    CREATE OR REPLACE FUNCTION public.queue_sync_campaign_to_van(campaign_id integer) RETURNS void
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public'
+    AS $$
+    declare
+      v_system_id uuid;
+      v_username text;
+      v_api_key_ref text;
+      v_missing_configs integer;
+      v_job_request_id integer;
+      v_contact_count integer;
+    begin
+      select external_system_id
+      from campaign where id = queue_sync_campaign_to_van.campaign_id
+      into v_system_id;
+
+      if v_system_id is null then
+        raise 'No external system configured for campaign with id %', queue_sync_campaign_to_van.campaign_id;
+      end if;
+
+      select username, api_key_ref
+      from external_system
+      where id = v_system_id
+      into v_username, v_api_key_ref;
+
+      if v_api_key_ref is null then
+        raise 'No API key configured for with id %', v_system_id;
+      end if;
+
+      select count(*)
+      from external_sync_question_response_configuration qrc
+      where
+        qrc.campaign_id = queue_sync_campaign_to_van.campaign_id
+        and qrc.system_id = v_system_id
+        and is_missing = true
+        and is_required = true
+      into v_missing_configs;
+
+      if v_missing_configs > 0 then
+        raise 'Campaign % is missing % required configs', queue_sync_campaign_to_van.campaign_id, v_missing_configs;
+      end if;
+
+      select count(*)
+      from campaign_contact
+      where campaign_contact.campaign_id = queue_sync_campaign_to_van.campaign_id
+      into v_contact_count;
+
+      insert into public.job_request (campaign_id, payload, result_message, queue_name, job_type, status)
+      values (
+        campaign_id,
+        json_build_object('contact_count', v_contact_count)::text,
+        json_build_object('message', 'Synced 0 of ' || v_contact_count || ' contacts to VAN')::text,
+        campaign_id::text || ':sync_campaign',
+        'sync_van_campaign',
+        0
+      )
+      returning id
+      into v_job_request_id;
+
+      perform
+        graphile_worker.add_job(
+          'van-sync-campaign-contact',
+          json_build_object(
+            'username', v_username,
+            'api_key', json_build_object('__secret', v_api_key_ref),
+            'system_id', v_system_id,
+            'cc_created_at', cc.created_at,
+            'campaign_id', cc.campaign_id,
+            'contact_id', cc.id,
+            'external_id', cc.external_id,
+            'phone_id', ((cc.custom_fields)::json->>'phone_id')::integer,
+            'phone_number', cc.cell,
+            '__context', json_build_object(
+              'job_request_id', v_job_request_id,
+              'contact_count', v_contact_count
+            )
+          ),
+          'van-api',
+          priority => 10
+        )
+      from public.campaign_contact cc
+      where
+        cc.campaign_id = queue_sync_campaign_to_van.campaign_id
+      ;
+    end;
+    $$;
+  `);
+};

--- a/migrations/20220714022406_use-run-at-in-queue_sync_campaign_to_van.js
+++ b/migrations/20220714022406_use-run-at-in-queue_sync_campaign_to_van.js
@@ -63,6 +63,8 @@ exports.up = (knex) => {
         graphile_worker.add_job(
           'van-sync-campaign-contact',
           payload,
+          -- VAN API docs suggest 60 req/s for post canvass results; we'll use 30 req/s to be safe
+          -- Ref: https://docs.ngpvan.com/docs/throttling-guidelines#suggested-throttling
           run_at => now() + (interval '1 second' / 30) * n,
           priority => 10
         )

--- a/schema-dump.sql
+++ b/schema-dump.sql
@@ -1074,6 +1074,12 @@ CREATE FUNCTION public.queue_sync_campaign_to_van(campaign_id integer) RETURNS v
       perform
         graphile_worker.add_job(
           'van-sync-campaign-contact',
+          payload,
+          run_at => now() + (interval '1 second' / 30) * n,
+          priority => 10
+        )
+      from (
+        select 
           json_build_object(
             'username', v_username,
             'api_key', json_build_object('__secret', v_api_key_ref),
@@ -1088,14 +1094,12 @@ CREATE FUNCTION public.queue_sync_campaign_to_van(campaign_id integer) RETURNS v
               'job_request_id', v_job_request_id,
               'contact_count', v_contact_count
             )
-          ),
-          'van-api',
-          priority => 10
-        )
-      from public.campaign_contact cc
-      where
-        cc.campaign_id = queue_sync_campaign_to_van.campaign_id
-      ;
+          ) as payload,
+          row_number() over (partition by 1) as n
+        from public.campaign_contact cc
+        where
+          cc.campaign_id = queue_sync_campaign_to_van.campaign_id
+      ) payloads;
     end;
     $$;
 

--- a/schema-dump.sql
+++ b/schema-dump.sql
@@ -1075,6 +1075,8 @@ CREATE FUNCTION public.queue_sync_campaign_to_van(campaign_id integer) RETURNS v
         graphile_worker.add_job(
           'van-sync-campaign-contact',
           payload,
+          -- VAN API docs suggest 60 req/s for post canvass results; we'll use 30 req/s to be safe
+          -- Ref: https://docs.ngpvan.com/docs/throttling-guidelines#suggested-throttling
           run_at => now() + (interval '1 second' / 30) * n,
           priority => 10
         )


### PR DESCRIPTION
## Description

This PR changes `queue_sync_campaign_to_van` to use `graphile-worker`'s `run_at` instead of named queues to prevent us from overloading VAN's API.

## Motivation and Context

We have frequently run into this issue (https://github.com/graphile/worker/issues/240) when `queue_sync_campaign_to_van` is run.

## How Has This Been Tested?

This hasn't been tested yet!


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
