### PR TITLE
fix: fix autosending query parameter type error

### DIFF
--- a/src/server/tasks/queue-autosend-initials.ts
+++ b/src/server/tasks/queue-autosend-initials.ts
@@ -16,9 +16,9 @@ export const queueAutoSendInitials: Task = async (payload, helpers) => {
   await helpers.query(
     `
       select graphile_worker.add_job(
-        $1, 
+        $1::text,
         json_build_object('organization_id', organization.id),
-        job_key := format('%s|%s', $1, organization.id)
+        job_key := format('%s|%s', $1::text, organization.id)
       )
       from organization
       where autosending_mps is not null
@@ -205,7 +205,7 @@ export const queueAutoSendOrganizationInitials: Task = async (
     .map((campaign) => campaign.campaign_id);
 
   await helpers.query(
-    `update campaign set autosend_status = 'complete' where id = ANY($1)`,
+    `update campaign set autosend_status = 'complete' where id = ANY($1::integer[])`,
     [toMarkAsDoneSending]
   );
 };


### PR DESCRIPTION
## Description

This fixes a `could not determine data type of parameter $1` error in the `queue-autosend-initials` task.

## Motivation and Context

Regression introduced in #1446.

Full error:

```
5:02:03 PM server.1         |  {"level":"error","message":"Failed task 373053 (queue-autosend-initials) with error could not determine data type of parameter $1 (7.95ms):\n  error: could not determine data type
5:02:03 PM server.1         |  >  of parameter $1\n      at Parser.parseErrorMessage (/Users/bchrobot/rewired/oss/spoke/node_modules/pg-protocol/src/parser.ts:369:69)\n      at Parser.handlePacket (/Users/bchrobot/
5:02:03 PM server.1         |  >  rewired/oss/spoke/node_modules/pg-protocol/src/parser.ts:188:21)\n      at Parser.parse (/Users/bchrobot/rewired/oss/spoke/node_modules/pg-protocol/src/parser.ts:103:30)\n      at
5:02:03 PM server.1         |  >  Socket.<anonymous> (/Users/bchrobot/rewired/oss/spoke/node_modules/pg-protocol/src/index.ts:7:48)\n      at Socket.emit (node:events:520:28)\n      at Socket.emit (node:domain:475:
5:02:03 PM server.1         |  >  12)\n      at addChunk (node:internal/streams/readable:315:12)\n      at readableAddChunk (node:internal/streams/readable:289:9)\n      at Socket.Readable.push (node:internal/strea
5:02:03 PM server.1         |  >  ms/readable:228:10)\n      at TCP.onStreamRead (node:internal/stream_base_commons:190:23)","failure":true,"job":{"id":"373053","queue_name":"37a30daf-4afb-4f34-86a6-e6b7161bbeb9","
5:02:03 PM server.1         |  >  task_identifier":"queue-autosend-initials","payload":{"fireDate":"2022-10-05T17:02:00-04:00"},"priority":0,"run_at":"2022-10-05T21:02:02.897Z","attempts":2,"max_attempts":25,"last_
5:02:03 PM server.1         |  >  error":"could not determine data type of parameter $1","created_at":"2022-10-05T21:01:36.911Z","updated_at":"2022-10-05T21:02:03.219Z","key":null,"locked_at":"2022-10-05T21:02:03.2
5:02:03 PM server.1         |  >  19Z","locked_by":"worker-9c08bf0baa2e420137","revision":0,"flags":null},"error":{"length":133,"name":"error","severity":"ERROR","code":"42P08","position":"151","file":"parse_param.
5:02:03 PM server.1         |  >  c","line":"315","routine":"check_parameter_resolution_walker"},"duration":7.945625,"label":"worker","workerId":"worker-9c08bf0baa2e420137","timestamp":"2022-10-05T21:02:03.233Z"}
```

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
