### PR TITLE
feat: show a snackbar on mulitple graphql server errors

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -9,6 +9,7 @@ import ApolloClientSingleton from "../network/apollo-client-singleton";
 import AppRoutes from "../routes";
 import { SpokeThemeProvider } from "../styles/spoke-theme-context";
 import baseTheme from "../styles/theme";
+import ErrorHandler from "./ErrorHandler";
 import { SpokeContextProvider } from "./spoke-context";
 import VersionNotifier from "./VersionNotifier";
 
@@ -30,6 +31,7 @@ const App: React.FC = () => {
             <SpokeThemeProvider>
               <div className={css(styles.root)}>
                 <VersionNotifier />
+                <ErrorHandler />
                 <AppRoutes />
               </div>
             </SpokeThemeProvider>

--- a/src/client/ErrorHandler.tsx
+++ b/src/client/ErrorHandler.tsx
@@ -1,0 +1,56 @@
+import Snackbar from "@material-ui/core/Snackbar";
+import Alert from "@material-ui/lab/Alert";
+import React, { useEffect, useRef, useState } from "react";
+
+import { eventBus, EventTypes } from "./events";
+
+const ErrorHandler: React.FC = () => {
+  const errorCount = useRef(0);
+  const [open, setOpen] = useState<boolean>(false);
+
+  const handleNewEvent = () => {
+    errorCount.current += 1;
+
+    // We have our first event triggered
+    if (errorCount.current === 1) {
+      // Set timeout to expire count after 30 seconds
+      // so a few events over a long period of time
+      // don't set off the snackbar
+      setTimeout(() => {
+        errorCount.current = 0;
+      }, 30 * 1000);
+    }
+
+    // Show the snackbar, and reset the count to 0
+    if (errorCount.current > 3) {
+      setOpen(true);
+      errorCount.current = 0;
+    }
+  };
+
+  const handleClose = () => setOpen(false);
+
+  useEffect(() => {
+    eventBus.on(EventTypes.GraphQLServerError, handleNewEvent);
+  }, []);
+
+  return (
+    <Snackbar
+      open={open}
+      autoHideDuration={6000}
+      onClose={handleClose}
+      anchorOrigin={{ vertical: "top", horizontal: "right" }}
+    >
+      <Alert
+        onClose={handleClose}
+        severity="error"
+        style={{ fontSize: "1.3em" }}
+      >
+        We're having issues communicating with the server. If issues persist,
+        please wait a minute, refresh, and try again!
+      </Alert>
+    </Snackbar>
+  );
+};
+
+export default ErrorHandler;

--- a/src/client/ErrorHandler.tsx
+++ b/src/client/ErrorHandler.tsx
@@ -5,7 +5,8 @@ import React, { useEffect, useRef, useState } from "react";
 import { eventBus, EventTypes } from "./events";
 
 const ErrorHandler: React.FC = () => {
-  const errorCount = useRef(0);
+  const errorCount = useRef<number>(0);
+  const timerRef = useRef<NodeJS.Timeout>();
   const [open, setOpen] = useState<boolean>(false);
 
   const handleNewEvent = () => {
@@ -16,7 +17,7 @@ const ErrorHandler: React.FC = () => {
       // Set timeout to expire count after 30 seconds
       // so a few events over a long period of time
       // don't set off the snackbar
-      setTimeout(() => {
+      timerRef.current = setTimeout(() => {
         errorCount.current = 0;
       }, 30 * 1000);
     }
@@ -32,7 +33,11 @@ const ErrorHandler: React.FC = () => {
 
   useEffect(() => {
     eventBus.on(EventTypes.GraphQLServerError, handleNewEvent);
-  }, []);
+    return () => {
+      eventBus.removeListener(EventTypes.GraphQLServerError, handleNewEvent);
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [handleNewEvent]);
 
   return (
     <Snackbar

--- a/src/client/events.ts
+++ b/src/client/events.ts
@@ -1,7 +1,8 @@
 import EventEmitter from "events";
 
-export const EventTypes = Object.freeze({
-  NewSpokeVersionAvailble: "NewSpokeVersionAvailble"
-});
+export enum EventTypes {
+  NewSpokeVersionAvailble = "NewSpokeVersionAvailble",
+  GraphQLServerError = "GraphQLServerError"
+}
 
 export const eventBus = new EventEmitter();

--- a/src/network/apollo-client-singleton.ts
+++ b/src/network/apollo-client-singleton.ts
@@ -13,6 +13,12 @@ const uploadLink = createUploadLink({
   credentials: "same-origin"
 });
 
+enum GraphQLErrors {
+  Unathenticated = "UNAUTHENTICATED",
+  GraphQLParseFailed = "GRAPHQL_PARSE_FAILED",
+  InternalServerError = "INTERNAL_SERVER_ERROR"
+}
+
 const errorLink = onError(({ graphQLErrors, networkError }) => {
   if (networkError && "statusCode" in networkError) {
     switch (networkError.statusCode) {
@@ -31,8 +37,12 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
   if (graphQLErrors) {
     for (const err of graphQLErrors) {
       switch (err.extensions.code) {
-        case "UNAUTHENTICATED":
+        case GraphQLErrors.Unathenticated:
           window.location.href = `/login?nextUrl=${window.location.pathname}`;
+          break;
+        case GraphQLErrors.GraphQLParseFailed:
+        case GraphQLErrors.InternalServerError:
+          eventBus.emit(EventTypes.GraphQLServerError);
           break;
         // no default
       }


### PR DESCRIPTION
## Description

Emit errors on the eventbus when a graphql server error is encountered, and show a snackbar 

## Motivation and Context

Fixes #1342 

## How Has This Been Tested?

Tested locally with a few scenarios. Will require some extra testing on staging. 

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
