### PR TITLE
fix: handle case where underlying assignment no longer exists

### DIFF
--- a/src/server/api/notification.ts
+++ b/src/server/api/notification.ts
@@ -1,6 +1,7 @@
 import groupBy from "lodash/groupBy";
 
 import { config } from "../../config";
+import NotificationMissingAssignmentError from "../errors/NotificationMissingAssignmentError";
 import getDigestContent from "../lib/templates/digest";
 import getNotificationContent from "../lib/templates/notification";
 import { r } from "../models";
@@ -50,6 +51,11 @@ export const getSingleNotificationContent = async (
       campaign_id: notification.campaign_id
     })
     .first();
+
+  if (!assignment) {
+    throw new NotificationMissingAssignmentError(notification.id);
+  }
+
   const { count: assignmentCount } = await r
     .knex("campaign_contact")
     .where({ campaign_id: campaign.id, assignment_id: assignment.id })

--- a/src/server/errors/NotificationMissingAssignmentError.ts
+++ b/src/server/errors/NotificationMissingAssignmentError.ts
@@ -1,0 +1,10 @@
+export class NotificationMissingAssignmentError extends Error {
+  readonly notificationId: number;
+
+  constructor(notificationId: number) {
+    super(`Notification ${notificationId} missing an assignment`);
+    this.notificationId = notificationId;
+  }
+}
+
+export default NotificationMissingAssignmentError;


### PR DESCRIPTION
## Description

This adds an early return when the underlying assignment for an `AssignmentCreated` notification no longer exists.

## Motivation and Context

Defensive fix for #1447.

Closes #1447.

## How Has This Been Tested?

No reproduction steps for original issue so this is purely defensive.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
