### PR TITLE
fix: restrict campaign templates to organization

### DIFF
--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -52,7 +52,10 @@ export const resolvers = {
       await accessRequired(user, organization.id, "SUPERVOLUNTEER");
       const query = r
         .reader("all_campaign")
-        .where({ is_template: true })
+        .where({
+          organization_id: organization.id,
+          is_template: true
+        })
         .select("*");
       const pagerOptions = { first, after };
       return formatPage(query, pagerOptions);


### PR DESCRIPTION
## Description

This restricts campaign templates returned to the requested organization.

## Motivation and Context

Closes #1471.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203166788760492