### PR TITLE
fix(export): fix campaign campaign error

### DIFF
--- a/src/server/tasks/export-campaign.ts
+++ b/src/server/tasks/export-campaign.ts
@@ -153,7 +153,6 @@ const processFilteredContactsChunk = async (
       "contact[zip]": contact.zip,
       "contact[city]": contact.city || null,
       "contact[state]": contact.state || null,
-      "contact[optOut]": contact.is_opted_out,
       "contact[messageStatus]": "removed",
       "contact[external_id]": contact.external_id
     };

--- a/src/server/tasks/export-campaign.ts
+++ b/src/server/tasks/export-campaign.ts
@@ -481,13 +481,15 @@ interface UploadCampaignMessages {
   contactsCount: number;
   helpers: ProgressTaskHelpers;
   campaignId: number;
+  campaignVariableNames: string[];
 }
 
 const processAndUploadCampaignMessages = async ({
   fileNameKey,
   contactsCount,
   helpers,
-  campaignId
+  campaignId,
+  campaignVariableNames
 }: UploadCampaignMessages): Promise<string> => {
   const messagesKey = `${fileNameKey}-messages`;
   const messagesUploadStream = await getUploadStream(`${messagesKey}.csv`);
@@ -649,7 +651,8 @@ export const exportCampaign: ProgressTask<ExportCampaignPayload> = async (
   const {
     campaignTitle,
     notificationEmail,
-    interactionSteps
+    interactionSteps,
+    campaignVariableNames
   } = await fetchExportData(campaignId, requesterId);
 
   const countQueryResult = await r
@@ -702,7 +705,8 @@ export const exportCampaign: ProgressTask<ExportCampaignPayload> = async (
         fileNameKey,
         campaignId,
         contactsCount,
-        helpers
+        helpers,
+        campaignVariableNames
       })
     : null;
 

--- a/src/server/tasks/export-campaign.ts
+++ b/src/server/tasks/export-campaign.ts
@@ -405,8 +405,8 @@ const processAndUploadCampaignContacts = async ({
   const uniqueQuestionsByStepId = getUniqueQuestionsByStepId(interactionSteps);
 
   const campaignContactsKey = onlyOptOuts
-    ? fileNameKey
-    : `${fileNameKey}-optouts`;
+    ? `${fileNameKey}-optouts`
+    : fileNameKey;
 
   const campaignContactsUploadStream = await getUploadStream(
     `${campaignContactsKey}.csv`


### PR DESCRIPTION
## Description

This PR does three things:
1. Fixes missing `campaignVariableNames` error
2. Fixes export filename swap
3. Removes nonexistent optOut column from filtered contacts export

## Motivation and Context

The `campaignVariableNames` error prevented exporting campaigns.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
