### PR TITLE
fix: fix saving empty team priority

### DIFF
--- a/src/api/team.ts
+++ b/src/api/team.ts
@@ -11,7 +11,7 @@ export interface Team {
   backgroundColor: string;
   author: User;
   isAssignmentEnabled: boolean;
-  assignmentPriority: number;
+  assignmentPriority: number | null;
   assignmentType: TextRequestType;
   maxRequestCount: number;
   createdAt: string;
@@ -43,7 +43,7 @@ export const schema = `
     backgroundColor: String!
     author: User
     isAssignmentEnabled: Boolean!
-    assignmentPriority: Int!
+    assignmentPriority: Int
     assignmentType: TextRequestType
     maxRequestCount: Int
     createdAt: Date!

--- a/src/containers/AdminTeamEditor/index.jsx
+++ b/src/containers/AdminTeamEditor/index.jsx
@@ -64,7 +64,9 @@ class AdminTeamEditor extends Component {
       "assignmentPriority"
     ]);
     if ("assignmentPriority" in team) {
-      team.assignmentPriority = parseInt(team.assignmentPriority, 10);
+      const rawPriority = team.assignmentPriority;
+      team.assignmentPriority =
+        rawPriority === "" ? 500 : parseInt(team.assignmentPriority, 10);
     }
 
     this.setState({ isWorking: true });

--- a/src/containers/AdminTeamEditor/index.jsx
+++ b/src/containers/AdminTeamEditor/index.jsx
@@ -66,7 +66,7 @@ class AdminTeamEditor extends Component {
     if ("assignmentPriority" in team) {
       const rawPriority = team.assignmentPriority;
       team.assignmentPriority =
-        rawPriority === "" ? 500 : parseInt(team.assignmentPriority, 10);
+        rawPriority === "" ? 500 : parseInt(rawPriority, 10);
     }
 
     this.setState({ isWorking: true });

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -1065,7 +1065,7 @@ type Team {
   backgroundColor: String!
   author: User
   isAssignmentEnabled: Boolean!
-  assignmentPriority: Int!
+  assignmentPriority: Int
   assignmentType: TextRequestType
   maxRequestCount: Int
   createdAt: Date!


### PR DESCRIPTION
## Description
This prevents saving a team with a null priority value, and also adjusts the GraphQL schema to allow retrieving teams which have null priority values.

## Motivation and Context
Due to the visual bug on the create team form that presents an empty string value as 500 to the user, the user can create a team with a null priority. If a team with a null priority exists, loading the teams page isn't possible, because the GraphQL schema expects non null assignment priority values.

We generally want teams to have assignment priorities, but there are a number of database functions that already expect this column to be nullable. Assigning default priorities for team creation, and allowing the loading of teams if the priority value is null feels like a good solution here for these reasons.

## How Has This Been Tested?
This has been tested locally.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
