### PR TITLE
feat: send webhook on large campaign event

### DIFF
--- a/package.json
+++ b/package.json
@@ -278,6 +278,7 @@
     "json2csv": "^3.6.2",
     "lint-staged": "^10.4.0",
     "mockdate": "^2.0.2",
+    "nock": "^13.2.9",
     "nodemon": "^2.0.7",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.1.2",

--- a/src/config.js
+++ b/src/config.js
@@ -444,6 +444,14 @@ const validators = {
     desc: "When true, log each lambda event to the console.",
     default: false
   }),
+  LARGE_CAMPAIGN_THRESHOLD: num({
+    desc: 'Threshold for what qualifies as a "large campaign"',
+    default: 100 * 1000
+  }),
+  LARGE_CAMPAIGN_WEBHOOK: url({
+    desc: "URL to send webhook to when large campaign is uploaded or started",
+    default: undefined
+  }),
   LOGGING_MONGODB_URI: url({
     desc: "If present, requestLogger will send logs events to MongoDB.",
     default: undefined

--- a/src/server/api/lib/alerts.spec.ts
+++ b/src/server/api/lib/alerts.spec.ts
@@ -1,0 +1,98 @@
+import {
+  createCampaign,
+  createCampaignContact
+} from "__test__/testbed-preparation/core";
+import nock from "nock";
+import type { PoolClient } from "pg";
+import { Pool } from "pg";
+import supertest from "supertest";
+
+import { createOrgAndSession } from "../../../../__test__/lib/session";
+import { UserRoleType } from "../../../api/organization-membership";
+import { config } from "../../../config";
+import { createApp } from "../../app";
+import { withClient } from "../../utils";
+import { notifyLargeCampaignEvent } from "./alerts";
+
+describe("notifyLargeCampaignEvent", () => {
+  let pool: Pool;
+  let agent: supertest.SuperAgentTest;
+
+  const TEST_WEBHOOK_URL = "https://poke.spokerewired.com";
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: config.TEST_DATABASE_URL });
+    const app = await createApp();
+    agent = supertest.agent(app);
+  });
+
+  afterAll(async () => {
+    if (pool) await pool.end();
+  });
+
+  const setUpCampaign = async (client: PoolClient) => {
+    const { organization } = await createOrgAndSession(client, {
+      agent,
+      role: UserRoleType.OWNER
+    });
+    const campaign = await createCampaign(client, {
+      organizationId: organization.id
+    });
+    await Promise.all(
+      [...new Array(10)].map(() =>
+        createCampaignContact(client, { campaignId: campaign.id })
+      )
+    );
+    return campaign;
+  };
+
+  it("notifies when contacts exceed threshold", async () => {
+    await withClient(pool, async (client) => {
+      const campaign = await setUpCampaign(client);
+
+      let wasCalled = false;
+
+      nock(TEST_WEBHOOK_URL)
+        .post("/webhook")
+        .reply(200, () => {
+          wasCalled = true;
+        });
+
+      await notifyLargeCampaignEvent(
+        campaign.id,
+        "upload",
+        5,
+        `${TEST_WEBHOOK_URL}/webhook`
+      );
+
+      expect(wasCalled).toBe(true);
+      expect(nock.isDone()).toBe(true);
+    });
+  });
+
+  it("does not notify when contacts do not exceed threshold", async () => {
+    await withClient(pool, async (client) => {
+      const campaign = await setUpCampaign(client);
+
+      let wasCalled = false;
+
+      const nockScope = nock(TEST_WEBHOOK_URL)
+        .post("/webhook")
+        .reply(200, () => {
+          wasCalled = true;
+        });
+
+      await notifyLargeCampaignEvent(
+        campaign.id,
+        "upload",
+        15,
+        `${TEST_WEBHOOK_URL}/webhook`
+      );
+
+      expect(wasCalled).toBe(false);
+      expect(nockScope.isDone()).toBe(false);
+      expect(nock.isDone()).toBe(false);
+      nock.cleanAll();
+    });
+  });
+});

--- a/src/server/api/lib/alerts.ts
+++ b/src/server/api/lib/alerts.ts
@@ -215,7 +215,7 @@ export async function notifyLargeCampaignEvent(
   const campaignInfo = await r
     .knex("campaign")
     .join("organization", "organization.id", "=", "campaign.organization_id")
-    .where({ id: campaignId })
+    .where({ "campaign.id": campaignId })
     .first([
       "organization.id as org_id",
       "organization.name as org_name",

--- a/src/server/api/lib/alerts.ts
+++ b/src/server/api/lib/alerts.ts
@@ -203,9 +203,11 @@ export async function notifyOnTagConversation(
     )
   );
 }
+
 export async function notifyLargeCampaignEvent(
   campaignId: number,
   event: "upload" | "start",
+  threshold = config.LARGE_CAMPAIGN_THRESHOLD,
   url = config.LARGE_CAMPAIGN_WEBHOOK
 ) {
   if (!url) return;
@@ -226,7 +228,7 @@ export async function notifyLargeCampaignEvent(
     .where({ campaign_id: campaignId })
     .count("id");
 
-  if (count < config.LARGE_CAMPAIGN_THRESHOLD) return;
+  if (count < threshold) return;
 
   const payload = {
     instance: config.BASE_URL,

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -76,7 +76,11 @@ import { resolvers as externalSyncConfigResolvers } from "./external-sync-config
 import { resolvers as externalSystemResolvers } from "./external-system";
 import { resolvers as interactionStepResolvers } from "./interaction-step";
 import { resolvers as inviteResolvers } from "./invite";
-import { notifyAssignmentCreated, notifyOnTagConversation } from "./lib/alerts";
+import {
+  notifyAssignmentCreated,
+  notifyLargeCampaignEvent,
+  notifyOnTagConversation
+} from "./lib/alerts";
 import { getStepsToUpdate } from "./lib/bulk-script-editor";
 import { copyCampaign, editCampaign } from "./lib/campaign";
 import { saveNewIncomingMessage } from "./lib/message-sending";
@@ -1021,10 +1025,13 @@ const rootMutations = {
         .where({ id })
         .returning("*");
 
-      await sendUserNotification({
-        type: Notifications.CAMPAIGN_STARTED,
-        campaignId: id
-      });
+      await Promise.all([
+        sendUserNotification({
+          type: Notifications.CAMPAIGN_STARTED,
+          campaignId: id
+        }),
+        notifyLargeCampaignEvent(id, "start")
+      ]);
 
       return campaign;
     },

--- a/src/server/tasks/ngp-van/van-fetch-saved-list.ts
+++ b/src/server/tasks/ngp-van/van-fetch-saved-list.ts
@@ -7,6 +7,7 @@ import type { SuperAgentRequest } from "superagent";
 import { get, post } from "superagent";
 
 import { config } from "../../../config";
+import { notifyLargeCampaignEvent } from "../../api/lib/alerts";
 import type { VanSecretAuthPayload } from "../../lib/external-systems";
 import { withVan } from "../../lib/external-systems";
 import { withTransaction } from "../../utils";
@@ -168,6 +169,9 @@ interface FetchSavedListsPayload extends VanSecretAuthPayload {
   column_config: ColumnConfig;
   first_n_rows: number;
   extract_phone_type: VanPhoneType | null;
+  __context: {
+    campaign_id: number;
+  };
 }
 
 export const fetchSavedList: Task = async (
@@ -244,4 +248,6 @@ export const fetchSavedList: Task = async (
   });
 
   await handleResult(helpers, payload, {});
+
+  await notifyLargeCampaignEvent(payload.__context.campaign_id, "upload");
 };

--- a/src/workers/jobs/index.js
+++ b/src/workers/jobs/index.js
@@ -7,6 +7,7 @@ import { gunzip } from "../../lib";
 import { getFormattedPhoneNumber } from "../../lib/phone-format";
 import { isValidTimezone } from "../../lib/tz-helpers";
 import logger from "../../logger";
+import { notifyLargeCampaignEvent } from "../../server/api/lib/alerts";
 import {
   assignMissingMessagingServices,
   // eslint-disable-next-line import/named
@@ -351,6 +352,8 @@ export async function uploadContacts(job) {
       .update({ result_message: message });
   }
 
+  await notifyLargeCampaignEvent(campaignId, "upload");
+
   await cacheableData.campaign.reload(campaignId);
 }
 
@@ -555,6 +558,7 @@ export async function loadContactsFromDataWarehouseFragment(jobEvent) {
         });
     }
     await r.knex("job_request").where({ id: jobEvent.jobId }).del();
+    await notifyLargeCampaignEvent(jobEvent.campaignId, "upload");
     await cacheableData.campaign.reload(jobEvent.campaignId);
     return { completed: 1, validationStats };
   } else if (jobEvent.part < jobEvent.totalParts - 1) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19553,6 +19553,16 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
+nock@^13.2.9:
+  version "13.2.9"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.2.9.tgz#4faf6c28175d36044da4cfa68e33e5a15086ad4c"
+  integrity sha512-1+XfJNYF1cjGB+TKMWi29eZ0b82QOvQs2YoLNzbpWGqFMtRQHTa57osqdGj4FrFPgkO4D4AZinzUJR9VvW3QUA==
+  dependencies:
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.21"
+    propagate "^2.0.0"
+
 node-cron@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/node-cron/-/node-cron-2.0.3.tgz#b9649784d0d6c00758410eef22fa54a10e3f602d"
@@ -21873,6 +21883,11 @@ prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8,
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
+
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 property-expr@^2.0.2, property-expr@^2.0.4:
   version "2.0.4"


### PR DESCRIPTION
## Description

This adds support for sending webhooks when a large number of contacts are uploaded or a large campaign is started.

## Motivation and Context

Closes #1405.

This depends on bringing VAN list import into Spoke Rewired in #1403.

## How Has This Been Tested?

See `alert.spec.ts`.

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202924564824464