### PR TITLE
chore: deprioritize autosending

### DIFF
--- a/src/server/tasks/queue-autosend-initials.ts
+++ b/src/server/tasks/queue-autosend-initials.ts
@@ -90,7 +90,8 @@ const queueAutoSendInitials: Task = async (payload: Payload, helpers) => {
           null as queue_name,
           1 as max_attempts,
           now() + ((n / $2::float) * interval '1 second') as run_at,
-          1 as priority
+          -- prioritize in order as: autoassignment, autosending, handle delivery reports
+          4 as priority
         from contacts_to_queue
         -- this line doesn't modify the result at all, it just forces the execution of the intermediate CTE
         where id in ( select id from contacts_assigned )

--- a/src/server/tasks/queue-autosend-initials.ts
+++ b/src/server/tasks/queue-autosend-initials.ts
@@ -78,7 +78,7 @@ const queueAutoSendInitials: Task = async (payload: Payload, helpers) => {
         returning id
       ),
       new_jobs_queued as (
-        insert into graphile_worker.jobs (task_identifier, payload, key, queue_name, max_attempts, run_at)
+        insert into graphile_worker.jobs (task_identifier, payload, key, queue_name, max_attempts, run_at, priority)
         select 
           'retry-interaction-step' as task_identifier, 
           json_build_object(
@@ -89,7 +89,8 @@ const queueAutoSendInitials: Task = async (payload: Payload, helpers) => {
           id::text as key,
           null as queue_name,
           1 as max_attempts,
-          now() + ((n / $2::float) * interval '1 second') as run_at
+          now() + ((n / $2::float) * interval '1 second') as run_at,
+          1 as priority
         from contacts_to_queue
         -- this line doesn't modify the result at all, it just forces the execution of the intermediate CTE
         where id in ( select id from contacts_assigned )


### PR DESCRIPTION
## Description
This deprioritizes autosending jobs, so that jobs related to message sending are prioritized in the following order: autoassignment, autosending, handling delivery reports.

## Motivation and Context
On instances with high autosending throughput that also had autoassignment requests occur simulatenously, autoassignment requests could get "stuck in pending" because there were significantly more autosending jobs generated at a given time than autoassignment jobs, and workers never picked up the autoassignment jobs. When autoassignment has a higher priority, this should not occur so frequently.

## How Has This Been Tested?
This has been tested locally to ensure both autoassignment and autosending jobs are picked up by workers. We should also observe autosending performance on previously mentioned instances that have a high rate of autosending and autoassignment requests before a wide rollout. 

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
