### PR TITLE
fix(opt outs): add unique cell per organization constraint

### DIFF
--- a/migrations/20221117021725_remove-duplicate-opt-outs.js
+++ b/migrations/20221117021725_remove-duplicate-opt-outs.js
@@ -1,0 +1,19 @@
+exports.up = function up(knex) {
+  return knex.raw(`
+    delete from opt_out oo
+    using opt_out existing
+    where oo.id > existing.id
+      and oo.cell = existing.cell
+      and oo.organization_id = existing.organization_id;
+
+    alter table opt_out
+      add constraint unique_cell_per_organization_id unique (cell, organization_id)
+  `);
+};
+
+exports.down = function down(knex) {
+  return knex.raw(`
+    alter table opt_out
+      drop constraint unique_cell_per_organization_id
+  `);
+};

--- a/schema-dump.sql
+++ b/schema-dump.sql
@@ -4210,6 +4210,14 @@ ALTER TABLE ONLY public.unhealthy_link_domain
 
 
 --
+-- Name: opt_out unique_cell_per_organization_id; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.opt_out
+    ADD CONSTRAINT unique_cell_per_organization_id UNIQUE (cell, organization_id);
+
+
+--
 -- Name: canned_response unique_per_campaign; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 


### PR DESCRIPTION
## Description

This PR:
1. Adds a unique cell per organization constraint to the `opt_out` table
2. Adds checking for an existing opt out before processing a new auto opt out in `message-sending.js`

## Motivation and Context

Having multiple opt out records for the same conversation can be confusing for read replica users who expect at most 1 record to be returned per campaign contact when joining to `opt_out`. Duplicate records are currently created for example if a contact spams "STOP" as a reply.

## How Has This Been Tested?
This has been tested locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
