### PR TITLE
feat(script editor): add opt out language warning

### DIFF
--- a/src/components/ScriptEditor.tsx
+++ b/src/components/ScriptEditor.tsx
@@ -119,6 +119,7 @@ interface Props {
   scriptText: string;
   scriptFields: string[];
   campaignVariables: CampaignVariable[];
+  isRootStep: boolean;
   integrationSourced: boolean;
   onChange: (value: string) => Promise<void> | void;
   receiveFocus?: boolean;
@@ -320,6 +321,34 @@ class ScriptEditor extends React.Component<Props, State> {
     }
   }
 
+  renderOptOutLanguageWarning() {
+    const text = this.state.editorState
+      .getCurrentContent()
+      .getPlainText()
+      .toLowerCase();
+
+    // 2022-09-24 - stop as a separate word is best for avoiding spam blocks
+    if (this.props.isRootStep && text.length > 0 && !text.includes(" stop "))
+      return (
+        <div style={{ color: baseTheme.colors.red }}>
+          <br />
+          WARNING! This script does not include opt out language. You must let
+          the recipient know they can opt out of receiving future texts, or your
+          messages are very likely to be blocked as spam. We recommend a phrase
+          with the individual word STOP, such as "Reply STOP to quit." Please
+          see our{" "}
+          <a
+            href="https://docs.spokerewired.com/article/168-spoke-101-tips-for-a-successful-mass-text"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            deliverability checklist
+          </a>{" "}
+          for other best practices for improving deliverability.
+        </div>
+      );
+  }
+
   renderCustomFields() {
     const { scriptFields, campaignVariables } = this.props;
     return (
@@ -376,6 +405,7 @@ class ScriptEditor extends React.Component<Props, State> {
         {this.renderCustomFields()}
         <div>
           {this.renderAttachmentWarning()}
+          {this.renderOptOutLanguageWarning()}
           <br />
           Estimated Segments: {info.msgCount} <br />
           Characters left in current segment:{" "}

--- a/src/components/forms/GSScriptOptionsField.jsx
+++ b/src/components/forms/GSScriptOptionsField.jsx
@@ -96,6 +96,7 @@ class GSScriptOptionsField extends GSFormField {
       name,
       customFields,
       campaignVariables,
+      isRootStep,
       value: scriptVersions,
       integrationSourced,
       orgSettings
@@ -154,6 +155,7 @@ class GSScriptOptionsField extends GSFormField {
             scriptFields={scriptFields}
             campaignVariables={campaignVariables}
             integrationSourced={integrationSourced}
+            isRootStep={isRootStep}
             receiveFocus
             expandable
             onChange={(val) => this.setState({ scriptDraft: val.trim() })}
@@ -230,6 +232,7 @@ GSScriptOptionsField.propTypes = {
       value: PropTypes.string
     })
   ).isRequired,
+  isRootStep: PropTypes.bool.isRequired,
   name: PropTypes.string,
   className: PropTypes.string,
   hintText: PropTypes.string,

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/components/InteractionStepCard.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/components/InteractionStepCard.tsx
@@ -245,6 +245,7 @@ export const InteractionStepCard: React.FC<Props> = (props) => {
               hintText="This is what your texters will send to your contacts. E.g. Hi, {firstName}. It's {texterFirstName} here."
               customFields={customFields}
               campaignVariables={campaignVariables}
+              isRootStep={isRootStep}
               integrationSourced={integrationSourced}
               fullWidth
               multiLine


### PR DESCRIPTION
## Description
This adds a warning for including opt out language when users are editing initial messages.
## Motivation and Context
Closes #1433 

## How Has This Been Tested?
This has been tested locally.

## Screenshots (if appropriate):
<table>
<tr>
<th>Bad MMS attachment without good opt out language</th>
<th>Bad MMS attachment with good opt out language </th>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/76596635/192122226-8f8c325d-4199-42c5-91d4-c9c7a00776a0.png"/></td>
<td><img src="https://user-images.githubusercontent.com/76596635/192122228-1a7c94ef-6995-4d90-96fc-55b6e157ba46.png"/></td>
</tr>
</table>

## Documentation Changes


<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
