### PR TITLE
feat: add database backed per organization autosending

### DIFF
--- a/__test__/testbed-preparation/core.ts
+++ b/__test__/testbed-preparation/core.ts
@@ -28,7 +28,11 @@ import {
 import type { HashedPassword } from "../../src/server/local-auth-helpers";
 
 export type CreateOrganizationOptions = Partial<
-  Pick<Organization, "name"> & { uuid: string; features: Record<string, any> }
+  Pick<Organization, "name"> & {
+    uuid: string;
+    features: Record<string, any>;
+    autosending_mps: number;
+  }
 >;
 
 export const createOrganization = async (
@@ -38,14 +42,15 @@ export const createOrganization = async (
   client
     .query<OrganizationRecord>(
       `
-        insert into organization (name, uuid, features)
-        values ($1, $2, $3)
+        insert into organization (name, uuid, features, autosending_mps)
+        values ($1, $2, $3, $4)
         returning *
       `,
       [
         options.name ?? faker.company.companyName(),
         options.uuid ?? faker.random.uuid(),
-        JSON.stringify(options.features ?? {})
+        JSON.stringify(options.features ?? {}),
+        options.autosending_mps || null
       ]
     )
     .then(({ rows: [organization] }) => organization);

--- a/migrations/20220930011755_add-organization-autosending-mps.js
+++ b/migrations/20220930011755_add-organization-autosending-mps.js
@@ -1,0 +1,11 @@
+exports.up = function (knex) {
+  return knex.schema.alterTable("organization", (table) => {
+    table.integer("autosending_mps");
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.alterTable("organization", (table) => {
+    table.dropColumn("autosending_mps");
+  });
+};

--- a/src/config.js
+++ b/src/config.js
@@ -115,10 +115,6 @@ const validators = {
     default: false,
     isClient: true
   }),
-  AUTOSEND_MESSAGES_PER_SECOND: num({
-    desc: "How many messages autosending should send per second",
-    default: 10
-  }),
   DISABLE_ASSIGNMENT_CASCADE: bool({
     desc:
       "Whether to just assign from 1 campaign rather than gathering from multiple to fulfill a request",

--- a/src/server/api/lib/autosend-initials.spec.ts
+++ b/src/server/api/lib/autosend-initials.spec.ts
@@ -27,7 +27,7 @@ describe("autosend initials mutations", () => {
     if (pool) await pool.end();
   });
 
-  it("creates queue-autosend-initials job on startAutsending", async () => {
+  it("creates queue-autosend-organization-initials job on startAutsending", async () => {
     const testbed = await withClient(pool, async (client) => {
       const { organization, user, cookies } = await createOrgAndSession(
         client,
@@ -83,14 +83,14 @@ describe("autosend initials mutations", () => {
       rows: [job]
     } = await pool.query(
       `select * from graphile_worker.jobs where task_identifier = $1`,
-      ["queue-autosend-initials"]
+      ["queue-autosend-organization-initials"]
     );
 
     expect(job).not.toBeUndefined();
 
     await pool.query(
       `delete from graphile_worker.jobs where task_identifier = $1`,
-      ["queue-autosend-initials"]
+      ["queue-autosend-organization-initials"]
     );
   });
 });

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1927,7 +1927,7 @@ const rootMutations = {
 
         const taskIdentifier = "queue-autosend-organization-initials";
         await trx.raw(
-          `select graphile_worker.add_job(1?, json_build_object('organization_id', 2?))`,
+          `select graphile_worker.add_job(?, json_build_object('organization_id', ?::text))`,
           [taskIdentifier, organizationId]
         );
 

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1927,7 +1927,7 @@ const rootMutations = {
 
         const taskIdentifier = "queue-autosend-organization-initials";
         await trx.raw(
-          `select graphile_worker.add_job(?, json_build_object('organization_id', ?))`,
+          `select graphile_worker.add_job(1?, json_build_object('organization_id', 2?))`,
           [taskIdentifier, organizationId]
         );
 

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1925,8 +1925,11 @@ const rootMutations = {
           .where({ id })
           .returning("*");
 
-        const taskIdentifier = "queue-autosend-initials";
-        await trx.raw(`select graphile_worker.add_job(?)`, [taskIdentifier]);
+        const taskIdentifier = "queue-autosend-organization-initials";
+        await trx.raw(
+          `select graphile_worker.add_job(?, json_build_object('organization_id', ?))`,
+          [taskIdentifier, organizationId]
+        );
 
         return updatedCampaign;
       });

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -37,6 +37,7 @@ import { addExportCampaign } from "../tasks/export-campaign";
 import { addExportForVan } from "../tasks/export-for-van";
 import { TASK_IDENTIFIER as exportOptOutsIdentifier } from "../tasks/export-opt-outs";
 import { addFilterLandlines } from "../tasks/filter-landlines";
+import { QUEUE_AUTOSEND_ORGANIZATION_INITIALS_TASK_IDENTIFIER } from "../tasks/queue-autosend-initials";
 import { errToObj } from "../utils";
 import { getWorker } from "../worker";
 import {
@@ -1925,11 +1926,11 @@ const rootMutations = {
           .where({ id })
           .returning("*");
 
-        const taskIdentifier = "queue-autosend-organization-initials";
-        await trx.raw(
-          `select graphile_worker.add_job(?, json_build_object('organization_id', ?::text))`,
-          [taskIdentifier, organizationId]
-        );
+        const taskIdentifier = QUEUE_AUTOSEND_ORGANIZATION_INITIALS_TASK_IDENTIFIER;
+        await trx.raw(`select graphile_worker.add_job(?, ?)`, [
+          taskIdentifier,
+          { organization_id: organizationId }
+        ]);
 
         return updatedCampaign;
       });

--- a/src/server/tasks/queue-autosend-initials.spec.ts
+++ b/src/server/tasks/queue-autosend-initials.spec.ts
@@ -18,7 +18,10 @@ import type {
   UserRecord
 } from "../api/types";
 import { withClient } from "../utils";
-import { queueAutoSendOrganizationInitials } from "./queue-autosend-initials";
+import {
+  QUEUE_AUTOSEND_ORGANIZATION_INITIALS_TASK_IDENTIFIER,
+  queueAutoSendOrganizationInitials
+} from "./queue-autosend-initials";
 
 describe("queue-autosend-organization-initials", () => {
   let pool: Pool;
@@ -32,7 +35,7 @@ describe("queue-autosend-organization-initials", () => {
     await withClient(pool, async (client) => {
       // Set up campaign contact
       texter = await createTexter(client, {});
-      organization = await createOrganization(client, {});
+      organization = await createOrganization(client, { autosending_mps: 5 });
     });
   });
 
@@ -126,14 +129,14 @@ describe("queue-autosend-organization-initials", () => {
       );
 
       await client.query(`select graphile_worker.add_job($1, $2)`, [
-        "queue-autosend-organization-initials",
+        QUEUE_AUTOSEND_ORGANIZATION_INITIALS_TASK_IDENTIFIER,
         { organization_id: organization.id }
       ]);
 
       await runTaskListOnce(
         workerOptions,
         {
-          "queue-autosend-organization-initials": queueAutoSendOrganizationInitials
+          [QUEUE_AUTOSEND_ORGANIZATION_INITIALS_TASK_IDENTIFIER]: queueAutoSendOrganizationInitials
         },
         client
       );
@@ -158,7 +161,12 @@ describe("queue-autosend-organization-initials", () => {
 
       await pool.query(
         `delete from graphile_worker.jobs where task_identifier = ANY($1)`,
-        [["queue-autosend-organization-initials", "retry-interaction-step"]]
+        [
+          [
+            QUEUE_AUTOSEND_ORGANIZATION_INITIALS_TASK_IDENTIFIER,
+            "retry-interaction-step"
+          ]
+        ]
       );
     });
   });
@@ -194,14 +202,14 @@ describe("queue-autosend-organization-initials", () => {
 
       const runQueueAutoSendInitials = async () => {
         await client.query(`select graphile_worker.add_job($1, $2)`, [
-          "queue-autosend-organization-initials",
+          QUEUE_AUTOSEND_ORGANIZATION_INITIALS_TASK_IDENTIFIER,
           { organization_id: organization.id }
         ]);
 
         await runTaskListOnce(
           workerOptions,
           {
-            "queue-autosend-organization-initials": queueAutoSendOrganizationInitials
+            [QUEUE_AUTOSEND_ORGANIZATION_INITIALS_TASK_IDENTIFIER]: queueAutoSendOrganizationInitials
           },
           client
         );
@@ -220,7 +228,12 @@ describe("queue-autosend-organization-initials", () => {
 
       await pool.query(
         `delete from graphile_worker.jobs where task_identifier = ANY($1)`,
-        [["queue-autosend-organization-initials", "retry-interaction-step"]]
+        [
+          [
+            QUEUE_AUTOSEND_ORGANIZATION_INITIALS_TASK_IDENTIFIER,
+            "retry-interaction-step"
+          ]
+        ]
       );
     });
   });

--- a/src/server/tasks/queue-autosend-initials.spec.ts
+++ b/src/server/tasks/queue-autosend-initials.spec.ts
@@ -65,10 +65,10 @@ describe("queue-autosend-organization-initials", () => {
         )
       );
 
-      await client.query(
-        `select graphile_worker.add_job($1, json_build_object('organization_id', $2))`,
-        ["queue-autosend-organization-initials", organization.id]
-      );
+      await client.query(`select graphile_worker.add_job($1, $2)`, [
+        "queue-autosend-organization-initials",
+        { organization_id: organization.id }
+      ]);
 
       await runTaskListOnce(
         workerOptions,
@@ -125,10 +125,10 @@ describe("queue-autosend-organization-initials", () => {
         )
       );
 
-      await client.query(
-        `select graphile_worker.add_job($1, json_build_object('organization_id', $2))`,
-        ["queue-autosend-organization-initials", organization.id]
-      );
+      await client.query(`select graphile_worker.add_job($1, $2)`, [
+        "queue-autosend-organization-initials",
+        { organization_id: organization.id }
+      ]);
 
       await runTaskListOnce(
         workerOptions,
@@ -193,10 +193,10 @@ describe("queue-autosend-organization-initials", () => {
       );
 
       const runQueueAutoSendInitials = async () => {
-        await client.query(
-          `select graphile_worker.add_job($1, json_build_object('organization_id', $2))`,
-          ["queue-autosend-organization-initials", organization.id]
-        );
+        await client.query(`select graphile_worker.add_job($1, $2)`, [
+          "queue-autosend-organization-initials",
+          { organization_id: organization.id }
+        ]);
 
         await runTaskListOnce(
           workerOptions,

--- a/src/server/tasks/queue-autosend-initials.spec.ts
+++ b/src/server/tasks/queue-autosend-initials.spec.ts
@@ -18,9 +18,9 @@ import type {
   UserRecord
 } from "../api/types";
 import { withClient } from "../utils";
-import queueAutoSendInitials from "./queue-autosend-initials";
+import { queueAutoSendOrganizationInitials } from "./queue-autosend-initials";
 
-describe("queue-autosend-initials", () => {
+describe("queue-autosend-organization-initials", () => {
   let pool: Pool;
   let workerOptions: WorkerOptions;
   let texter: UserRecord;
@@ -65,14 +65,15 @@ describe("queue-autosend-initials", () => {
         )
       );
 
-      await client.query(`select graphile_worker.add_job($1)`, [
-        "queue-autosend-initials"
-      ]);
+      await client.query(
+        `select graphile_worker.add_job($1, json_build_object('organization_id', $2))`,
+        ["queue-autosend-organization-initials", organization.id]
+      );
 
       await runTaskListOnce(
         workerOptions,
         {
-          "queue-autosend-initials": queueAutoSendInitials
+          "queue-autosend-organization-initials": queueAutoSendOrganizationInitials
         },
         client
       );
@@ -94,7 +95,7 @@ describe("queue-autosend-initials", () => {
 
       await pool.query(
         `delete from graphile_worker.jobs where task_identifier = ANY($1)`,
-        [["queue-autosend-initials", "retry-interaction-step"]]
+        [["queue-autosend-organization-initials", "retry-interaction-step"]]
       );
     });
   });
@@ -124,14 +125,15 @@ describe("queue-autosend-initials", () => {
         )
       );
 
-      await client.query(`select graphile_worker.add_job($1)`, [
-        "queue-autosend-initials"
-      ]);
+      await client.query(
+        `select graphile_worker.add_job($1, json_build_object('organization_id', $2))`,
+        ["queue-autosend-organization-initials", organization.id]
+      );
 
       await runTaskListOnce(
         workerOptions,
         {
-          "queue-autosend-initials": queueAutoSendInitials
+          "queue-autosend-organization-initials": queueAutoSendOrganizationInitials
         },
         client
       );
@@ -156,7 +158,7 @@ describe("queue-autosend-initials", () => {
 
       await pool.query(
         `delete from graphile_worker.jobs where task_identifier = ANY($1)`,
-        [["queue-autosend-initials", "retry-interaction-step"]]
+        [["queue-autosend-organization-initials", "retry-interaction-step"]]
       );
     });
   });
@@ -191,14 +193,15 @@ describe("queue-autosend-initials", () => {
       );
 
       const runQueueAutoSendInitials = async () => {
-        await client.query(`select graphile_worker.add_job($1)`, [
-          "queue-autosend-initials"
-        ]);
+        await client.query(
+          `select graphile_worker.add_job($1, json_build_object('organization_id', $2))`,
+          ["queue-autosend-organization-initials", organization.id]
+        );
 
         await runTaskListOnce(
           workerOptions,
           {
-            "queue-autosend-initials": queueAutoSendInitials
+            "queue-autosend-organization-initials": queueAutoSendOrganizationInitials
           },
           client
         );
@@ -217,7 +220,7 @@ describe("queue-autosend-initials", () => {
 
       await pool.query(
         `delete from graphile_worker.jobs where task_identifier = ANY($1)`,
-        [["queue-autosend-initials", "retry-interaction-step"]]
+        [["queue-autosend-organization-initials", "retry-interaction-step"]]
       );
     });
   });

--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -33,7 +33,10 @@ import {
   schedules as ngpVanSchedules,
   taskList as ngpVanTaskList
 } from "./tasks/ngp-van";
-import queueAutoSendInitials from "./tasks/queue-autosend-initials";
+import {
+  queueAutoSendInitials,
+  queueAutoSendOrganizationInitials
+} from "./tasks/queue-autosend-initials";
 import {
   queueDailyNotifications,
   queuePendingNotifications,
@@ -78,6 +81,7 @@ export const getWorker = async (attempt = 0): Promise<Runner> => {
     "send-notification-email": sendNotificationEmail,
     "send-notification-digest": sendNotificationDigestForUser,
     "queue-autosend-initials": queueAutoSendInitials,
+    "queue=autosend-organization-initials": queueAutoSendOrganizationInitials,
     [exportCampaignIdentifier]: wrapProgressTask(exportCampaign, {
       removeOnComplete: true
     }),

--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -34,6 +34,8 @@ import {
   taskList as ngpVanTaskList
 } from "./tasks/ngp-van";
 import {
+  QUEUE_AUTOSEND_INITIALS_TASK_IDENTIFIER,
+  QUEUE_AUTOSEND_ORGANIZATION_INITIALS_TASK_IDENTIFIER,
   queueAutoSendInitials,
   queueAutoSendOrganizationInitials
 } from "./tasks/queue-autosend-initials";
@@ -80,8 +82,10 @@ export const getWorker = async (attempt = 0): Promise<Runner> => {
     "queue-daily-notifications": queueDailyNotifications,
     "send-notification-email": sendNotificationEmail,
     "send-notification-digest": sendNotificationDigestForUser,
-    "queue-autosend-initials": queueAutoSendInitials,
-    "queue=autosend-organization-initials": queueAutoSendOrganizationInitials,
+    [QUEUE_AUTOSEND_INITIALS_TASK_IDENTIFIER]: queueAutoSendInitials,
+    // prettier and eslint are fighting here
+    // eslint-disable-next-line max-len
+    [QUEUE_AUTOSEND_ORGANIZATION_INITIALS_TASK_IDENTIFIER]: queueAutoSendOrganizationInitials,
     [exportCampaignIdentifier]: wrapProgressTask(exportCampaign, {
       removeOnComplete: true
     }),
@@ -159,8 +163,8 @@ export const getScheduler = async (attempt = 0): Promise<Scheduler> => {
 
   if (config.ENABLE_AUTOSENDING) {
     schedules.push({
-      name: "queue-autosend-initials",
-      taskIdentifier: "queue-autosend-initials",
+      name: QUEUE_AUTOSEND_INITIALS_TASK_IDENTIFIER,
+      taskIdentifier: QUEUE_AUTOSEND_INITIALS_TASK_IDENTIFIER,
       pattern: "*/1 * * * *",
       timeZone: config.TZ
     });


### PR DESCRIPTION
## Description

This PR does two things:
- Changes autosending speed to be controlled by a database column that lives on the organization table
- Allows multiple campaigns to concurrently autosend across multiple organizations

## Motivation and Context

This accomplishes the following:
- Makes 10DLC compliance easier, since you can send at 30/sec on multiple campaigns
- Makes it easier for texters to simultaneously handle replies across multiple campaigns instead of sequentially dealing with big reply backlogs

See: https://github.com/politics-rewired/Spoke/issues/1441

## How Has This Been Tested?

Test suite

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
