### PR TITLE
fix(autosending): prevent "Queue" user action for orgs without mps

### DIFF
--- a/src/server/api/lib/autosend-initials.spec.ts
+++ b/src/server/api/lib/autosend-initials.spec.ts
@@ -33,7 +33,8 @@ describe("autosend initials mutations", () => {
         client,
         {
           agent,
-          role: UserRoleType.OWNER
+          role: UserRoleType.OWNER,
+          orgOptions: { autosending_mps: 30 }
         }
       );
       const campaign = await createCampaign(client, {

--- a/src/server/api/lib/autosend-initials.spec.ts
+++ b/src/server/api/lib/autosend-initials.spec.ts
@@ -3,6 +3,7 @@ import {
   createCampaignContact
 } from "__test__/testbed-preparation/core";
 import type { campaign as CampaignRecord } from "@spoke/spoke-codegen";
+import type { PoolClient } from "pg";
 import { Pool } from "pg";
 import { UserRoleType } from "src/api/organization-membership";
 import supertest from "supertest";
@@ -12,6 +13,56 @@ import { config } from "../../../config";
 import { createApp } from "../../app";
 import { withClient } from "../../utils";
 import { MessageStatusType } from "../types";
+
+const createTestBed = async (
+  client: PoolClient,
+  agent: supertest.SuperAgentTest,
+  opts?: { mps?: number }
+) => {
+  const { organization, user, cookies } = await createOrgAndSession(client, {
+    agent,
+    role: UserRoleType.OWNER,
+    ...(opts?.mps !== undefined
+      ? { orgOptions: { autosending_mps: opts.mps } }
+      : {})
+  });
+  const campaign = await createCampaign(client, {
+    organizationId: organization.id,
+    isStarted: true
+  });
+  await Promise.all(
+    [...Array(5)].map(() =>
+      createCampaignContact(client, {
+        campaignId: campaign.id,
+        messageStatus: MessageStatusType.NeedsMessage
+      })
+    )
+  );
+  return { organization, user, cookies, campaign };
+};
+
+const queueCampaign = async (
+  agent: supertest.SuperAgentTest,
+  cookies: Record<string, string>,
+  campaignId: number
+) =>
+  agent
+    .post(`/graphql`)
+    .set(cookies)
+    .send({
+      operationName: "StartAutosending",
+      variables: {
+        campaignId: `${campaignId}`
+      },
+      query: `
+        mutation StartAutosending($campaignId: String!) {
+          startAutosending(campaignId: $campaignId) {
+            id
+            autosendStatus
+          }
+        }
+      `
+    });
 
 describe("autosend initials mutations", () => {
   let pool: Pool;
@@ -29,46 +80,10 @@ describe("autosend initials mutations", () => {
 
   it("creates queue-autosend-organization-initials job on startAutsending", async () => {
     const testbed = await withClient(pool, async (client) => {
-      const { organization, user, cookies } = await createOrgAndSession(
-        client,
-        {
-          agent,
-          role: UserRoleType.OWNER,
-          orgOptions: { autosending_mps: 30 }
-        }
-      );
-      const campaign = await createCampaign(client, {
-        organizationId: organization.id,
-        isStarted: true
-      });
-      await Promise.all(
-        [...Array(5)].map(() =>
-          createCampaignContact(client, {
-            campaignId: campaign.id,
-            messageStatus: MessageStatusType.NeedsMessage
-          })
-        )
-      );
-      return { organization, user, cookies, campaign };
+      return createTestBed(client, agent, { mps: 30 });
     });
 
-    await agent
-      .post(`/graphql`)
-      .set(testbed.cookies)
-      .send({
-        operationName: "StartAutosending",
-        variables: {
-          campaignId: `${testbed.campaign.id}`
-        },
-        query: `
-          mutation StartAutosending($campaignId: String!) {
-            startAutosending(campaignId: $campaignId) {
-              id
-              autosendStatus
-            }
-          }
-        `
-      });
+    await queueCampaign(agent, testbed.cookies, testbed.campaign.id);
 
     const {
       rows: [campaign]


### PR DESCRIPTION
## Description

Prevent queuing autosending for an organization that does not have an assigned autosending MPS.

## Motivation and Context

Cleaner logs.

This is a safety for the UI-only fix in #1479.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<img width="598" alt="Screenshot 2022-10-22 at 11 46 08 PM" src="https://user-images.githubusercontent.com/2145526/197373022-a412a67d-b715-403d-a38b-d9369a9f6039.png">

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
