### PR TITLE
feat: allow cloning, and deleting template campaigns

### DIFF
--- a/libs/gql-schema/schema.ts
+++ b/libs/gql-schema/schema.ts
@@ -275,6 +275,8 @@ const rootSchema = `
     createInvite(invite:InviteInput!): Invite
     createCampaign(campaign:CampaignInput!): Campaign
     createTemplateCampaign(organizationId: String!): Campaign!
+    deleteTemplateCampaign(organizationId: String!, campaignId: String!): Boolean!
+    cloneTemplateCampaign(organizationId: String!, campaignId: String!): Campaign!
     editCampaign(id:String!, campaign:CampaignInput!): Campaign
     saveCampaignGroups(organizationId: String!, campaignGroups: [CampaignGroupInput!]!): [CampaignGroup!]!
     deleteCampaignGroup(organizationId: String!, campaignGroupId: String!): Boolean!

--- a/libs/spoke-codegen/src/graphql/template-campaigns.graphql
+++ b/libs/spoke-codegen/src/graphql/template-campaigns.graphql
@@ -52,3 +52,13 @@ mutation CreateCampaignFromTemplate($templateId: String!, $quantity: Int!) {
     title
   }
 }
+
+mutation DeleteTemplateCampaign($organizationId: String!, $campaignId: String!) {
+  deleteTemplateCampaign(organizationId: $organizationId, campaignId: $campaignId) 
+}
+
+mutation CloneTemplateCampaign($organizationId: String!, $campaignId: String!) {
+  cloneTemplateCampaign(organizationId: $organizationId, campaignId: $campaignId) {
+    ...TemplateCampaign
+  }
+}

--- a/src/components/CreateCampaignFromTemplateDialog.tsx
+++ b/src/components/CreateCampaignFromTemplateDialog.tsx
@@ -18,7 +18,7 @@ export interface CreateCampaignFromTemplateDialogProps {
   organizationId: string;
   open: boolean;
   onClose?: () => Promise<void> | void;
-  preselectedTemplate?: TemplateCampaignFragment;
+  defaultTemplate?: TemplateCampaignFragment;
 }
 
 export const CreateCampaignFromTemplateDialog: React.FC<CreateCampaignFromTemplateDialogProps> = (
@@ -27,9 +27,7 @@ export const CreateCampaignFromTemplateDialog: React.FC<CreateCampaignFromTempla
   const [
     selectedTemplate,
     setSelectedTemplate
-  ] = useState<TemplateCampaignFragment | null>(
-    props.preselectedTemplate ?? null
-  );
+  ] = useState<TemplateCampaignFragment | null>(props.defaultTemplate ?? null);
   const [quantity, setQuantity] = useState<number | null>(1);
   const { data, error } = useGetTemplateCampaignsQuery({
     variables: { organizationId: props.organizationId }

--- a/src/components/CreateCampaignFromTemplateDialog.tsx
+++ b/src/components/CreateCampaignFromTemplateDialog.tsx
@@ -18,6 +18,7 @@ export interface CreateCampaignFromTemplateDialogProps {
   organizationId: string;
   open: boolean;
   onClose?: () => Promise<void> | void;
+  preselectedTemplate?: TemplateCampaignFragment;
 }
 
 export const CreateCampaignFromTemplateDialog: React.FC<CreateCampaignFromTemplateDialogProps> = (
@@ -26,7 +27,9 @@ export const CreateCampaignFromTemplateDialog: React.FC<CreateCampaignFromTempla
   const [
     selectedTemplate,
     setSelectedTemplate
-  ] = useState<TemplateCampaignFragment | null>(null);
+  ] = useState<TemplateCampaignFragment | null>(
+    props.preselectedTemplate ?? null
+  );
   const [quantity, setQuantity] = useState<number | null>(1);
   const { data, error } = useGetTemplateCampaignsQuery({
     variables: { organizationId: props.organizationId }

--- a/src/containers/AdminTemplateCampaigns/components/TemplateCampaignRow.tsx
+++ b/src/containers/AdminTemplateCampaigns/components/TemplateCampaignRow.tsx
@@ -23,8 +23,8 @@ import type { TemplateCampaignFragment } from "@spoke/spoke-codegen";
 import isEmpty from "lodash/isEmpty";
 import type { ReactNode } from "react";
 import React, { useCallback, useState } from "react";
-import CreateCampaignFromTemplateDialog from "src/components/CreateCampaignFromTemplateDialog";
 
+import CreateCampaignFromTemplateDialog from "../../../components/CreateCampaignFromTemplateDialog";
 import { DateTime } from "../../../lib/datetime";
 
 const useStyles = makeStyles((theme) => ({
@@ -189,7 +189,7 @@ export const TemplateCampaignRow: React.FC<TemplateCampaignRowProps> = ({
         <DialogTitle>Delete this template?</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            Are you sture you want to delete this template?
+            Are you sure you want to delete this template?
           </DialogContentText>
         </DialogContent>
         <DialogActions>
@@ -207,7 +207,7 @@ export const TemplateCampaignRow: React.FC<TemplateCampaignRowProps> = ({
       <CreateCampaignFromTemplateDialog
         organizationId={organizationId}
         open={createFromTemplateOpen}
-        preselectedTemplate={templateCampaign}
+        defaultTemplate={templateCampaign}
         onClose={() => setCreateFromTemplateOpen(false)}
       />
     </Card>

--- a/src/containers/AdminTemplateCampaigns/components/TemplateCampaignRow.tsx
+++ b/src/containers/AdminTemplateCampaigns/components/TemplateCampaignRow.tsx
@@ -1,14 +1,29 @@
+import Button from "@material-ui/core/Button";
 import Card from "@material-ui/core/Card";
+import CardActions from "@material-ui/core/CardActions";
 import CardContent from "@material-ui/core/CardContent";
 import CardHeader from "@material-ui/core/CardHeader";
 import Chip from "@material-ui/core/Chip";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
+import DialogTitle from "@material-ui/core/DialogTitle";
 import IconButton from "@material-ui/core/IconButton";
+import ListItemIcon from "@material-ui/core/ListItemIcon";
+import Menu from "@material-ui/core/Menu";
+import MenuItem from "@material-ui/core/MenuItem";
 import { makeStyles } from "@material-ui/core/styles";
+import AddIcon from "@material-ui/icons/AddOutlined";
+import DeleteIcon from "@material-ui/icons/DeleteOutlined";
 import EditIcon from "@material-ui/icons/Edit";
+import FileCopyIcon from "@material-ui/icons/FileCopyOutlined";
+import MoreVertIcon from "@material-ui/icons/MoreVertOutlined";
 import type { TemplateCampaignFragment } from "@spoke/spoke-codegen";
 import isEmpty from "lodash/isEmpty";
 import type { ReactNode } from "react";
-import React from "react";
+import React, { useCallback, useState } from "react";
+import CreateCampaignFromTemplateDialog from "src/components/CreateCampaignFromTemplateDialog";
 
 import { DateTime } from "../../../lib/datetime";
 
@@ -23,14 +38,26 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export interface TemplateCampaignRowProps {
+  organizationId: string;
   templateCampaign: TemplateCampaignFragment;
-  onClickEdit?: () => Promise<void> | void;
+  onClickEdit: () => Promise<void> | void;
+  onClickClone: () => Promise<void> | void;
+  onClickDelete: () => Promise<void> | void;
 }
 
 export const TemplateCampaignRow: React.FC<TemplateCampaignRowProps> = ({
+  organizationId,
   templateCampaign,
-  onClickEdit
+  onClickEdit,
+  onClickClone,
+  onClickDelete
 }) => {
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState<boolean>(false);
+  const [createFromTemplateOpen, setCreateFromTemplateOpen] = useState<boolean>(
+    false
+  );
+  const [menuAnchor, setMenuAnchor] = useState<HTMLButtonElement | null>(null);
+
   const classes = useStyles();
 
   const createdAt = DateTime.fromISO(
@@ -59,6 +86,40 @@ export const TemplateCampaignRow: React.FC<TemplateCampaignRowProps> = ({
     );
   }
 
+  const handleClickMenu = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) =>
+      setMenuAnchor(event.currentTarget),
+    [setMenuAnchor]
+  );
+
+  const handleCloseMenu = useCallback(() => setMenuAnchor(null), [
+    setMenuAnchor
+  ]);
+
+  const handleEdit = async () => {
+    handleCloseMenu();
+    await onClickEdit();
+  };
+
+  const handleCopy = async () => {
+    handleCloseMenu();
+    await onClickClone();
+  };
+
+  const handleOpenDelete = async () => {
+    handleCloseMenu();
+    setDeleteDialogOpen(true);
+  };
+
+  const handleDelete = async () => {
+    await onClickDelete();
+    setDeleteDialogOpen(false);
+  };
+
+  const handleCreateTemplateClicked = () => {
+    setCreateFromTemplateOpen(true);
+  };
+
   return (
     <Card>
       <CardHeader
@@ -77,16 +138,78 @@ export const TemplateCampaignRow: React.FC<TemplateCampaignRowProps> = ({
           </>
         }
         action={
-          <IconButton aria-label="edit" onClick={onClickEdit}>
-            <EditIcon />
+          <IconButton
+            aria-label="template-campaign-row"
+            onClick={handleClickMenu}
+          >
+            <MoreVertIcon />
           </IconButton>
         }
       />
+      <Menu
+        anchorEl={menuAnchor}
+        open={Boolean(menuAnchor)}
+        onClose={handleCloseMenu}
+      >
+        <MenuItem onClick={handleEdit}>
+          <ListItemIcon>
+            <EditIcon style={{ paddingRight: 15 }} /> Edit Template
+          </ListItemIcon>
+        </MenuItem>
+        <MenuItem onClick={handleCopy}>
+          <ListItemIcon>
+            <FileCopyIcon style={{ paddingRight: 15 }} /> Copy Template
+          </ListItemIcon>
+        </MenuItem>
+        <MenuItem onClick={handleOpenDelete}>
+          <ListItemIcon>
+            <DeleteIcon style={{ paddingRight: 15 }} /> Delete Template
+          </ListItemIcon>
+        </MenuItem>
+      </Menu>
       {chips.length > 0 && (
         <CardContent>
           <div className={classes.campaignInfo}>{chips}</div>
         </CardContent>
       )}
+      <CardActions>
+        <Button
+          style={{ marginLeft: "auto" }}
+          variant="outlined"
+          startIcon={<AddIcon />}
+          onClick={handleCreateTemplateClicked}
+        >
+          Create From Template
+        </Button>
+      </CardActions>
+      <Dialog
+        open={deleteDialogOpen}
+        onClose={() => setDeleteDialogOpen(false)}
+      >
+        <DialogTitle>Delete this template?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Are you sture you want to delete this template?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button variant="contained" color="primary" onClick={handleDelete}>
+            Delete Template
+          </Button>
+          <Button
+            variant="contained"
+            onClick={() => setDeleteDialogOpen(false)}
+          >
+            Cancel
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <CreateCampaignFromTemplateDialog
+        organizationId={organizationId}
+        open={createFromTemplateOpen}
+        preselectedTemplate={templateCampaign}
+        onClose={() => setCreateFromTemplateOpen(false)}
+      />
     </Card>
   );
 };

--- a/src/containers/AdminTemplateCampaigns/index.tsx
+++ b/src/containers/AdminTemplateCampaigns/index.tsx
@@ -3,7 +3,9 @@ import { makeStyles } from "@material-ui/core/styles";
 import AddIcon from "@material-ui/icons/Add";
 import {
   GetTemplateCampaignsDocument,
+  useCloneTemplateCampaignMutation,
   useCreateTemplateCampaignMutation,
+  useDeleteTemplateCampaignMutation,
   useGetTemplateCampaignsQuery
 } from "@spoke/spoke-codegen";
 import React, { useCallback } from "react";
@@ -28,16 +30,27 @@ export const AdminTemplateCampaigns: React.FC = () => {
   const classes = useStyles();
   const history = useHistory();
   const { organizationId } = useParams<{ organizationId: string }>();
+
   const { data, loading, error } = useGetTemplateCampaignsQuery({
     variables: { organizationId }
   });
+
+  const refetchQueries = [
+    { query: GetTemplateCampaignsDocument, variables: { organizationId } }
+  ];
+
   const [
     createTemplateCampaign,
     { loading: createTemplateLoading }
   ] = useCreateTemplateCampaignMutation({
-    refetchQueries: [
-      { query: GetTemplateCampaignsDocument, variables: { organizationId } }
-    ]
+    refetchQueries
+  });
+
+  const [deleteTemplateCampaign] = useDeleteTemplateCampaignMutation({
+    refetchQueries
+  });
+  const [cloneTemplateCampaign] = useCloneTemplateCampaignMutation({
+    refetchQueries
   });
 
   const templateCampaigns = (
@@ -61,6 +74,18 @@ export const AdminTemplateCampaigns: React.FC = () => {
     );
   };
 
+  const createCloneClickEdit = (templateCampaignId: string) => async () => {
+    await cloneTemplateCampaign({
+      variables: { organizationId, campaignId: templateCampaignId }
+    });
+  };
+
+  const createDeleteClickEdit = (templateCampaignId: string) => async () => {
+    await deleteTemplateCampaign({
+      variables: { organizationId, campaignId: templateCampaignId }
+    });
+  };
+
   return (
     <>
       {loading && "Loading..."}
@@ -69,9 +94,12 @@ export const AdminTemplateCampaigns: React.FC = () => {
       <div className={classes.listContainer}>
         {templateCampaigns.map((templateCampaign) => (
           <TemplateCampaignRow
+            organizationId={organizationId}
             key={templateCampaign.id}
             templateCampaign={templateCampaign}
             onClickEdit={createHandleClickEdit(templateCampaign.id)}
+            onClickClone={createCloneClickEdit(templateCampaign.id)}
+            onClickDelete={createDeleteClickEdit(templateCampaign.id)}
           />
         ))}
       </div>

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -242,6 +242,8 @@ type RootMutation {
   createInvite(invite:InviteInput!): Invite
   createCampaign(campaign:CampaignInput!): Campaign
   createTemplateCampaign(organizationId: String!): Campaign!
+  deleteTemplateCampaign(organizationId: String!, campaignId: String!): Boolean!
+  cloneTemplateCampaign(organizationId: String!, campaignId: String!): Campaign!
   editCampaign(id:String!, campaign:CampaignInput!): Campaign
   saveCampaignGroups(organizationId: String!, campaignGroups: [CampaignGroupInput!]!): [CampaignGroup!]!
   deleteCampaignGroup(organizationId: String!, campaignGroupId: String!): Boolean!

--- a/src/server/api/root-mutations.ts
+++ b/src/server/api/root-mutations.ts
@@ -16,6 +16,7 @@ import { hasRole } from "../../lib/permissions";
 import { applyScript } from "../../lib/scripts";
 import { replaceAll } from "../../lib/utils";
 import logger from "../../logger";
+import type { SpokeRequestContext } from "../contexts/types";
 import pgPool from "../db";
 import { eventBus, EventType } from "../event-bus";
 import {
@@ -56,7 +57,7 @@ import {
   notifyOnTagConversation
 } from "./lib/alerts";
 import { getStepsToUpdate } from "./lib/bulk-script-editor";
-import { copyCampaign, editCampaign } from "./lib/campaign";
+import { copyCampaign, deleteCampaign, editCampaign } from "./lib/campaign";
 import { saveNewIncomingMessage } from "./lib/message-sending";
 import { processNumbers } from "./lib/opt-out";
 import { sendMessage } from "./lib/send-message";
@@ -875,6 +876,35 @@ const rootMutations = {
 
       cacheableData.campaign.reload(templateCampaign.id);
       return templateCampaign;
+    },
+
+    deleteTemplateCampaign: async (
+      _root: any,
+      { organizationId, campaignId }: Record<string, any>,
+      { user }: SpokeRequestContext
+    ) => {
+      await accessRequired(user, organizationId, "ADMIN");
+
+      await deleteCampaign(campaignId);
+
+      return true;
+    },
+
+    cloneTemplateCampaign: async (
+      _root: any,
+      { organizationId, campaignId }: Record<string, any>,
+      { user, db }: SpokeRequestContext
+    ) => {
+      await accessRequired(user, organizationId, "ADMIN");
+
+      const [result] = await copyCampaign({
+        db,
+        campaignId,
+        userId: parseInt(user.id, 10),
+        template: true
+      });
+
+      return result;
     },
 
     copyCampaign: async (_root, { id }, { user, loaders, db }) => {


### PR DESCRIPTION
## Description

allow cloning, and deleting template campaigns
also allow creating new campaigns from the templates list page

## Motivation and Context

Fixes #1335 and #1497 

## How Has This Been Tested?

Tested locally

## Screenshots (if appropriate):
<img width="1625" alt="Screenshot 2022-11-08 at 6 38 57 PM" src="https://user-images.githubusercontent.com/367605/200573707-433ddd14-f140-4d96-b1b6-52d8f0edf0be.png">
<img width="1636" alt="Screenshot 2022-11-08 at 6 38 50 PM" src="https://user-images.githubusercontent.com/367605/200573681-4d7f03ee-0963-404c-97e6-0f1288969d28.png">

Deleting asks for confirmations:
<img width="1617" alt="Screenshot 2022-11-08 at 6 39 38 PM" src="https://user-images.githubusercontent.com/367605/200573713-cb46e6d4-b124-4bd7-a8d2-376f9403d059.png">

Create from template opens the dialog, with the template preselected: 
<img width="1630" alt="Screenshot 2022-11-08 at 6 39 49 PM" src="https://user-images.githubusercontent.com/367605/200573718-04ce1f5c-2158-4ea0-8a40-cb45cd9fca22.png">

This reuses the same dialog from the floating create from template button.

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
