### PR TITLE
style: import codegen using alias rather than path

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -100,6 +100,10 @@ module.exports = {
         ],
         patterns: [
           {
+            group: ["**/spoke-codegen/src"],
+            message: "Please use @spoke/spoke-codegen instead."
+          },
+          {
             group: ["material-ui/svg-icons/*"],
             message: "Please use @material-ui/icons instead."
           },

--- a/src/components/CampaignNavigation.tsx
+++ b/src/components/CampaignNavigation.tsx
@@ -1,8 +1,7 @@
 import Button from "@material-ui/core/Button";
 import ButtonGroup from "@material-ui/core/ButtonGroup";
+import { useGetCampaignNavigationQuery } from "@spoke/spoke-codegen";
 import React from "react";
-
-import { useGetCampaignNavigationQuery } from "../../libs/spoke-codegen/src";
 
 interface Props {
   prevCampaignClicked(campaignId: string | null): void;

--- a/src/containers/AdminCampaignEdit/components/ApproveCampaignButton.tsx
+++ b/src/containers/AdminCampaignEdit/components/ApproveCampaignButton.tsx
@@ -1,11 +1,11 @@
 import Button from "@material-ui/core/Button";
 import Tooltip from "@material-ui/core/Tooltip";
-import React, { useCallback } from "react";
-
 import {
   useGetCampaignStatusQuery,
   useSetCampaignApprovedMutation
-} from "../../../../libs/spoke-codegen/src";
+} from "@spoke/spoke-codegen";
+import React, { useCallback } from "react";
+
 import { useSpokeContext } from "../../../client/spoke-context";
 import { useAuthzContext } from "../../../components/AuthzProvider";
 

--- a/src/containers/AdminCampaignEdit/components/StartCampaignButton.tsx
+++ b/src/containers/AdminCampaignEdit/components/StartCampaignButton.tsx
@@ -1,11 +1,11 @@
 import Button from "@material-ui/core/Button";
 import Tooltip from "@material-ui/core/Tooltip";
-import React, { useCallback } from "react";
-
 import {
   useGetCampaignStatusQuery,
   useStartCampaignMutation
-} from "../../../../libs/spoke-codegen/src";
+} from "@spoke/spoke-codegen";
+import React, { useCallback } from "react";
+
 import { useSpokeContext } from "../../../client/spoke-context";
 import { useAuthzContext } from "../../../components/AuthzProvider";
 

--- a/src/containers/AdminCampaignEdit/index.jsx
+++ b/src/containers/AdminCampaignEdit/index.jsx
@@ -14,6 +14,7 @@ import { withTheme } from "@material-ui/core/styles";
 import CancelIcon from "@material-ui/icons/Cancel";
 import DoneIcon from "@material-ui/icons/Done";
 import WarningIcon from "@material-ui/icons/Warning";
+import { CampaignBuilderMode } from "@spoke/spoke-codegen";
 import isEqual from "lodash/isEqual";
 import pick from "lodash/pick";
 import Avatar from "material-ui/Avatar";
@@ -26,7 +27,6 @@ import React from "react";
 import { Helmet } from "react-helmet";
 import { compose } from "recompose";
 
-import { CampaignBuilderMode } from "../../../libs/spoke-codegen/src/generated";
 import { withSpokeContext } from "../../client/spoke-context";
 import { withAuthzContext } from "../../components/AuthzProvider";
 import CampaignNavigation from "../../components/CampaignNavigation";

--- a/src/containers/Settings/components/CampaignBuilderSettingsCard.tsx
+++ b/src/containers/Settings/components/CampaignBuilderSettingsCard.tsx
@@ -9,13 +9,13 @@ import MenuItem from "@material-ui/core/MenuItem";
 import Select from "@material-ui/core/Select";
 import type { SelectInputProps } from "@material-ui/core/Select/SelectInput";
 import Switch from "@material-ui/core/Switch";
-import React from "react";
-
 import {
   CampaignBuilderMode,
   useGetCampaignBuilderSettingsQuery,
   useUpdateCampaignBuilderSettingsMutation
-} from "../../../../libs/spoke-codegen/src";
+} from "@spoke/spoke-codegen";
+import React from "react";
+
 import { useAuthzContext } from "../../../components/AuthzProvider";
 
 export interface CampaignBuilderSettingsCardProps {

--- a/src/containers/Settings/components/ScriptPreviewSettingsCard.tsx
+++ b/src/containers/Settings/components/ScriptPreviewSettingsCard.tsx
@@ -4,12 +4,11 @@ import CardHeader from "@material-ui/core/CardHeader";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import FormGroup from "@material-ui/core/FormGroup";
 import Switch from "@material-ui/core/Switch";
-import React from "react";
-
 import {
   useGetScriptPreviewSettingsQuery,
   useUpdateScriptPreviewSettingsMutation
-} from "../../../../libs/spoke-codegen/src";
+} from "@spoke/spoke-codegen";
+import React from "react";
 
 export interface ScriptPreviewSettingsCardProps {
   organizationId: string;


### PR DESCRIPTION
## Description

Require importing codegen using alias rather than relative path.

## Motivation and Context

Codegen is an internal library and should be used like one.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
