### PR TITLE
build: move platform choice out of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### Dependency Cacher
 ### -------------------------
-FROM --platform=linux/amd64 endeveit/docker-jq:latest as deps
+FROM endeveit/docker-jq:latest as deps
 
 # To prevent cache invalidation from changes in fields other than dependencies
 # https://stackoverflow.com/a/59606373
@@ -10,7 +10,7 @@ RUN jq '{ dependencies, devDependencies, resolutions }' < /tmp/package.json > /t
 
 ### Fat Build
 ### -------------------------
-FROM --platform=linux/amd64 node:16.14.0 AS builder
+FROM node:16.14.0 AS builder
 
 WORKDIR /usr/Spoke
 
@@ -36,7 +36,7 @@ RUN yarn run build
 
 ### Slim Deploy
 ### -------------------------
-FROM --platform=linux/amd64 node:16.14.0
+FROM node:16.14.0
 
 WORKDIR /usr/Spoke
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ Run in development mode:
 yarn dev
 ```
 
+If you plan to build container images locally for use in production you may want to set the default architecture by adding the following to your shell config (e.g. `~/.bash_profile`):
+
+```sh
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
+```
+
+or pass `--platform=linux/amd64` to all `docker buildx` commands.
+
 ### SMS
 
 For development, you can set `DEFAULT_SERVICE=fakeservice` to skip using an SMS provider (Assemble Switchboard or Twilio) and insert the message directly into the database. This is set by default in `.env`.


### PR DESCRIPTION
## Description

Move platform architecture out of the Dockerfile.

## Motivation and Context

This addresses Hadolint warning against this.

See also https://stackoverflow.com/a/66900911/3015709

This reverts #1437

## How Has This Been Tested?

GitHub Actions builds ran fine before #1437.

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

Readme has been updated.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have included updates for the documentation accordingly.
