### PR TITLE
fix(people): fix searching by only campaign

### DIFF
--- a/src/api/organization-membership.ts
+++ b/src/api/organization-membership.ts
@@ -60,7 +60,7 @@ export const schema = `
 
   input MembershipFilter {
     nameSearch: String
-    campaignId: Int
+    campaignId: String
     campaignArchived: Boolean
     roles: [String!]
   }

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -516,7 +516,7 @@ enum RequestAutoApprove {
 
 input MembershipFilter {
   nameSearch: String
-  campaignId: Int
+  campaignId: String
   campaignArchived: Boolean
   roles: [String!]
 }

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -147,7 +147,7 @@ export const resolvers = {
         query.whereExists(function subquery() {
           this.select(this.client.raw("1"))
             .from("assignment")
-            .whereRaw('"assignment"."user_id" = "user"."id"')
+            .whereRaw('"assignment"."user_id" = "user_organization"."user_id"')
             .where({ campaign_id: campaignIdInt });
         });
       } else if (campaignArchived === true || campaignArchived === false) {


### PR DESCRIPTION
## Description

This PR does two things:
1. Fixes a BAD_USER_INPUT Apollo error
2. Fixes the join on assignment to work when searching only on campaign, and not user

## Motivation and Context

Searching by campaign expected the `user` table to have already been joined but that was not _necessarily_ the case.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
