### PR TITLE
fix: reset dialog values when submitting

### DIFF
--- a/src/containers/AdminOptOutList/components/PasteNumbersDialog.tsx
+++ b/src/containers/AdminOptOutList/components/PasteNumbersDialog.tsx
@@ -42,6 +42,7 @@ const PasteNumbersDialog: React.FC<PasteNumbersDialogProps> = ({
 
   const handleSubmit = () => {
     onSubmit({ numbersList: numbers });
+    setNumbers("");
     onClose();
   };
 

--- a/src/containers/AdminOptOutList/components/UploadCSVDialog.tsx
+++ b/src/containers/AdminOptOutList/components/UploadCSVDialog.tsx
@@ -49,6 +49,7 @@ const UploadCSVDialog: React.FC<UploadCSVDialogProps> = ({
 
   const handleSubmit = () => {
     onSubmit({ csvFile: file });
+    setFile(null);
     onClose();
   };
 

--- a/src/containers/AdminOptOutList/index.tsx
+++ b/src/containers/AdminOptOutList/index.tsx
@@ -43,7 +43,7 @@ const AdminOptOutList: React.FC = (props) => {
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
   const [dialogMode, setDialogMode] = useState<DialogMode>(DialogMode.None);
   const [snackbarOpen, setSnackbarOpen] = useState<boolean>(false);
-  const [showSection, setShowSection] = useState<boolean>(false);
+  const [showSection, setShowSection] = useState<boolean>(true);
   const [exportingOptOuts, setExportingOptOuts] = useState<boolean>(false);
   const [searchText, setSearchText] = React.useState("");
   const [selectedCampaignIds, setSelectedCampaignIds] = useState<Array<string>>(


### PR DESCRIPTION
## Description

In opt outs import/export, the dialog values don't reset. If page is open, opt ins are imported, and you go back to import more, it keeps the previous file / list of pasted numbers.

Also keep export opt outs section open by default 

## Motivation and Context

Feedback from Organizing team

## How Has This Been Tested?

Tested Locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
