### PR TITLE
chore(util): add graphile-secrets crypto utils

### DIFF
--- a/dev-tools/graphile-secrets-decrypt.js
+++ b/dev-tools/graphile-secrets-decrypt.js
@@ -1,0 +1,11 @@
+// Run this script from the top level directory to decrypt a value:
+//
+//    node ./dev-tools/graphile-secrets-decrypt.js ValueToBeDecrypted
+
+require("dotenv").config();
+const Cryptr = require("cryptr");
+const cryptr = new Cryptr(process.env.SESSION_SECRET);
+
+const result = cryptr.decrypt(process.argv[2]);
+console.log(result);
+process.exit(0);

--- a/dev-tools/graphile-secrets-encrypt.js
+++ b/dev-tools/graphile-secrets-encrypt.js
@@ -1,6 +1,6 @@
 // Run this script from the top level directory to encrypt a value:
 //
-//    node ./dev-tools/graphile-secrets-encrypt.js ValueToBeDecrypted
+//    node ./dev-tools/graphile-secrets-encrypt.js ValueToBeEncrypted
 
 require("dotenv").config();
 const Cryptr = require("cryptr");

--- a/dev-tools/graphile-secrets-encrypt.js
+++ b/dev-tools/graphile-secrets-encrypt.js
@@ -1,0 +1,11 @@
+// Run this script from the top level directory to encrypt a value:
+//
+//    node ./dev-tools/graphile-secrets-encrypt.js ValueToBeDecrypted
+
+require("dotenv").config();
+const Cryptr = require("cryptr");
+const cryptr = new Cryptr(process.env.SESSION_SECRET);
+
+const result = cryptr.encrypt(process.argv[2]);
+console.log(result);
+process.exit(0);


### PR DESCRIPTION
## Description

Adds util scripts for encrypting and decrypting `graphile-secrets` values.

## Motivation and Context

Necessary for debugging NGP VAN integration user issues.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
