### PR TITLE
fix(autosending): change how initials are picked

### DIFF
--- a/src/server/api/lib/send-message.ts
+++ b/src/server/api/lib/send-message.ts
@@ -240,6 +240,13 @@ export const sendMessage = async (
   }
 
   if (checkOptOut && !!record.is_opted_out) {
+    // if trying to message an opted out contact
+    // mark conversation as closed before throwing error
+    await r
+      .knex("campaign_contact")
+      .update({ message_status: "closed" })
+      .where({ id: record.cc_id });
+
     throw new ContactOptedOutError();
   }
 


### PR DESCRIPTION
## Description

Change now initials are picked when autosending. 

Also if sending to a contact that is opted out, mark conversations as closed for that contact. Will help pause campaigns correctly for campaigns that have some opts out from other campaigns. 

## Motivation and Context

Barnes autosending incident 
https://rewiredcoop.slack.com/archives/C02KUGE68UX/p1668758724530879

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
