### PR TITLE
fix(message-review): display accurate error description

### DIFF
--- a/libs/spoke-codegen/src/graphql/message-review.graphql
+++ b/libs/spoke-codegen/src/graphql/message-review.graphql
@@ -5,6 +5,7 @@ fragment ConversationMessage on Message {
   createdAt
   userId
   sendStatus
+  errorCodes
 }
 
 fragment ConversationInfo on Conversation {

--- a/src/api/message.ts
+++ b/src/api/message.ts
@@ -11,6 +11,7 @@ export interface Message {
   campaignId: string;
   userId: string;
   sendStatus: string;
+  errorCodes: string[];
 }
 
 export const schema = `
@@ -25,5 +26,6 @@ export const schema = `
     campaignId: String
     userId: ID
     sendStatus: String
+    errorCodes: [String!]
   }
 `;

--- a/src/containers/AdminCampaignStats/DeliverabilityStats.tsx
+++ b/src/containers/AdminCampaignStats/DeliverabilityStats.tsx
@@ -5,48 +5,11 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import { Campaign } from "../../api/campaign";
+import errorCodeDescriptions from "../../lib/telco-error-codes";
 import { asPercent, asPercentWithTotal } from "../../lib/utils";
 import theme from "../../styles/theme";
 import { loadData } from "../hoc/with-operations";
 import CampaignStat from "./CampaignStat";
-
-const descriptions: Record<string, string> = {
-  "40001": "Invalid destination number",
-  "40002": "Blocked as spam",
-  "40003": "Blocked as spam",
-  "40004": "Unknown",
-  "40005": "Expired",
-  "40006": "Carrier outage",
-  "40007": "Unknown",
-  "40008": "Unknown",
-  "40009": "Invalid body",
-  "40011": "Too many messages",
-  "40012": "Invalid destination number",
-  "21610": "Recipient unsubscribed",
-  "30001": "Queue overflow",
-  "30002": "Account suspended",
-  "30003": "Unreachable phone number",
-  "30004": "Message blocked",
-  "30005": "Unknown destination handset",
-  "30006": "Landline or unreachable carrier",
-  "30007": "Blocked as spam",
-  "30008": "Unknown error",
-  "4405": "Unreachable sending phone number", // this one shouldn't happen
-  "4406": "Unreachable phone number",
-  "4432": "Unreachable country",
-  "4434": "Unreachable toll-free number",
-  "4700": "Landline or unreachable carrier",
-  "4720": "Unreachable phone number",
-  "4730": "Unreachable phone number (recipient maybe roaming)",
-  "4740": "Unreachable sending phone number", // this one shouldn't happen, but has happened
-  "4750": "Carrier rejected (maybe spam)",
-  "4770": "Blocked as spam",
-  "4780": "Carrier rejected (sending rates exceeded)",
-  "5106": "Unroutable (can be retried)",
-  "5620": "Carrier outage",
-  "9902": "Delivery receipt expired",
-  "9999": "Unknown error"
-};
 
 const styles = StyleSheet.create({
   secondaryHeader: {
@@ -111,8 +74,8 @@ const DeliverabilityStats = (props: {
           return (
             <div key={errorCode}>
               {errorCode}{" "}
-              {descriptions[errorCode]
-                ? `(${descriptions[errorCode]})`
+              {errorCodeDescriptions[errorCode]
+                ? `(${errorCodeDescriptions[errorCode]})`
                 : "Unknown error"}
               : {asPercentWithTotal(e.count, total)}
             </div>

--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageList/MessageColumn/MessageList.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageList/MessageColumn/MessageList.tsx
@@ -1,8 +1,10 @@
 import { gql } from "@apollo/client";
+import { Message, User } from "@spoke/spoke-codegen";
 import { css, StyleSheet } from "aphrodite";
 import React, { Component } from "react";
+import errorCodeDescriptions from "src/lib/telco-error-codes";
+import { MessageSendStatus } from "src/server/api/types";
 
-import { Message } from "../../../../../api/message";
 import { DateTime } from "../../../../../lib/datetime";
 import { QueryMap } from "../../../../../network/types";
 import { loadData } from "../../../../hoc/with-operations";
@@ -21,6 +23,25 @@ interface Props {
   userNames: any;
   messages: Message[];
 }
+
+const footerText = (message: Message, sender: User) => {
+  const senderName = sender ? sender.displayName : "Unknown";
+
+  const sentAgoRelative = DateTime.fromISO(message.createdAt).toRelative();
+
+  if (message.isFromContact) {
+    return `Received ${sentAgoRelative}`;
+  }
+
+  if (message.sendStatus === MessageSendStatus.Error) {
+    const errorCode = (message.errorCodes ?? [])[0];
+
+    const errorDesc = errorCodeDescriptions[errorCode] ?? "Unknown error";
+    return `Sent by ${senderName} ${sentAgoRelative}. Error: ${errorDesc}.`;
+  }
+
+  return `Sent by ${senderName} ${sentAgoRelative}`;
+};
 
 class MessageList extends Component<Props> {
   messageWindow: HTMLDivElement | null = null;
@@ -88,26 +109,13 @@ class MessageList extends Component<Props> {
           const sender = this.props.userNames.peopleByUserIds.users.filter(
             (user: any) => user.id === message.userId
           )[0];
-          const senderName = sender ? sender.displayName : "Unknown";
 
           return (
             <div key={message.id} style={containerStyle}>
               <p className={css(styles.conversationRow)} style={messageStyle}>
                 {message.text}
               </p>
-              <p style={senderInfoStyle}>
-                {message.isFromContact
-                  ? `Received at ${DateTime.fromISO(
-                      message.createdAt
-                    ).toRelative()}`
-                  : message.sendStatus === "ERROR"
-                  ? `Carrier rejected this message sent by ${senderName} at ${DateTime.fromISO(
-                      message.createdAt
-                    ).toRelative()}`
-                  : `Sent by ${senderName} ${DateTime.fromISO(
-                      message.createdAt
-                    ).toRelative()}`}
-              </p>
+              <p style={senderInfoStyle}>{footerText(message, sender)}</p>
             </div>
           );
         })}

--- a/src/lib/telco-error-codes.tsx
+++ b/src/lib/telco-error-codes.tsx
@@ -1,0 +1,39 @@
+export const errorCodeDescriptions: Record<string, string> = {
+  "40001": "Invalid destination number",
+  "40002": "Blocked as spam",
+  "40003": "Blocked as spam",
+  "40004": "Unknown",
+  "40005": "Expired",
+  "40006": "Carrier outage",
+  "40007": "Unknown",
+  "40008": "Unknown",
+  "40009": "Invalid body",
+  "40011": "Too many messages",
+  "40012": "Invalid destination number",
+  "21610": "Recipient unsubscribed",
+  "30001": "Queue overflow",
+  "30002": "Account suspended",
+  "30003": "Unreachable phone number",
+  "30004": "Message blocked",
+  "30005": "Unknown destination handset",
+  "30006": "Landline or unreachable carrier",
+  "30007": "Blocked as spam",
+  "30008": "Unknown error",
+  "4405": "Unreachable sending phone number", // this one shouldn't happen
+  "4406": "Unreachable phone number",
+  "4432": "Unreachable country",
+  "4434": "Unreachable toll-free number",
+  "4700": "Landline or unreachable carrier",
+  "4720": "Unreachable phone number",
+  "4730": "Unreachable phone number (recipient maybe roaming)",
+  "4740": "Unreachable sending phone number", // this one shouldn't happen, but has happened
+  "4750": "Carrier rejected (maybe spam)",
+  "4770": "Blocked as spam",
+  "4780": "Carrier rejected (sending rates exceeded)",
+  "5106": "Unroutable (can be retried)",
+  "5620": "Carrier outage",
+  "9902": "Delivery receipt expired",
+  "9999": "Unknown error"
+};
+
+export default errorCodeDescriptions;

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -775,6 +775,7 @@ type Message {
   campaignId: String
   userId: ID
   sendStatus: String
+  errorCodes: [String!]
 }
 
 

--- a/src/server/api/conversations.js
+++ b/src/server/api/conversations.js
@@ -242,7 +242,8 @@ export async function getConversations(
     "message.is_from_contact",
     "message.created_at",
     "message.send_status",
-    "message.user_id"
+    "message.user_id",
+    "message.error_codes"
   );
 
   query = (
@@ -286,7 +287,8 @@ export async function getConversations(
     "created_at",
     "is_from_contact",
     "user_id",
-    "send_status"
+    "send_status",
+    "error_codes"
   ];
 
   const groupedContacts = _.groupBy(conversationRows, "cc_id");

--- a/src/server/api/message.ts
+++ b/src/server/api/message.ts
@@ -11,7 +11,8 @@ export const resolvers = {
       "contactNumber",
       "isFromContact",
       "sendStatus",
-      "createdAt"
+      "createdAt",
+      "errorCodes"
     ])
   }
 };


### PR DESCRIPTION
## Description

When possible, display the correct human-friendly error message for a message.

## Motivation and Context

We currently report all errored messages "rejected by carrier." This was a reasonable assumption when Spoke did not track error codes and had no knowledge about why a message errored. We now track that and already have a mapping of error codes to human-friendly descriptions.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<img width="782" alt="Screen Shot 2022-08-12 at 3 07 30 PM" src="https://user-images.githubusercontent.com/2145526/184427431-f3a5f878-cc3b-496f-bce6-c51a40617650.png">


## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
