### PR TITLE
fix: fix integration cell click handling

### DIFF
--- a/src/containers/AdminExternalSystems.tsx
+++ b/src/containers/AdminExternalSystems.tsx
@@ -191,6 +191,8 @@ class AdminExternalSystems extends Component<Props, State> {
       </Button>
     ];
 
+    const { organizationId } = this.props.match.params;
+
     return (
       <div>
         <FloatingActionButton
@@ -222,10 +224,9 @@ class AdminExternalSystems extends Component<Props, State> {
             </TableHead>
             <TableBody>
               {externalSystems.edges.map(({ node: system }) => {
-                const { organizationId } = this.props.match.params;
                 const detailURL = `/admin/${organizationId}/integrations/${system.id}`;
                 return (
-                  <TableRow key={system.id}>
+                  <TableRow key={system.id} hover>
                     <TableCell>
                       <Link to={detailURL}>{system.name}</Link>
                     </TableCell>

--- a/src/containers/AdminExternalSystems.tsx
+++ b/src/containers/AdminExternalSystems.tsx
@@ -44,8 +44,6 @@ const OPERATION_MODE_OPTS: [string, string][] = [
   ["MyCampaign", VanOperationMode.MYCAMPAIGN]
 ];
 
-const ACTIONS_COLUMN_INDEX = 3;
-
 interface Props {
   match: any;
   history: History;
@@ -163,13 +161,6 @@ class AdminExternalSystems extends Component<Props, State> {
       externalSystem: { ...prevState.externalSystem, ...{ [prop]: newVal } }
     }));
 
-  handleCellClick = (row: number, columnIndex: number) => {
-    if (columnIndex === ACTIONS_COLUMN_INDEX) return;
-
-    const systemId = this.props.data.externalSystems.edges[row].node.id;
-    this.navigateToSystemDetail(systemId);
-  };
-
   handleSelectOperationMode = (
     _event: any,
     _index: number,
@@ -226,8 +217,8 @@ class AdminExternalSystems extends Component<Props, State> {
         </Button>
 
         <TableContainer component={Paper}>
-          <Table selectable={false} onCellClick={this.handleCellClick}>
-            <TableHead displaySelectAll={false} enableSelectAll={false}>
+          <Table>
+            <TableHead>
               <TableRow>
                 {/* Make sure to update ACTIONS_COLUMN_INDEX when changing columns! */}
                 <TableCell>Name</TableCell>
@@ -236,12 +227,22 @@ class AdminExternalSystems extends Component<Props, State> {
                 <TableCell>Actions</TableCell>
               </TableRow>
             </TableHead>
-            <TableBody displayRowCheckbox={false} showRowHover>
+            <TableBody>
               {externalSystems.edges.map(({ node: system }) => (
                 <TableRow key={system.id}>
-                  <TableCell>{system.name}</TableCell>
-                  <TableCell>{system.type}</TableCell>
-                  <TableCell>
+                  <TableCell
+                    onClick={() => this.navigateToSystemDetail(system.id)}
+                  >
+                    {system.name}
+                  </TableCell>
+                  <TableCell
+                    onClick={() => this.navigateToSystemDetail(system.id)}
+                  >
+                    {system.type}
+                  </TableCell>
+                  <TableCell
+                    onClick={() => this.navigateToSystemDetail(system.id)}
+                  >
                     {system.syncedAt
                       ? DateTime.fromISO(system.syncedAt).toRelative()
                       : "never"}

--- a/src/containers/AdminExternalSystems.tsx
+++ b/src/containers/AdminExternalSystems.tsx
@@ -24,7 +24,7 @@ import SelectField from "material-ui/SelectField";
 import Snackbar from "material-ui/Snackbar";
 import TextField from "material-ui/TextField";
 import React, { Component } from "react";
-import { withRouter } from "react-router-dom";
+import { Link, withRouter } from "react-router-dom";
 import { compose } from "recompose";
 
 import type {
@@ -128,13 +128,6 @@ class AdminExternalSystems extends Component<Props, State> {
       }
     });
 
-  navigateToSystemDetail = (systemId: string) => {
-    const { organizationId } = this.props.match.params;
-    this.props.history.push(
-      `/admin/${organizationId}/integrations/${systemId}`
-    );
-  };
-
   saveExternalSystem = async () => {
     const { editingExternalSystem, externalSystem } = this.state;
     try {
@@ -228,47 +221,45 @@ class AdminExternalSystems extends Component<Props, State> {
               </TableRow>
             </TableHead>
             <TableBody>
-              {externalSystems.edges.map(({ node: system }) => (
-                <TableRow key={system.id}>
-                  <TableCell
-                    onClick={() => this.navigateToSystemDetail(system.id)}
-                  >
-                    {system.name}
-                  </TableCell>
-                  <TableCell
-                    onClick={() => this.navigateToSystemDetail(system.id)}
-                  >
-                    {system.type}
-                  </TableCell>
-                  <TableCell
-                    onClick={() => this.navigateToSystemDetail(system.id)}
-                  >
-                    {system.syncedAt
-                      ? DateTime.fromISO(system.syncedAt).toRelative()
-                      : "never"}
-                  </TableCell>
-                  <TableCell style={{ textOverflow: "clip" }}>
-                    <Button
-                      variant="contained"
-                      color="primary"
-                      endIcon={<CreateIcon />}
-                      style={{ marginRight: 10 }}
-                      onClick={this.makeStartEditExternalSystem(system.id)}
-                    >
-                      Edit
-                    </Button>
-                    <Button
-                      variant="contained"
-                      endIcon={<CloudDownloadIcon />}
-                      style={{ marginRight: 10 }}
-                      disabled={this.state.syncInitiatedForId === system.id}
-                      onClick={this.makeHandleRefreshExternalSystem(system.id)}
-                    >
-                      Sync
-                    </Button>
-                  </TableCell>
-                </TableRow>
-              ))}
+              {externalSystems.edges.map(({ node: system }) => {
+                const { organizationId } = this.props.match.params;
+                const detailURL = `/admin/${organizationId}/integrations/${system.id}`;
+                return (
+                  <TableRow key={system.id}>
+                    <TableCell>
+                      <Link to={detailURL}>{system.name}</Link>
+                    </TableCell>
+                    <TableCell>{system.type}</TableCell>
+                    <TableCell>
+                      {system.syncedAt
+                        ? DateTime.fromISO(system.syncedAt).toRelative()
+                        : "never"}
+                    </TableCell>
+                    <TableCell style={{ textOverflow: "clip" }}>
+                      <Button
+                        variant="contained"
+                        color="primary"
+                        endIcon={<CreateIcon />}
+                        style={{ marginRight: 10 }}
+                        onClick={this.makeStartEditExternalSystem(system.id)}
+                      >
+                        Edit
+                      </Button>
+                      <Button
+                        variant="contained"
+                        endIcon={<CloudDownloadIcon />}
+                        style={{ marginRight: 10 }}
+                        disabled={this.state.syncInitiatedForId === system.id}
+                        onClick={this.makeHandleRefreshExternalSystem(
+                          system.id
+                        )}
+                      >
+                        Sync
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
             </TableBody>
           </Table>
         </TableContainer>


### PR DESCRIPTION
## Description
This fixes click handling when clicking cells on the Integrations page.

## Motivation and Context
The MUI v4 [`<Table>`](https://v4.mui.com/api/table/) upgrade in #1360 prevented users from clicking on table cells to access the integration detail page, because the `onCellClick` event is no longer supported. The v4 [`<Table>`](https://v4.mui.com/api/table/) also doesn't support several other props we were using from v0, and are no longer required because of default behavior.

## How Has This Been Tested?
This has been tested locally.
## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
