### PR TITLE
fix: handle external_id field correctly in scripts

### DIFF
--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -15,6 +15,7 @@ const contactDataFragment = `
         lastName
         cell
         zip
+        external_id
         customFields
         optOut {
           id


### PR DESCRIPTION
## Description

This fixes how `external_id` is handled when applying scripts.

## Motivation and Context

The `external_id` field is special in that it is always snake-case, in both the database and in GraphQL. This was not being accounted for resulting in `applyScript()` trying to populate `external_id` variables with nonexistent `contact.externalId`.

## How Has This Been Tested?

This has been tested locally in `retry-interaction-step` and in the texter interface.

It has not been tested with bulk sending (disabled in our fork anyway).

## Screenshots (if appropriate):


N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
