### PR TITLE
build: fix dockerignore rules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,8 @@
 !/package.json
 !/yarn.lock
 !/webpack.config.ts
-!/webpack/build-config.js
+!/webpack/build-config.ts
+!/tsconfig.json
 !/babel.config.js
 !/knexfile.env.js
 !/dev-tools/babel-run


### PR DESCRIPTION
## Description

Ensure all files necessary to build Spoke are included in the Docker context with their current file extensions.

## Motivation and Context

`build-config` was converted to TS in 608b90309244063488c76beedcfaa2cdc4aa862b.
`tsconfig.json` was somehow never part of the Docker context.

Builds were still succeeding in CI but recently began failing when running locally.

## How Has This Been Tested?

This has been tested locally and in CI (see workflow executions and parent commit of 4be6aa0aba0787ff35a12203a9081df9c78b0532).

## Screenshots (if appropriate):

N/A

## Documentation Changes

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
