### PR TITLE
Add `--ignore-engines` to `yarn install` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ git config --local blame.ignoreRevsFile .git-blame-ignore-revs
 Install Node dependencies:
 
 ```sh
-yarn install
+yarn install --ignore-engines
 ```
 
 Copy the example environment. The only change you may need to make is updating the database connection string.


### PR DESCRIPTION
## Description

Add `--ignore-engines` to `yarn install` in README.

## Motivation and Context

I was getting:

```
$ yarn install                                                  
yarn install v1.22.19
$ node -e "if(process.env.npm_execpath.indexOf('yarn') === -1) throw new Error('spoke must be installed with Yarn: https://yarnpkg.com/')"
[1/5] 🔍  Validating package.json...
error spoke@6.1.0-rc.1: The engine "node" is incompatible with this module. Expected version "^16.14.0". Got "19.5.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

Solution from [Stack Overflow](https://stackoverflow.com/questions/56617209/the-engine-node-is-incompatible-with-this-module).

## How Has This Been Tested?

N/a.

## Screenshots (if appropriate):

N/a.

## Documentation Changes

N/a.

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
