### PR TITLE
fix: fix escalate badge count

### DIFF
--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -305,12 +305,11 @@ export const resolvers = {
 
       const countQuery = r
         .reader("campaign_contact")
-        .whereNull("assignment_id")
         .where({
           archived: false,
-          is_opted_out: false
+          is_opted_out: false,
+          message_status: "needsResponse"
         })
-        .whereNot({ message_status: "closed" })
         .whereExists(function subquery() {
           this.select("campaign_contact_tag.campaign_contact_id")
             .from("campaign_contact_tag")


### PR DESCRIPTION
## Description
This updates the escalate badge to reflect a count of escalated, unarchived, and not opted out contacts who need to be responded to.
## Motivation and Context
[Feedback](https://rewiredcoop.slack.com/archives/C02KUGHV6J3/p1664236210775349?thread_ts=1664233386.619739&cid=C02KUGHV6J3) from @politics-rewired/organizing that this is a more appropriate count of messages that need attention.

## How Has This Been Tested?
This has been tested locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
