### PR TITLE
fix(perf): fetch campaign

### DIFF
--- a/src/server/api/lib/campaign.ts
+++ b/src/server/api/lib/campaign.ts
@@ -731,8 +731,7 @@ WHERE campaign_id = ?`,
 
   const campaignContact = await r
     .knex("campaign_contact")
-    .where({ message_status: "needsMessage", campaign_id: campaignId })
-    .orderBy("updated_at")
+    .where({ campaign_id: campaignId })
     .first();
 
   const customFields = campaignContact

--- a/src/server/api/lib/campaign.ts
+++ b/src/server/api/lib/campaign.ts
@@ -732,7 +732,7 @@ WHERE campaign_id = ?`,
   const campaignContact = await r
     .knex("campaign_contact")
     .where({ campaign_id: campaignId })
-    .first();
+    .first(["custom_fields"]);
 
   const customFields = campaignContact
     ? Object.keys(JSON.parse(campaignContact.custom_fields))


### PR DESCRIPTION
## Description

This fixes a query performance issue fetching campaign fields for a campaign.

## Motivation and Context

Only the names of custom fields are used by `invalidScriptFields()`. Every campaign contact will have the same custom field names so it does not matter which campaign contact we select from for a given campaign. The where clause and `order by` were performance issues on large instances.

Partly addresses #1331.

## How Has This Been Tested?

This has been tested locally and as hot fix in select production instances.

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
