### PR TITLE
build(docker): specify platform explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### Dependency Cacher
 ### -------------------------
-FROM endeveit/docker-jq:latest as deps
+FROM --platform=linux/amd64 endeveit/docker-jq:latest as deps
 
 # To prevent cache invalidation from changes in fields other than dependencies
 # https://stackoverflow.com/a/59606373
@@ -10,7 +10,7 @@ RUN jq '{ dependencies, devDependencies, resolutions }' < /tmp/package.json > /t
 
 ### Fat Build
 ### -------------------------
-FROM node:16.14.0 AS builder
+FROM --platform=linux/amd64 node:16.14.0 AS builder
 
 WORKDIR /usr/Spoke
 
@@ -36,7 +36,7 @@ RUN yarn run build
 
 ### Slim Deploy
 ### -------------------------
-FROM node:16.14.0
+FROM --platform=linux/amd64 node:16.14.0
 
 WORKDIR /usr/Spoke
 


### PR DESCRIPTION
## Description

This ensures that we build for the `linux/amd64` platform without the need to pass the `--platform` option to `docker buildx build`.

## Motivation and Context

The Docker image is only being used on `linux/amd64` nodes in production so that is the only platform we care about currently. We did not need to specify the platform explicitly in the past as CI/CD and local builds were all happening on amd64 architectures. This is no longer the case as Apple M1 arm64 architectures are introduced into development workstations.

To avoid building an arm64 image that won't run in production we either need to remember to pass the `--platform amd64` option at build time or specify it in the Dockerfile. Specifying in the Dockerfile is less prone to error/forgetfulness.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
