### PR TITLE
fix(interactions): dont show duplicate warnings

### DIFF
--- a/src/server/api/lib/campaign.ts
+++ b/src/server/api/lib/campaign.ts
@@ -720,7 +720,7 @@ export const editCampaign = async (
 export const invalidScriptFields = async (campaignId: string) => {
   const { rows: variables } = await r.knex.raw(
     // eslint-disable-next-line no-useless-escape
-    `SELECT regexp_matches(array_to_string(script_options, ','), '\{([^\{]*)\}', 'g') as variable
+    `SELECT DISTINCT regexp_matches(array_to_string(script_options, ','), '\{([^\{]*)\}', 'g') as variable
 FROM interaction_step
 WHERE campaign_id = ?`,
     [campaignId]


### PR DESCRIPTION
## Description

Don't show duplicate warnings for missing custom fields or campaign variables.

## Motivation and Context

Fixes #1331 

## How Has This Been Tested?

Tested locally

## Screenshots (if appropriate):

<img width="2268" alt="Screenshot 2022-08-09 at 1 51 03 PM" src="https://user-images.githubusercontent.com/367605/183601301-2b260314-84b6-489a-8b07-0651397c1fc3.png">


## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
