### PR TITLE
refactor(script editor): move opt out language warning into a dialog

### DIFF
--- a/src/components/ScriptEditor.tsx
+++ b/src/components/ScriptEditor.tsx
@@ -119,7 +119,6 @@ interface Props {
   scriptText: string;
   scriptFields: string[];
   campaignVariables: CampaignVariable[];
-  isRootStep: boolean;
   integrationSourced: boolean;
   onChange: (value: string) => Promise<void> | void;
   receiveFocus?: boolean;
@@ -321,38 +320,6 @@ class ScriptEditor extends React.Component<Props, State> {
     }
   }
 
-  renderOptOutLanguageWarning() {
-    const lowercaseText = this.state.editorState
-      .getCurrentContent()
-      .getPlainText()
-      .toLowerCase();
-
-    // 2022-09-24 - stop as a separate word is best for avoiding spam blocks
-    if (
-      this.props.isRootStep &&
-      lowercaseText.length > 0 &&
-      !lowercaseText.includes("stop ")
-    )
-      return (
-        <div style={{ color: baseTheme.colors.red }}>
-          <br />
-          WARNING! This script does not include opt out language. You must let
-          the recipient know they can opt out of receiving future texts, or your
-          messages are very likely to be blocked as spam. We recommend a phrase
-          with the individual word STOP, such as "Reply STOP to quit." Please
-          see our{" "}
-          <a
-            href="https://docs.spokerewired.com/article/168-spoke-101-tips-for-a-successful-mass-text"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            deliverability checklist
-          </a>{" "}
-          for other best practices for improving deliverability.
-        </div>
-      );
-  }
-
   renderCustomFields() {
     const { scriptFields, campaignVariables } = this.props;
     return (
@@ -409,7 +376,6 @@ class ScriptEditor extends React.Component<Props, State> {
         {this.renderCustomFields()}
         <div>
           {this.renderAttachmentWarning()}
-          {this.renderOptOutLanguageWarning()}
           <br />
           Estimated Segments: {info.msgCount} <br />
           Characters left in current segment:{" "}

--- a/src/components/ScriptLinkWarningDialog.tsx
+++ b/src/components/ScriptLinkWarningDialog.tsx
@@ -5,6 +5,8 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import React from "react";
 
+// dialogs stack on top of each other when all are open as:
+// opt out language warning > link warning > script editor
 const styles = {
   dialog: {
     zIndex: 10002

--- a/src/components/ScriptOptOutLanguageWarningDialog.tsx
+++ b/src/components/ScriptOptOutLanguageWarningDialog.tsx
@@ -1,0 +1,67 @@
+import Button from "@material-ui/core/Button";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import React from "react";
+
+// dialogs stack on top of each other when all are open as:
+// opt out language warning > link warning > script editor
+const styles = {
+  dialog: {
+    zIndex: 10003
+  }
+};
+
+const DialogContentWrapper = () => {
+  return (
+    <div>
+      WARNING! This script does not include opt out language. You must let the
+      recipient know they can opt out of receiving future texts, or your
+      messages are very likely to be blocked as spam. <br /> <br /> We recommend
+      a phrase with the individual word STOP, such as "Reply STOP to quit"
+      Please see our{" "}
+      <a
+        href="https://docs.spokerewired.com/article/168-spoke-101-tips-for-a-successful-mass-text"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        deliverability checklist
+      </a>{" "}
+      for other best practices for improving deliverability.
+    </div>
+  );
+};
+
+interface WarningProps {
+  open: boolean;
+  handleConfirm: () => void;
+  handleClose: () => void;
+}
+
+const ScriptOptOutLanguageWarningDialog = (props: WarningProps) => {
+  const { handleClose, handleConfirm, open } = props;
+
+  const title = "Opt Out Language Warning";
+
+  const actions = [
+    <Button key="close" onClick={handleClose}>
+      Close
+    </Button>,
+    <Button key="save" color="primary" onClick={handleConfirm}>
+      Confirm and Save
+    </Button>
+  ];
+
+  return (
+    <Dialog open={open} style={styles.dialog}>
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>
+        <DialogContentWrapper />
+      </DialogContent>
+      <DialogActions>{actions}</DialogActions>
+    </Dialog>
+  );
+};
+
+export default ScriptOptOutLanguageWarningDialog;


### PR DESCRIPTION
## Description

This moves the opt out language warning into a dialog.

## Motivation and Context

Follows up on feedback from @politics-rewired/organizing on #1436 

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/76596635/200237133-2d2f929b-b460-4d04-911d-4a4aae0713ff.png)
## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
