### PR TITLE
fix(clipboard): fix safari paste popup

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "react-file-drop": "^3.1.4",
     "react-formal": "^2.2.2",
     "react-helmet": "^6.1.0",
+    "react-hook-clipboard": "^1.0.3",
     "react-hook-form": "^7.31.1",
     "react-markdown": "^8.0.3",
     "react-portal": "^4.2.1",

--- a/src/client/lib/index.ts
+++ b/src/client/lib/index.ts
@@ -1,16 +1,3 @@
+/* eslint-disable import/prefer-default-export */
 export const supportsClipboard = () =>
   navigator?.clipboard?.readText !== undefined;
-
-export const readClipboardText = async () => {
-  if (navigator?.clipboard?.readText) {
-    return navigator.clipboard.readText().catch(() => "");
-  }
-  return Promise.resolve("");
-};
-
-export const writeClipboardText = async (text: string) => {
-  if (navigator?.clipboard?.writeText) {
-    return navigator.clipboard.writeText(text).catch(() => {});
-  }
-  return Promise.resolve();
-};

--- a/src/containers/AdminTrollAlarms/index.tsx
+++ b/src/containers/AdminTrollAlarms/index.tsx
@@ -10,6 +10,7 @@ import Paper from "material-ui/Paper";
 import Snackbar from "material-ui/Snackbar";
 import Toggle from "material-ui/Toggle";
 import React, { useState } from "react";
+import useClipboard from "react-hook-clipboard";
 import { RouteChildrenProps } from "react-router-dom";
 import {
   BooleanParam,
@@ -64,6 +65,8 @@ const AdminTrollAlarms: React.FC<Props> = (props) => {
   const [page, setPage] = useQueryParam("page", NumberParam);
   const [dismissed, setDismissed] = useQueryParam("dismissed", BooleanParam);
   const [token, setToken] = useQueryParam("token", StringParam);
+
+  const [_clipboard, copyToClipboard] = useClipboard();
 
   const handleOnCancelError = () => setError(undefined);
 
@@ -145,7 +148,7 @@ const AdminTrollAlarms: React.FC<Props> = (props) => {
     ].join("\n");
 
     try {
-      navigator.clipboard.writeText(clipboardContents);
+      copyToClipboard(clipboardContents);
       setCopiedAlarmID(alarm.id);
     } catch (err) {
       setError(err.message);

--- a/yarn.lock
+++ b/yarn.lock
@@ -21252,6 +21252,11 @@ react-helmet@^6.1.0:
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
 
+react-hook-clipboard@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/react-hook-clipboard/-/react-hook-clipboard-1.0.3.tgz#f0aeaa8b5cde67be9269e5a12ed67cc6095a8e08"
+  integrity sha512-LuvMPkvX9FWhudrkjQ/AJGtnRkGdjbF6F2OySukMb29KLCXKhocxEzCRu0vQu8rC8pn2bwFyfR67rHnbcYbexg==
+
 react-hook-form@^7.31.1:
   version "7.31.1"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.31.1.tgz#16c357dd366bc226172e6acbb5a1672873bbfb28"


### PR DESCRIPTION
## Description

Use `react-hook-clipboard` to read and write clipboard contents

## Motivation and Context

Fixes #1153

## How Has This Been Tested?
Tested on Safari on macOS 12.4

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
