### PR TITLE
feat: upgrade connect-datadog-graphql

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "camelcase-keys": "^4.1.0",
     "chart.js": "^2.9.4",
     "clsx": "^1.2.1",
-    "connect-datadog-graphql": "^0.0.11",
+    "connect-datadog-graphql": "^0.0.13",
     "connect-pg-simple": "^7.0.0",
     "cors": "^2.8.5",
     "cryptr": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "camelcase-keys": "^4.1.0",
     "chart.js": "^2.9.4",
     "clsx": "^1.2.1",
-    "connect-datadog-graphql": "^0.0.13",
+    "connect-datadog-graphql": "^1.0.0",
     "connect-pg-simple": "^7.0.0",
     "cors": "^2.8.5",
     "cryptr": "^6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9954,13 +9954,12 @@ confusing-browser-globals@^1.0.10:
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz#30d1e7f3d1b882b25ec4933d1d1adac353d20a59"
   integrity sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==
 
-connect-datadog-graphql@^0.0.11:
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/connect-datadog-graphql/-/connect-datadog-graphql-0.0.11.tgz#10043e0079c4b5f3cc369ce82b586a38b9dff3f2"
-  integrity sha512-NXowBZkLeCkdnUYUeQM5YpEQW74Kg57vcPjHAd9tfeM9/Taf6paNfkpOO1im3wxnBk+MDyVobgI1vLDzu0ncuw==
+connect-datadog-graphql@^0.0.13:
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/connect-datadog-graphql/-/connect-datadog-graphql-0.0.13.tgz#4a32dc5292f13fe6cf122f7188b2ac494c401e8b"
+  integrity sha512-rKFLDmNZglClbSxvmOW6PTrE4cxEzbu240c/7h9B7T3HSy6W52cbnQQf56y343AQrlqFF1ktJ8b5M2N0lFq02w==
   dependencies:
-    graphql "^14.4.2"
-    hot-shots "^6.3.0"
+    graphql "^15.1.0"
 
 connect-history-api-fallback@^1.6.0:
   version "1.6.0"
@@ -14455,14 +14454,7 @@ graphql-ws@^5.4.1:
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.3.0.tgz#a91e24d10babf9e60c706919bb182b53ccdffc05"
   integrity sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==
 
-graphql@^14.4.2:
-  version "14.6.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.6.0.tgz#57822297111e874ea12f5cd4419616930cd83e49"
-  integrity sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==
-  dependencies:
-    iterall "^1.2.2"
-
-graphql@^15.6.1:
+graphql@^15.1.0, graphql@^15.6.1:
   version "15.8.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.8.0.tgz#33410e96b012fa3bdb1091cc99a94769db212b38"
   integrity sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==
@@ -14782,13 +14774,6 @@ hosted-git-info@^2.1.4:
   version "2.8.5"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.5.tgz#759cfcf2c4d156ade59b0b2dfabddc42a6b9c70c"
   integrity sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==
-
-hot-shots@^6.3.0:
-  version "6.8.5"
-  resolved "https://registry.yarnpkg.com/hot-shots/-/hot-shots-6.8.5.tgz#fcd6676d68c5e105aa464caf6a59f11df1159b56"
-  integrity sha512-l+SeSK1eqmzDdWMMW5fBithdLDVoRaWBmm9iqW8eDt3Ic/SK6ALb7TFcLO6xy1f+mSDgSeaMrgrpgoGmBP1wXw==
-  optionalDependencies:
-    unix-dgram "2.0.x"
 
 hot-shots@^8.3.0:
   version "8.3.0"
@@ -16358,7 +16343,7 @@ items@2.x.x:
   resolved "https://registry.yarnpkg.com/items/-/items-2.1.2.tgz#0849354595805d586dac98e7e6e85556ea838558"
   integrity sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg==
 
-iterall@^1.2.1, iterall@^1.2.2:
+iterall@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -9954,10 +9954,10 @@ confusing-browser-globals@^1.0.10:
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz#30d1e7f3d1b882b25ec4933d1d1adac353d20a59"
   integrity sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==
 
-connect-datadog-graphql@^0.0.13:
-  version "0.0.13"
-  resolved "https://registry.yarnpkg.com/connect-datadog-graphql/-/connect-datadog-graphql-0.0.13.tgz#4a32dc5292f13fe6cf122f7188b2ac494c401e8b"
-  integrity sha512-rKFLDmNZglClbSxvmOW6PTrE4cxEzbu240c/7h9B7T3HSy6W52cbnQQf56y343AQrlqFF1ktJ8b5M2N0lFq02w==
+connect-datadog-graphql@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/connect-datadog-graphql/-/connect-datadog-graphql-1.0.0.tgz#5cc98e70c3a9e2a6c32e6daeeb407c3f3299cd2a"
+  integrity sha512-T68x8dxKp06FbbLlYwliNdPoXZTCJTm1rVeTKPe9XUekDq6yVVT2leZw4Qt+lVmfTMOOIM+BYSBWH+pncUIsew==
   dependencies:
     graphql "^15.1.0"
 


### PR DESCRIPTION
## Description

Upgrades `connect-datadog-graphql` to include calls to `datadog.distribution` for GraphQL requests.

This commit is the only change we're getting: https://github.com/politics-rewired/node-connect-datadog-graphql/commit/64a71e807a2d00dfb0c7b25b79380407fbba77b8

## Motivation and Context

We'd rather have response time distributions than just histograms so we can measure specific long requests instead of the overall trend.

## How Has This Been Tested?

Not tested.
