### PR TITLE
feat: don't hide campaign create options on removing focus

### DIFF
--- a/src/containers/AdminCampaignList.jsx
+++ b/src/containers/AdminCampaignList.jsx
@@ -95,6 +95,11 @@ class AdminCampaignList extends React.Component {
     });
   };
 
+  handleClickSpeedDial = () => {
+    const { speedDialOpen } = this.state;
+    this.setState({ speedDialOpen: !speedDialOpen });
+  };
+
   releaseAllReplies = () => {
     const ageInHours = parseFloat(this.numberOfHoursToReleaseRef.input.value);
     const releaseOnRestricted = this.releaseOnRestrictedRef.state.switched;
@@ -269,7 +274,7 @@ class AdminCampaignList extends React.Component {
             ariaLabel="SpeedDial example"
             style={theme.components.floatingButton}
             icon={<SpeedDialIcon />}
-            onClose={() => this.setState({ speedDialOpen: false })}
+            onClick={this.handleClickSpeedDial}
             onOpen={() => this.setState({ speedDialOpen: true })}
             open={this.state.speedDialOpen}
             direction="up"


### PR DESCRIPTION
## Description

Open the speed dial options when you click on the + button, or hover over it, and don't hide it on removing focus, closing it requires clicking the X button.

## Motivation and Context

Fixes #1477

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
