### PR TITLE
fix: import server-defined type

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,7 +84,8 @@ module.exports = {
     "@typescript-eslint/no-non-null-assertion": "off",
     "no-use-before-define": "off",
     "@typescript-eslint/no-use-before-define": "error",
-    "no-restricted-imports": [
+    "no-restricted-imports": "off",
+    "@typescript-eslint/no-restricted-imports": [
       "error",
       {
         paths: [
@@ -172,13 +173,14 @@ module.exports = {
     {
       files: ["src/server/**/*"],
       rules: {
-        "no-restricted-imports": [
+        "@typescript-eslint/no-restricted-imports": [
           "error",
           {
             paths: [
               {
                 name: "@spoke/spoke-codegen",
-                message: "Client codegen may not be used in the server."
+                message: "Client codegen may not be used in the server.",
+                allowTypeImports: true
               }
             ]
           }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -168,6 +168,22 @@ module.exports = {
         "@typescript-eslint/no-shadow": "error",
         "no-unused-vars": "off" // JS `no-unused-vars` rule doesn't handle typescript correctly
       }
+    },
+    {
+      files: ["src/server/**/*"],
+      rules: {
+        "no-restricted-imports": [
+          "error",
+          {
+            paths: [
+              {
+                name: "@spoke/spoke-codegen",
+                message: "Client codegen may not be used in the server."
+              }
+            ]
+          }
+        ]
+      }
     }
   ]
 };

--- a/src/lib/datetime.ts
+++ b/src/lib/datetime.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-restricted-imports */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import { DateTime as LuxonDateTime, Zone, ZoneOptions } from "luxon";
 
 export { Interval } from "luxon";

--- a/src/server/api/lib/autosend-initials.spec.ts
+++ b/src/server/api/lib/autosend-initials.spec.ts
@@ -2,7 +2,7 @@ import {
   createCampaign,
   createCampaignContact
 } from "__test__/testbed-preparation/core";
-import { campaign as CampaignRecord } from "@spoke/spoke-codegen";
+import type { campaign as CampaignRecord } from "@spoke/spoke-codegen";
 import { Pool } from "pg";
 import { UserRoleType } from "src/api/organization-membership";
 import supertest from "supertest";

--- a/src/server/api/lib/bulk-script-editor.ts
+++ b/src/server/api/lib/bulk-script-editor.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 
-import { BulkUpdateScriptInput } from "@spoke/spoke-codegen";
+import type { BulkUpdateScriptInput } from "@spoke/spoke-codegen";
 import { Knex } from "knex";
 
 import { r } from "../../models";

--- a/src/server/api/organization-settings.ts
+++ b/src/server/api/organization-settings.ts
@@ -1,5 +1,3 @@
-import { AutosendingControlsMode } from "@spoke/spoke-codegen";
-
 import {
   RequestAutoApproveType,
   UserRoleType
@@ -9,6 +7,7 @@ import { stringIsAValidUrl } from "../../lib/utils";
 import { r } from "../models";
 import { organizationCache } from "../models/cacheable_queries/organization";
 import { accessRequired, roleIndex } from "./errors";
+import { AutosendingControlsMode } from "./types";
 
 export enum CampaignBuilderMode {
   Basic = "BASIC",

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1,4 +1,3 @@
-import { DeactivateMode } from "@spoke/spoke-codegen";
 import { ForbiddenError } from "apollo-server-errors";
 import camelCaseKeys from "camelcase-keys";
 import GraphQLDate from "graphql-date";
@@ -101,6 +100,7 @@ import { resolvers as questionResponseResolvers } from "./question-response";
 import { resolvers as tagResolvers } from "./tag";
 import { resolvers as teamResolvers } from "./team";
 import { resolvers as trollbotResolvers } from "./trollbot";
+import { DeactivateMode } from "./types";
 import { getUsers, getUsersById, resolvers as userResolvers } from "./user";
 
 const uuidv4 = require("uuid").v4;

--- a/src/server/api/types.ts
+++ b/src/server/api/types.ts
@@ -280,3 +280,9 @@ export interface NotificationRecord {
   campaign_id?: number | null;
   sent_at?: Date | null;
 }
+
+export enum DeactivateMode {
+  Deleteall = "DELETEALL",
+  Nosuspend = "NOSUSPEND",
+  Suspendall = "SUSPENDALL"
+}

--- a/src/server/api/types.ts
+++ b/src/server/api/types.ts
@@ -286,3 +286,8 @@ export enum DeactivateMode {
   Nosuspend = "NOSUSPEND",
   Suspendall = "SUSPENDALL"
 }
+
+export enum AutosendingControlsMode {
+  Basic = "BASIC",
+  Detailed = "DETAILED"
+}

--- a/src/server/models/cacheable_queries/user.ts
+++ b/src/server/models/cacheable_queries/user.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   campaign as CampaignRecord,
   user as UserRecord
 } from "@spoke/spoke-codegen";

--- a/src/server/organization-settings.spec.ts
+++ b/src/server/organization-settings.spec.ts
@@ -1,7 +1,4 @@
-import {
-  AutosendingControlsMode,
-  OrganizationSettingsInput
-} from "@spoke/spoke-codegen";
+import type { OrganizationSettingsInput } from "@spoke/spoke-codegen";
 import { Pool } from "pg";
 import supertest from "supertest";
 
@@ -12,6 +9,7 @@ import {
 } from "../api/organization-membership";
 import { config } from "../config";
 import { writePermissionRequired } from "./api/organization-settings";
+import { AutosendingControlsMode } from "./api/types";
 import { createApp } from "./app";
 import { withClient } from "./utils";
 


### PR DESCRIPTION
## Description

Import `DeactivateMode` from server-defined type rather than client-defined type.

## Motivation and Context

`@spoke/spoke-codegen` is meant for use in the client application only and will fail to import in production.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
