### PR TITLE
fix(messaging services): add fakeservice default

### DIFF
--- a/src/server/api/root-mutations.ts
+++ b/src/server/api/root-mutations.ts
@@ -1302,6 +1302,12 @@ const rootMutations = {
               service_type: service.service_type
             }))
           );
+        } else if (config.DEFAULT_SERVICE === "fakeservice") {
+          await trx("messaging_service").insert({
+            messaging_service_sid: "fakeservice",
+            organization_id: newOrganization.id,
+            service_type: "assemble-numbers"
+          });
         }
 
         return newOrganization;


### PR DESCRIPTION
## Description

This adds a default fakeservice insert when an organization is created.

## Motivation and Context

In a dev environment (or when creating a [demo production instance](https://github.com/politics-rewired/spoke-rewired-k8s/blob/main/leviathans/demo/deployment.yaml#L241)), we expect that a real messaging service will not be configured for each organization. This PR helps skip a manual step for getting Spoke set up in these cases.

## How Has This Been Tested?
This has been tested locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203981312852110