### PR TITLE
fix(campaign builder): fix deleting interaction steps

### DIFF
--- a/__test__/testbed-preparation/core.ts
+++ b/__test__/testbed-preparation/core.ts
@@ -1,28 +1,31 @@
 import faker from "faker";
 import AuthHasher from "passport-local-authenticate";
-import { PoolClient } from "pg";
+import type { PoolClient } from "pg";
 
-import { Assignment } from "../../src/api/assignment";
-import { Campaign } from "../../src/api/campaign";
-import { CampaignContact } from "../../src/api/campaign-contact";
-import { InteractionStep } from "../../src/api/interaction-step";
-import { Message } from "../../src/api/message";
-import { Organization } from "../../src/api/organization";
+import type { Assignment } from "../../src/api/assignment";
+import type { Campaign } from "../../src/api/campaign";
+import type { CampaignContact } from "../../src/api/campaign-contact";
+import type { InteractionStep } from "../../src/api/interaction-step";
+import type { Message } from "../../src/api/message";
+import type { Organization } from "../../src/api/organization";
 import { UserRoleType } from "../../src/api/organization-membership";
-import { User } from "../../src/api/user";
+import type { User } from "../../src/api/user";
 import { DateTime } from "../../src/lib/datetime";
-import {
+import type {
   AssignmentRecord,
   CampaignContactRecord,
   CampaignRecord,
   InteractionStepRecord,
   MessageRecord,
-  MessageSendStatus,
-  MessageStatusType,
   OrganizationRecord,
+  QuestionResponseRecord,
   UserRecord
 } from "../../src/server/api/types";
-import { HashedPassword } from "../../src/server/local-auth-helpers";
+import {
+  MessageSendStatus,
+  MessageStatusType
+} from "../../src/server/api/types";
+import type { HashedPassword } from "../../src/server/local-auth-helpers";
 
 export type CreateOrganizationOptions = Partial<
   Pick<Organization, "name"> & { uuid: string; features: Record<string, any> }
@@ -495,3 +498,24 @@ export const createInteractionStep = async (
       ]
     )
     .then(({ rows: [message] }) => message);
+
+export type CreateQuestionResponseOptions = {
+  value: string;
+  campaignContactId: number;
+  interactionStepId: number;
+};
+
+export const createQuestionResponse = async (
+  client: PoolClient,
+  options: CreateQuestionResponseOptions
+) =>
+  client
+    .query<QuestionResponseRecord>(
+      `
+        insert into public.question_response (value, campaign_contact_id, interaction_step_id)
+        values ($1, $2, $3)
+        returning *
+      `,
+      [options.value, options.campaignContactId, options.interactionStepId]
+    )
+    .then(({ rows: [questionResponse] }) => questionResponse);

--- a/src/server/api/lib/interaction-steps.spec.ts
+++ b/src/server/api/lib/interaction-steps.spec.ts
@@ -1,13 +1,15 @@
 import { Pool } from "pg";
 
 import {
+  createCampaignContact,
   createCompleteCampaign,
-  createInteractionStep
+  createInteractionStep,
+  createQuestionResponse
 } from "../../../../__test__/testbed-preparation/core";
-import { InteractionStepWithChildren } from "../../../api/interaction-step";
+import type { InteractionStepWithChildren } from "../../../api/interaction-step";
 import { config } from "../../../config";
 import { withClient } from "../../utils";
-import { InteractionStepRecord } from "../types";
+import type { InteractionStepRecord } from "../types";
 import { persistInteractionStepTree } from "./interaction-steps";
 
 const emptyStep = {
@@ -82,8 +84,7 @@ describe("persistInteractionStepTree", () => {
         [rootStep.id]
       );
 
-      expect(deletedStep).toHaveProperty("is_deleted");
-      expect(deletedStep.is_deleted).toBe(true);
+      expect(deletedStep).toBeUndefined();
     });
   });
 
@@ -208,7 +209,7 @@ describe("persistInteractionStepTree", () => {
     });
   });
 
-  test("soft deletes steps for a started campaign", async () => {
+  test("soft deletes steps that have question response referenced", async () => {
     await withClient(pool, async (client) => {
       const { campaign } = await createCompleteCampaign(client, {
         campaign: { isStarted: true }
@@ -219,6 +220,14 @@ describe("persistInteractionStepTree", () => {
       const childStep = await createInteractionStep(client, {
         campaignId: campaign.id,
         parentInteractionId: rootStep.id
+      });
+      const newContact = await createCampaignContact(client, {
+        campaignId: campaign.id
+      });
+      await createQuestionResponse(client, {
+        value: childStep.answer_option,
+        campaignContactId: newContact.id,
+        interactionStepId: childStep.id
       });
 
       const stepToPersist: InteractionStepWithChildren = {

--- a/src/server/api/lib/interaction-steps.ts
+++ b/src/server/api/lib/interaction-steps.ts
@@ -107,7 +107,16 @@ export const persistInteractionStepTree = async (
     .where({ campaign_id: campaignId })
     .whereNotIn("id", stepIds);
 
-  if (origCampaignRecord.is_started) {
+  const messagedContacts = await r
+    .reader("campaign_contact")
+    .select("id")
+    .where({ campaign_id: campaignId })
+    .whereNot({ message_status: "needsMessage" })
+    .limit(1);
+
+  // if a campaign has been unstarted when using the superadmin approval feature,
+  // there can be messaged contacts on an unstarted campaign
+  if (origCampaignRecord.is_started || messagedContacts.length > 0) {
     await delQuery.update({ is_deleted: true });
   } else {
     await delQuery.del();


### PR DESCRIPTION
## Description
This fixes the deletion of interaction steps when using the superadmin approval feature.

## Motivation and Context
When a non superadmin edits the script on a started campaign when using superadmin approval, the campaign is unstarted. Messaged contacts on an unstarted campaign were previously (mostly) impossible, and so we used the `is_started` status of the campaign to check whether interaction steps could be safely deleted.

However, in this case with superadmin approval, a campaign can be unstarted even if contacts are messaged. If survey responses have been applied, deletion of a record in `interaction_step` violates the foreign key constraint on `question_response`. This blocks any script edits from taking effect, after deleting an interaction step has been attempted.

## How Has This Been Tested?
This has been tested locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
