### PR TITLE
fix: remove readiness check for texters section

### DIFF
--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -343,22 +343,7 @@ export const resolvers = {
         .then((records) => records.length > 0),
     autoassign: () => true,
     cannedResponses: () => true,
-    texters: async (campaign) => {
-      const { id, use_dynamic_assignment } = campaign;
-      const {
-        rows: [{ is_fully_assigned }]
-      } = await r.knex.raw(
-        `
-          select not exists (
-            select 1
-            from campaign_contact
-            where campaign_id = ? and assignment_id is null
-          ) as is_fully_assigned
-        `,
-        [id]
-      );
-      return use_dynamic_assignment || is_fully_assigned;
-    },
+    texters: () => true,
     interactions: async (campaign) => {
       const hasSteps = await r
         .reader("interaction_step")


### PR DESCRIPTION
## Description

This removes the readiness check for the texters section by always returning `true` for the check.

## Motivation and Context

Auto-assignment is the preferred way of assigning texters. We do not want to draw attention to the texters section, especially with the recent palette change (#1228).

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<table>
<tr><td>

![Tempity_Temp_Temp_Temp_-_Campaigns_-_168__COPY_-_GOTV_for_CANDIDATE_5](https://user-images.githubusercontent.com/2145526/189937811-edb131b4-a8c4-4468-b738-73e7d475d358.png)

Unassigned

</td></tr>
<tr><td>

![Tempity_Temp_Temp_Temp_-_Campaigns_-_168__COPY_-_GOTV_for_CANDIDATE_5](https://user-images.githubusercontent.com/2145526/189937527-be2ecb78-6195-4a27-9d08-b5e29f32f477.png)

Closed style

</td></tr>
</table>

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
