### PR TITLE
fix: remove opt-out collapse/expand behavior

### DIFF
--- a/src/containers/AdminOptOutList/index.tsx
+++ b/src/containers/AdminOptOutList/index.tsx
@@ -5,13 +5,9 @@ import ButtonGroup from "@material-ui/core/ButtonGroup";
 import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
 import CardHeader from "@material-ui/core/CardHeader";
-import Collapse from "@material-ui/core/Collapse";
 import Grid from "@material-ui/core/Grid";
-import IconButton from "@material-ui/core/IconButton";
 import Paper from "@material-ui/core/Paper";
 import Snackbar from "@material-ui/core/Snackbar";
-import ExpandLess from "@material-ui/icons/ExpandLess";
-import ExpandMore from "@material-ui/icons/ExpandMore";
 import Alert from "@material-ui/lab/Alert";
 import type { GridColDef, GridSelectionModel } from "@mui/x-data-grid-pro";
 import { DataGridPro } from "@mui/x-data-grid-pro";
@@ -43,7 +39,6 @@ const AdminOptOutList: React.FC = (props) => {
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
   const [dialogMode, setDialogMode] = useState<DialogMode>(DialogMode.None);
   const [snackbarOpen, setSnackbarOpen] = useState<boolean>(false);
-  const [showSection, setShowSection] = useState<boolean>(true);
   const [exportingOptOuts, setExportingOptOuts] = useState<boolean>(false);
   const [searchText, setSearchText] = React.useState("");
   const [selectedCampaignIds, setSelectedCampaignIds] = useState<Array<string>>(
@@ -70,8 +65,6 @@ const AdminOptOutList: React.FC = (props) => {
     setExportingOptOuts(false);
     setDialogMode(DialogMode.None);
   };
-
-  const handleExpandChange = () => setShowSection(!showSection);
 
   const handleSubmit = async ({ csvFile, numbersList }: BulkOptParams) => {
     const variables = {
@@ -183,29 +176,18 @@ const AdminOptOutList: React.FC = (props) => {
         </Grid>
       </Grid>
       <Card style={{ marginTop: 15, marginBottom: 15 }}>
-        <CardHeader
-          title="Export Opt Outs"
-          action={
-            <IconButton>
-              {showSection ? <ExpandLess /> : <ExpandMore />}
-            </IconButton>
-          }
-          style={{ cursor: "pointer" }}
-          onClick={handleExpandChange}
-        />
-        <Collapse in={showSection}>
-          <CardContent>
-            <ButtonGroup fullWidth variant="contained" color="primary">
-              <Button onClick={handleExportAll}>Export All</Button>
-              <Button
-                onClick={handleExportSelected}
-                disabled={selectedCampaignIds.length === 0}
-              >
-                Export Selected ({selectedCampaignIds.length} Selected)
-              </Button>
-            </ButtonGroup>
-          </CardContent>
-        </Collapse>
+        <CardHeader title="Export Opt Outs" />
+        <CardContent>
+          <ButtonGroup fullWidth variant="contained" color="primary">
+            <Button onClick={handleExportAll}>Export All</Button>
+            <Button
+              onClick={handleExportSelected}
+              disabled={selectedCampaignIds.length === 0}
+            >
+              Export Selected ({selectedCampaignIds.length} Selected)
+            </Button>
+          </ButtonGroup>
+        </CardContent>
       </Card>
       <Paper>
         <DataGridPro


### PR DESCRIPTION
## Description

This removes the collapse behavior from the "Export Opt Outs" card.

## Motivation and Context

Closes #1457.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<img width="738" alt="Screenshot 2022-10-31 at 7 27 41 AM" src="https://user-images.githubusercontent.com/2145526/199031794-ae7ea169-c32e-43fd-bb96-46aab491e005.png">

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203125662716844