### PR TITLE
fix(export-campaign): allow null campaign variables

### DIFF
--- a/src/server/tasks/export-campaign.ts
+++ b/src/server/tasks/export-campaign.ts
@@ -353,11 +353,12 @@ export const processMessagesChunk = async (
   lastContactId = rows[rows.length - 1].campaign_contact_id;
 
   const campaignVariableColumns = (message: MessageExportRow) =>
-    campaignVariableNames.reduce<Record<string, string>>(
+    campaignVariableNames.reduce<Record<string, string | null>>(
       (acc, variableName) => ({
         ...acc,
-        [`campaignVariable[${variableName}]`]:
-          message.campaign_variables[variableName] ?? null
+        [`campaignVariable[${variableName}]`]: message.campaign_variables
+          ? message.campaign_variables[variableName] ?? null
+          : null
       }),
       {}
     );


### PR DESCRIPTION
## Description

Allow exports to work if `message.campaign_variables` is null, which appears to be the case if the message is a freely typed reply.

## Motivation and Context

We're getting the following error in the wild uncertain conditions:
```
Failed task 179536 (export-campaign) with error Cannot read properties of null (reading 'redacted') (196.36ms):
  TypeError: Cannot read properties of null (reading 'redacted')
      at /usr/Spoke/build/src/server/tasks/export-campaign.js:410:201
      at Array.reduce (<anonymous>)
      at campaignVariableColumns (/usr/Spoke/build/src/server/tasks/export-campaign.js:407:69)
      at /usr/Spoke/build/src/server/tasks/export-campaign.js:431:18
      at Array.map (<anonymous>)
      at _callee4$ (/usr/Spoke/build/src/server/tasks/export-campaign.js:414:51)
      at tryCatch (/usr/Spoke/node_modules/@babel/runtime-corejs3/node_modules/regenerator-runtime/runtime.js:45:40)
      at Generator.invoke [as _invoke] (/usr/Spoke/node_modules/@babel/runtime-corejs3/node_modules/regenerator-runtime/runtime.js:274:22)
      at Generator.prototype.<computed> [as next] (/usr/Spoke/node_modules/@babel/runtime-corejs3/node_modules/regenerator-runtime/runtime.js:97:21)
      at asyncGeneratorStep (/usr/Spoke/node_modules/@babel/runtime-corejs3/helpers/asyncToGenerator.js:5:24)
      at _next (/usr/Spoke/node_modules/@babel/runtime-corejs3/helpers/asyncToGenerator.js:27:9)
```

Closes #1432.

## How Has This Been Tested?

Not yet tested
