### PR TITLE
fix(bulk script editor): tidy full script version replacement preview

### DIFF
--- a/src/containers/AdminBulkScriptEditor/ChangesDialog.tsx
+++ b/src/containers/AdminBulkScriptEditor/ChangesDialog.tsx
@@ -34,35 +34,49 @@ const ChangesDialog: React.FC<ChangesDialogProps> = ({
     // so we update the span of the split part with the color
     const expression = new RegExp(`(${searchString})`, "g");
     const scriptParts = script.split(expression);
-    return (
-      <span>
-        {scriptParts.map((part) =>
-          part.match(expression) ? (
-            <span style={{ color: theme.palette.warning.main }}>{part}</span>
-          ) : (
-            part
-          )
-        )}
-      </span>
-    );
+    const scriptSpan =
+      scriptParts.length > 1 ? (
+        <span>
+          {scriptParts.map((part) =>
+            part.match(expression) ? (
+              <span style={{ color: theme.palette.warning.main }}>{part}</span>
+            ) : (
+              part
+            )
+          )}
+        </span>
+      ) : (
+        <span>
+          <span style={{ color: theme.palette.warning.main }}>{script}</span>
+        </span>
+      );
+    return scriptSpan;
   };
 
   const colorReplacement = (script: string) => {
     const expression = new RegExp(`(${searchString})`, "g");
     const scriptParts = script.split(expression);
-    return (
-      <span>
-        {scriptParts.map((part) =>
-          part.match(expression) ? (
-            <span style={{ color: theme.palette.primary.main }}>
-              {replaceString}
-            </span>
-          ) : (
-            part
-          )
-        )}
-      </span>
-    );
+    const scriptSpan =
+      scriptParts.length > 1 ? (
+        <span>
+          {scriptParts.map((part) =>
+            part.match(expression) ? (
+              <span style={{ color: theme.palette.success.main }}>
+                {replaceString}
+              </span>
+            ) : (
+              part
+            )
+          )}
+        </span>
+      ) : (
+        <span>
+          <span style={{ color: theme.palette.success.main }}>
+            {replaceString}
+          </span>
+        </span>
+      );
+    return scriptSpan;
   };
 
   return (


### PR DESCRIPTION
## Description

This adjusts the bulk script editor preview so that:
1. Text replacement in the preview occurs correctly when the entire script version is being replaced
2. Color highlighting applies to the full script versions when the entire script version is being replaced
3. "Will replace with" color highlighting is displayed (in all cases)

## Motivation and Context
This edge case which occurs often in production was confusing to bulk script editor users.

## How Has This Been Tested?
This has been tested locally.

## Screenshots (if appropriate):
<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/76596635/201497939-8a9b8659-eb2e-479f-8692-1def632e9e3b.png"/></td>
<td><img src="https://user-images.githubusercontent.com/76596635/201497889-0e347b6d-10cf-4d94-b6fb-4f73c0c17b06.png"/></td>
</tr>
</table>




## Documentation Changes

Not necessary based on the current knowledge base article. @politics-rewired/organizing @jen-mckinney @jstgriswold do we think this article should be updated with screenshots? https://docs.spokerewired.com/article/69-bulk-script-editor

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
