### PR TITLE
revert(clipboard): revert fix safari paste popup

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,6 @@
     "react-file-drop": "^3.1.4",
     "react-formal": "^2.2.2",
     "react-helmet": "^6.1.0",
-    "react-hook-clipboard": "^1.0.3",
     "react-hook-form": "^7.31.1",
     "react-markdown": "^8.0.3",
     "react-portal": "^4.2.1",

--- a/src/client/lib/index.ts
+++ b/src/client/lib/index.ts
@@ -1,3 +1,16 @@
-/* eslint-disable import/prefer-default-export */
 export const supportsClipboard = () =>
   navigator?.clipboard?.readText !== undefined;
+
+export const readClipboardText = async () => {
+  if (navigator?.clipboard?.readText) {
+    return navigator.clipboard.readText().catch(() => "");
+  }
+  return Promise.resolve("");
+};
+
+export const writeClipboardText = async (text: string) => {
+  if (navigator?.clipboard?.writeText) {
+    return navigator.clipboard.writeText(text).catch(() => {});
+  }
+  return Promise.resolve();
+};

--- a/src/containers/AdminTrollAlarms/index.tsx
+++ b/src/containers/AdminTrollAlarms/index.tsx
@@ -10,7 +10,6 @@ import Paper from "material-ui/Paper";
 import Snackbar from "material-ui/Snackbar";
 import Toggle from "material-ui/Toggle";
 import React, { useState } from "react";
-import useClipboard from "react-hook-clipboard";
 import { RouteChildrenProps } from "react-router-dom";
 import {
   BooleanParam,
@@ -65,8 +64,6 @@ const AdminTrollAlarms: React.FC<Props> = (props) => {
   const [page, setPage] = useQueryParam("page", NumberParam);
   const [dismissed, setDismissed] = useQueryParam("dismissed", BooleanParam);
   const [token, setToken] = useQueryParam("token", StringParam);
-
-  const [_clipboard, copyToClipboard] = useClipboard();
 
   const handleOnCancelError = () => setError(undefined);
 
@@ -148,7 +145,7 @@ const AdminTrollAlarms: React.FC<Props> = (props) => {
     ].join("\n");
 
     try {
-      copyToClipboard(clipboardContents);
+      navigator.clipboard.writeText(clipboardContents);
       setCopiedAlarmID(alarm.id);
     } catch (err) {
       setError(err.message);

--- a/yarn.lock
+++ b/yarn.lock
@@ -21252,11 +21252,6 @@ react-helmet@^6.1.0:
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
 
-react-hook-clipboard@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/react-hook-clipboard/-/react-hook-clipboard-1.0.3.tgz#f0aeaa8b5cde67be9269e5a12ed67cc6095a8e08"
-  integrity sha512-LuvMPkvX9FWhudrkjQ/AJGtnRkGdjbF6F2OySukMb29KLCXKhocxEzCRu0vQu8rC8pn2bwFyfR67rHnbcYbexg==
-
 react-hook-form@^7.31.1:
   version "7.31.1"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.31.1.tgz#16c357dd366bc226172e6acbb5a1672873bbfb28"


### PR DESCRIPTION
## Description

This reverts commit a9b753cfbb7059074191f07f9826a44e46c463b7.

## Motivation and Context

#1326 fixed the Safari UX bug but changed behavior for accessing the clipboard. Previously, a user would need to click anywhere on the page for the browser to grant access to read the clipboard. After #1326 users have to click specifically on the interaction step card header.

We've decided we should revert the Safari fix in favor of a better user experience for the majority of our users on Chrome.

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

N/A

## Documentation Changes


N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
