### PR TITLE
perf: memoize deliverability stats

### DIFF
--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -704,10 +704,26 @@ export const resolvers = {
       return formatPage(query, { after, first, primaryColumn: "compound_id" });
     },
     deliverabilityStats: async (campaign, { filter }) => {
-      const stats = await getDeliverabilityStats(
-        parseInt(campaign.id, 10),
-        filter
+      // Wrapper to manage memoizer arg format
+      const doGetDeliverabilityStats = async (opts) => {
+        const { campaignId, initialMessagesOnly } = opts;
+        const deliverabilityStats = await getDeliverabilityStats(campaignId, {
+          initialMessagesOnly
+        });
+        return deliverabilityStats;
+      };
+
+      const memoizer = await MemoizeHelper.getMemoizer();
+      const memoizedDeliverabilityStats = memoizer.memoize(
+        doGetDeliverabilityStats,
+        cacheOpts.DeliverabilityStats
       );
+
+      const stats = await memoizedDeliverabilityStats({
+        campaignId: parseInt(campaign.id, 10),
+        initialMessagesOnly: filter.initialMessagesOnly
+      });
+
       return stats;
     },
     campaignGroups: async (campaign, { after, first }, { user }) => {

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -721,7 +721,7 @@ export const resolvers = {
 
       const stats = await memoizedDeliverabilityStats({
         campaignId: parseInt(campaign.id, 10),
-        initialMessagesOnly: filter.initialMessagesOnly
+        initialMessagesOnly: filter?.initialMessagesOnly
       });
 
       return stats;

--- a/src/server/memoredis.ts
+++ b/src/server/memoredis.ts
@@ -123,7 +123,8 @@ export const cacheOpts: Record<string, CacheOpt> = {
   CountNeedsMessageContacts: {
     key: "count-needs-message-contacts",
     ttl: ONE_MINUTE
-  }
+  },
+  DeliverabilityStats: { key: "campaign-deliverability-stats", ttl: ONE_MINUTE }
 };
 
 export default MemoizeHelper;


### PR DESCRIPTION
## Description

Add caching for campaign deliverability stats.

## Motivation and Context

getDeliverabilityStats was responsible for ~24% of CPU time on large clients.

## How Has This Been Tested?

This has been tested locally and in production.

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
