### PR TITLE
fix(bulk script editor): grammar and spelling

### DIFF
--- a/src/containers/AdminBulkScriptEditor/index.tsx
+++ b/src/containers/AdminBulkScriptEditor/index.tsx
@@ -231,9 +231,9 @@ const AdminBulkScriptEditor: React.FC = (props) => {
           onChange={handleChangeReplaceString}
         />
         <p style={{ fontStyle: "italic" }}>
-          Note: the text must be an exact match! For example, there a couple
-          apostraphe characters: <span style={styles.code}>'</span> vs{" "}
-          <span style={styles.code}>’</span> )
+          Note: the text must be an exact match! For example, there are a couple
+          apostrophe characters: <span style={styles.code}>'</span> vs{" "}
+          <span style={styles.code}>’</span>
         </p>
       </Paper>
       <Paper style={styles.paddedPaper}>


### PR DESCRIPTION
## Description

Fix spelling and grammar in the bulk script editor 

## Motivation and Context

Spelling errors are the leading cause of bad grammar, fix both so we can fix the symptom and the root causes. Fixes #1284 

## How Has This Been Tested?

Tested extensively locally. 

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->
<img width="710" alt="Screenshot 2022-10-05 at 2 48 51 PM" src="https://user-images.githubusercontent.com/367605/194026272-dea0441e-4326-4d0d-a2dd-6a72216fde77.png">

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
