### PR TITLE
fix: skip queuing organizations with 0 mps

### DIFF
--- a/src/server/tasks/queue-autosend-initials.ts
+++ b/src/server/tasks/queue-autosend-initials.ts
@@ -20,7 +20,9 @@ export const queueAutoSendInitials: Task = async (payload, helpers) => {
         job_key := format('%s|%s', $1::text, organization.id)
       )
       from organization
-      where autosending_mps is not null
+      where true
+        and autosending_mps is not null
+        and autosending_mps > 0
     `,
     [QUEUE_AUTOSEND_ORGANIZATION_INITIALS_TASK_IDENTIFIER]
   );


### PR DESCRIPTION
## Description

Skip queuing organizations with MPS = 0.

## Motivation and Context

Checking for `null` is not enough. Queueing 0 MPS orgs floods logs with:

```
Failed task 824046982 (queue-autosend-organization-initials) with error queueAutoSendInitials was queued for organization 858 but autosending_mps is 0 (1.81ms):
  Error: queueAutoSendInitials was queued for organization 858 but autosending_mps is 0
      at _callee2$ (/usr/Spoke/build/src/server/tasks/queue-autosend-initials.js:83:19)
      at tryCatch (/usr/Spoke/node_modules/@babel/runtime-corejs3/node_modules/regenerator-runtime/runtime.js:45:40)
      at Generator.invoke [as _invoke] (/usr/Spoke/node_modules/@babel/runtime-corejs3/node_modules/regenerator-runtime/runtime.js:274:22)
      at Generator.prototype.<computed> [as next] (/usr/Spoke/node_modules/@babel/runtime-corejs3/node_modules/regenerator-runtime/runtime.js:97:21)
      at asyncGeneratorStep (/usr/Spoke/node_modules/@babel/runtime-corejs3/helpers/asyncToGenerator.js:5:24)
      at _next (/usr/Spoke/node_modules/@babel/runtime-corejs3/helpers/asyncToGenerator.js:27:9)
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
