### PR TITLE
feat(assemble-numbers): add counter to sendMessage

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -7,7 +7,6 @@ import cors from "cors";
 import express from "express";
 import basicAuth from "express-basic-auth";
 import expressSession from "express-session";
-import StatsD from "hot-shots";
 
 import { config } from "../config";
 import requestLogging from "../lib/request-logging";
@@ -26,6 +25,7 @@ import {
   twilioRouter,
   utilsRouter
 } from "./routes";
+import statsd from "./statsd";
 import { errToObj } from "./utils";
 
 const {
@@ -101,12 +101,7 @@ export const createApp = async () => {
 
   if (config.DD_AGENT_HOST && config.DD_DOGSTATSD_PORT) {
     const datadogOptions = {
-      dogstatsd: new StatsD({
-        host: config.DD_AGENT_HOST,
-        port: config.DD_DOGSTATSD_PORT,
-        errorHandler: (err: Error) =>
-          logger.error("connect-datadog encountered error: ", errToObj(err))
-      }),
+      dogstatsd: statsd,
       path: true,
       method: false,
       response_code: true,

--- a/src/server/statsd.ts
+++ b/src/server/statsd.ts
@@ -1,0 +1,12 @@
+import StatsD from "hot-shots";
+
+import { config } from "../config";
+import logger from "../logger";
+import { errToObj } from "./utils";
+
+export default new StatsD({
+  host: config.DD_AGENT_HOST,
+  port: config.DD_DOGSTATSD_PORT,
+  errorHandler: (err: Error) =>
+    logger.error("connect-datadog encountered error: ", errToObj(err))
+});


### PR DESCRIPTION
## Description

This adds a counter to send message calls for more granular monitoring and detection.

It appears to be a bit difficult to distinguish between HTTP level errors and 200 + GraphQL errors right now, so we can punt that for now. This accomplishes the main goal of enabling better alerting, and then we can turn to logs to further diagnose in the event of an alert.

## How Has This Been Tested?

TODO

