### PR TITLE
fix: swap replies and convo colors

### DIFF
--- a/src/components/BadgeButton.tsx
+++ b/src/components/BadgeButton.tsx
@@ -23,8 +23,8 @@ const badgeColor = (messageType: MessageType, theme: Theme) =>
   messageType === "initial"
     ? theme.palette.success.light
     : messageType === "reply"
-    ? theme.palette.repliesBadge!.main
-    : theme.palette.error.light;
+    ? theme.palette.error.light
+    : theme.palette.convoMessageBadge!.main;
 
 const useStyles = makeStyles<Theme, BadgeButtonProps>((theme) => ({
   badge: {

--- a/src/styles/mui-theme.ts
+++ b/src/styles/mui-theme.ts
@@ -48,7 +48,7 @@ export const createMuiThemev1 = (theme: Partial<CustomTheme> = {}) => {
       primary: { main: primaryColor },
       secondary: { main: secondaryColor },
       badge: { main: badgeColor },
-      repliesBadge: { main: yellow[600] },
+      convoMessageBadge: { main: yellow[600] },
       inboundMessageBg: { main: blue[500] },
       success: { main: theme.successColor || green[500], light: green[100] },
       warning: { main: theme.warningColor || baseTheme.colors.orange },

--- a/src/styles/types.ts
+++ b/src/styles/types.ts
@@ -90,13 +90,13 @@ declare module "@material-ui/core/styles/createPalette" {
   interface Palette {
     badge?: Palette["primary"];
     inboundMessageBg?: Palette["primary"];
-    repliesBadge?: Palette["primary"];
+    convoMessageBadge?: Palette["primary"];
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface PaletteOptions {
     badge?: PaletteOptions["primary"];
     inboundMessageBg?: PaletteOptions["primary"];
-    repliesBadge?: PaletteOptions["primary"];
+    convoMessageBadge?: PaletteOptions["primary"];
   }
 }


### PR DESCRIPTION
## Description

This fixes badge colors for texter replies and active conversation buttons.

## Motivation and Context

They were switched in #1228.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

![Screen Shot 2022-09-13 at 1 20 36 PM](https://user-images.githubusercontent.com/2145526/189966438-2cfba838-fb9a-4858-a750-57fa539ee861.png)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
