### PR TITLE
perf: update fillfactor to reasonable value

### DIFF
--- a/migrations/20221023123523_update-fillfactors.js
+++ b/migrations/20221023123523_update-fillfactors.js
@@ -1,0 +1,21 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function up(knex) {
+  return knex.schema.raw(`
+    alter table public.message set (fillfactor = 85);
+    alter table public.campaign_contact set (fillfactor = 85);
+  `);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function down(knex) {
+  return knex.schema.raw(`
+    alter table public.campaign_contact set (fillfactor = 50);
+    alter table public.message set (fillfactor = 50);
+  `);
+};

--- a/schema-dump.sql
+++ b/schema-dump.sql
@@ -1514,7 +1514,7 @@ CREATE TABLE public.campaign_contact (
     archived boolean DEFAULT false,
     CONSTRAINT campaign_contact_message_status_check CHECK ((message_status = ANY (ARRAY['needsMessage'::text, 'needsResponse'::text, 'convo'::text, 'messaged'::text, 'closed'::text, 'UPDATING'::text])))
 )
-WITH (autovacuum_vacuum_scale_factor='0', autovacuum_vacuum_threshold='20000', fillfactor='50');
+WITH (autovacuum_vacuum_scale_factor='0', autovacuum_vacuum_threshold='20000', fillfactor='85');
 
 
 ALTER TABLE public.campaign_contact OWNER TO postgres;
@@ -2737,7 +2737,7 @@ CREATE TABLE public.message (
     campaign_variable_ids integer[] DEFAULT '{}'::integer[] NOT NULL,
     CONSTRAINT message_send_status_check CHECK ((send_status = ANY (ARRAY['QUEUED'::text, 'SENDING'::text, 'SENT'::text, 'DELIVERED'::text, 'ERROR'::text, 'PAUSED'::text, 'NOT_ATTEMPTED'::text])))
 )
-WITH (autovacuum_vacuum_scale_factor='0', autovacuum_vacuum_threshold='20000', fillfactor='50');
+WITH (autovacuum_vacuum_scale_factor='0', autovacuum_vacuum_threshold='20000', fillfactor='85');
 
 
 ALTER TABLE public.message OWNER TO postgres;


### PR DESCRIPTION
## Description

This sets the to a more reasonable value for our workloads.

## Motivation and Context

From the [manual](https://www.postgresql.org/docs/14/sql-createtable.html#SQL-CREATETABLE-STORAGE-PARAMETERS):

> `fillfactor` (integer)
>
> The fillfactor for a table is a percentage between 10 and 100. 100 (complete packing) is the default. When a smaller fillfactor is specified, INSERT operations pack table pages only to the indicated percentage; the remaining space on each page is reserved for updating rows on that page. This gives UPDATE a chance to place the updated copy of a row on the same page as the original, which is more efficient than placing it on a different page. For a table whose entries are never updated, complete packing is the best choice, but in heavily updated tables smaller fillfactors are appropriate. This parameter cannot be set for TOAST tables.

We previously understood correct tuning of fillfactor to be a based on how many updates the row was expected to have. campaign_contact and message are both update quite frequently and often in quick succession (e.g. SENT, SENDING, DELIVERED). Thus a fillfactor of 50 made sense: there would always be room in the same page to write a new version of the row.

However, we are generally not performing bulk updates in a transaction (admin operations for campaign_contact aside) and have very aggressive autovacuum settings. This means that there is plenty of opportunity between updates for autovacuum to reclaim page space and a fillfactor of 50 is unnecessary and only serves to slow down read workloads.

Updates to these tables are always to indexed columns so we will never see the benefits of heap-only tuple (HOT) updates which is where fillfactor really shines [[1](https://www.adyen.com/blog/postgresql-hot-updates), [2](https://youtu.be/B6IiuJRXw_E)] but there is still value to keeping tuples on the same page during updates to indexed columns [[3](https://stackoverflow.com/a/39148044)].

Increasing fillfactor also decreases the amount of work autovacuum has to do as there are fewer pages it has to scan [[4](https://www.cybertec-postgresql.com/en/what-is-fillfactor-and-how-does-it-affect-postgresql-performance/)].

## How Has This Been Tested?

This has not been tested.

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
