### PR TITLE
fix: add additional common stop phrases

### DIFF
--- a/src/server/api/lib/message-sending.js
+++ b/src/server/api/lib/message-sending.js
@@ -22,7 +22,13 @@ const OPT_OUT_TRIGGERS = [
   "unsubscribe",
   "cancel",
   "end",
-  "quit"
+  "quit",
+  "stop2quit",
+  "stop 2 quit",
+  "stop=quit",
+  "stop = quit",
+  "stop to quit",
+  "stoptoquit"
 ];
 
 /**


### PR DESCRIPTION
## Description

Add more common stop phrases to the list of auto-opt-out phrases.

## Motivation and Context

This increases the amount of replies that can be handled automatically and leads to better user experience.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

N/A

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

Do we have a knowledge base article on these, @politics-rewired/organizing?

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
