### PR TITLE
fix(offline): add a link to the status page

### DIFF
--- a/src/client/offline.html
+++ b/src/client/offline.html
@@ -301,6 +301,10 @@
         <br>
         <div class="mui--text-body1">Please try reconnecting in a moment.</div>
         <br>
+        <div class="mui--text-body1">
+            If the problem persists, check <a href="https://status.spokerewired.com" target="_blank">https://status.spokerewired.com</a>.
+        </div>
+        <br />
         <button class="mui-btn mui-btn--raised btn-reload" onclick="window.location.reload()">Reconnect</button>
       </div>
     </div>


### PR DESCRIPTION
## Description

Add a link to the Spoke Rewired status page on the offline page.

## Motivation and Context

Closes #1476.

## How Has This Been Tested?

See screenshot below.

## Screenshots (if appropriate):

<img width="528" alt="Screenshot 2022-10-19 at 9 19 02 AM" src="https://user-images.githubusercontent.com/2145526/196702456-34090c23-4b1a-481d-beba-f319d1d8de57.png">

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203170942924118