### PR TITLE
fix(gql-schema): server can't import schema when it's in libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build:codegen": "yarn codegen",
     "build:client": "webpack --mode production",
     "build:server": "babel -d ./build/src --source-maps --copy-files --extensions .ts,.tsx,.js,.jsx ./src",
+    "build:libs": "babel -d ./build/libs --source-maps --copy-files --extensions .ts,.tsx,.js,.jsx ./libs",
     "build:tools": "babel -d ./build/tools ./dev-tools",
     "start": "node ./build/src/server",
     "knex": "knex --knexfile ./knexfile.env.js",


### PR DESCRIPTION
## Description

gql-schema can't be imported from libs during production build. 

## Motivation and Context

```
node:internal/modules/cjs/loader:936
  throw err;
  ^

Error: Cannot find module '../../../libs/gql-schema/schema'
Require stack:
- /usr/Spoke/build/src/server/routes/graphql.js
- /usr/Spoke/build/src/server/routes/index.js
- /usr/Spoke/build/src/server/app.js
- /usr/Spoke/build/src/server/index.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/usr/Spoke/build/src/server/routes/graphql.js:29:16)
    at Module._compile (node:internal/modules/cjs/loader:1103:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1155:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/usr/Spoke/build/src/server/routes/index.js:73:16)
    at Module._compile (node:internal/modules/cjs/loader:1103:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1155:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/usr/Spoke/build/src/server/app.js:51:15)
    at Module._compile (node:internal/modules/cjs/loader:1103:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1155:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/usr/Spoke/build/src/server/index.js:25:12)
    at Module._compile (node:internal/modules/cjs/loader:1103:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1155:10) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/usr/Spoke/build/src/server/routes/graphql.js',
    '/usr/Spoke/build/src/server/routes/index.js',
    '/usr/Spoke/build/src/server/app.js',
    '/usr/Spoke/build/src/server/index.js'
  ]
}
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
