### PR TITLE
fix: set transparent background for progress indicator

### DIFF
--- a/src/containers/AdminCampaignEdit/components/SectionWrapper.tsx
+++ b/src/containers/AdminCampaignEdit/components/SectionWrapper.tsx
@@ -181,7 +181,11 @@ export const SectionWrapper: React.FC<WrapperProps> = (props) => {
   const cardHeaderStyle: React.CSSProperties = {};
 
   if (isSaving) {
-    avatar = <CircularProgress className={classes.cardAvatar} />;
+    avatar = (
+      <CircularProgress
+        className={clsx(classes.cardAvatar, classes.cardAvatarEmpty)}
+      />
+    );
     classNames.push(classes.saving);
     cardHeaderStyle.width = `${progressPercent}%`;
   } else if (active && expandable) {


### PR DESCRIPTION
## Description

This sets a transparent background for the circular progress indicator for campaign builder sections with active jobs.

## Motivation and Context

The progress indicator should not have a background color the way the other status icons do.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

<img width="232" alt="Screen Shot 2022-09-14 at 1 46 44 PM" src="https://user-images.githubusercontent.com/2145526/190226740-729d3873-6026-4a79-8799-23d502f4e271.png">

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
