### PR TITLE
fix: truncate day based on contact's timezone

### DIFF
--- a/src/server/tasks/ngp-van/sync-campaign-contact-to-van.ts
+++ b/src/server/tasks/ngp-van/sync-campaign-contact-to-van.ts
@@ -85,7 +85,13 @@ export const fetchCanvassResponses = async (
   client
     .query<CanvassResultRow>(
       `
-        with configured_response_values as (
+        with cc_timezone as (
+          select coalesce(cc.timezone, c.timezone) as timezone
+          from campaign_contact cc
+          join campaign c on c.id = cc.campaign_id
+          where cc.id = $1
+        ),
+        configured_response_values as (
           select
             qrc.id,
             question_response.created_at as canvassed_at
@@ -153,7 +159,7 @@ export const fetchCanvassResponses = async (
         ),
         first_message as (
           select
-            date_trunc('day', created_at) as canvassed_at,
+            date_trunc('day', created_at at time zone (select timezone from cc_timezone)) at time zone (select timezone from cc_timezone),
             '[]'::json as result_codes,
             '[]'::json as activist_codes,
             '[]'::json as response_options
@@ -166,7 +172,7 @@ export const fetchCanvassResponses = async (
         ),
         canvass_responses as (
           select
-            date_trunc('day', canvassed_at) as canvassed_at,
+            date_trunc('day', canvassed_at at time zone (select timezone from cc_timezone)) at time zone (select timezone from cc_timezone),
             array_to_json(array_remove(array_agg(result_code), null)) as result_codes,
             array_to_json(array_remove(array_agg(activist_code), null)) as activist_codes,
             array_to_json(array_remove(array_agg(response_option), null)) as response_options


### PR DESCRIPTION
## Description

This truncates the day in the contact's timezone rather than UTC.

## Motivation and Context

Truncating to the day in UTC means it will always sync as the day before (e.g. 8:00pm the day before in ET).

It may be worth releasing this as an intermediate to #1442. Or it may not!

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
