### PR TITLE
fix: fix refresh integration button hidden

### DIFF
--- a/src/containers/AdminExternalSystems.tsx
+++ b/src/containers/AdminExternalSystems.tsx
@@ -6,6 +6,13 @@ import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
 import DialogTitle from "@material-ui/core/DialogTitle";
+import Paper from "@material-ui/core/Paper";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableContainer from "@material-ui/core/TableContainer";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
 import AddIcon from "@material-ui/icons/Add";
 import CloudDownloadIcon from "@material-ui/icons/CloudDownload";
 import CreateIcon from "@material-ui/icons/Create";
@@ -15,14 +22,6 @@ import FloatingActionButton from "material-ui/FloatingActionButton";
 import MenuItem from "material-ui/MenuItem";
 import SelectField from "material-ui/SelectField";
 import Snackbar from "material-ui/Snackbar";
-import {
-  Table,
-  TableBody,
-  TableHeader,
-  TableHeaderColumn,
-  TableRow,
-  TableRowColumn
-} from "material-ui/Table";
 import TextField from "material-ui/TextField";
 import React, { Component } from "react";
 import { withRouter } from "react-router-dom";
@@ -222,54 +221,57 @@ class AdminExternalSystems extends Component<Props, State> {
           variant="contained"
           endIcon={<RefreshIcon />}
           onClick={this.handleRefreshSystems}
+          style={{ marginTop: 15, marginBottom: 15 }}
         >
-          Refresh
+          Refresh Lists
         </Button>
 
-        <Table selectable={false} onCellClick={this.handleCellClick}>
-          <TableHeader displaySelectAll={false} enableSelectAll={false}>
-            <TableRow>
-              {/* Make sure to update ACTIONS_COLUMN_INDEX when changing columns! */}
-              <TableHeaderColumn>Name</TableHeaderColumn>
-              <TableHeaderColumn>Type</TableHeaderColumn>
-              <TableHeaderColumn>Sync Options Last Fetched</TableHeaderColumn>
-              <TableHeaderColumn>Actions</TableHeaderColumn>
-            </TableRow>
-          </TableHeader>
-          <TableBody displayRowCheckbox={false} showRowHover>
-            {externalSystems.edges.map(({ node: system }) => (
-              <TableRow key={system.id}>
-                <TableRowColumn>{system.name}</TableRowColumn>
-                <TableRowColumn>{system.type}</TableRowColumn>
-                <TableRowColumn>
-                  {system.syncedAt
-                    ? DateTime.fromISO(system.syncedAt).toRelative()
-                    : "never"}
-                </TableRowColumn>
-                <TableRowColumn>
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    endIcon={<CreateIcon />}
-                    style={{ marginRight: 10 }}
-                    onClick={this.makeStartEditExternalSystem(system.id)}
-                  >
-                    Edit
-                  </Button>
-                  <Button
-                    variant="contained"
-                    endIcon={<CloudDownloadIcon />}
-                    style={{ marginRight: 10 }}
-                    disabled={this.state.syncInitiatedForId === system.id}
-                    onClick={this.makeHandleRefreshExternalSystem(system.id)}
-                  >
-                    Refresh Sync Options
-                  </Button>
-                </TableRowColumn>
+        <TableContainer component={Paper}>
+          <Table selectable={false} onCellClick={this.handleCellClick}>
+            <TableHead displaySelectAll={false} enableSelectAll={false}>
+              <TableRow>
+                {/* Make sure to update ACTIONS_COLUMN_INDEX when changing columns! */}
+                <TableCell>Name</TableCell>
+                <TableCell>Type</TableCell>
+                <TableCell>Sync Options Last Fetched</TableCell>
+                <TableCell>Actions</TableCell>
               </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+            </TableHead>
+            <TableBody displayRowCheckbox={false} showRowHover>
+              {externalSystems.edges.map(({ node: system }) => (
+                <TableRow key={system.id}>
+                  <TableCell>{system.name}</TableCell>
+                  <TableCell>{system.type}</TableCell>
+                  <TableCell>
+                    {system.syncedAt
+                      ? DateTime.fromISO(system.syncedAt).toRelative()
+                      : "never"}
+                  </TableCell>
+                  <TableCell style={{ textOverflow: "clip" }}>
+                    <Button
+                      variant="contained"
+                      color="primary"
+                      endIcon={<CreateIcon />}
+                      style={{ marginRight: 10 }}
+                      onClick={this.makeStartEditExternalSystem(system.id)}
+                    >
+                      Edit
+                    </Button>
+                    <Button
+                      variant="contained"
+                      endIcon={<CloudDownloadIcon />}
+                      style={{ marginRight: 10 }}
+                      disabled={this.state.syncInitiatedForId === system.id}
+                      onClick={this.makeHandleRefreshExternalSystem(system.id)}
+                    >
+                      Sync
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
 
         <Dialog
           open={editingExternalSystem !== undefined}

--- a/src/containers/AdminExternalSystems.tsx
+++ b/src/containers/AdminExternalSystems.tsx
@@ -223,7 +223,7 @@ class AdminExternalSystems extends Component<Props, State> {
           onClick={this.handleRefreshSystems}
           style={{ marginTop: 15, marginBottom: 15 }}
         >
-          Refresh Lists
+          Refresh List
         </Button>
 
         <TableContainer component={Paper}>


### PR DESCRIPTION
## Description

Set text overflow to clip, so it doesn't convert buttons to ellipsis. 

## Motivation and Context

Fixes #1283 

## How Has This Been Tested?
Tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->
<img width="1318" alt="Screenshot 2022-08-23 at 9 22 16 PM" src="https://user-images.githubusercontent.com/367605/186204902-1cbee713-3ea5-4f54-95cb-9d93dd8ede68.png">
<img width="1322" alt="Screenshot 2022-08-23 at 9 22 37 PM" src="https://user-images.githubusercontent.com/367605/186204923-cdc8efb0-aa1e-4040-8e2f-182b49470586.png">

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
