### PR TITLE
feat(canned responses): clarify instructional copy

### DIFF
--- a/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/index.tsx
@@ -223,7 +223,22 @@ class CampaignCannedResponsesForm extends React.Component<InnerProps, State> {
       <div>
         <CampaignFormSectionHeading
           title="Canned responses for texters"
-          subtitle="Share additional FAQ responses with your texters that are NOT associated with logging data. Please note that canned responses are not tracked or stored when used. Responses associated with data collection should be included in your interaction script instead."
+          subtitle={
+            <>
+              Share additional FAQ responses with your texters that are NOT
+              associated with logging data. Please note that canned responses
+              are not tracked or stored when used. Responses associated with
+              data collection should be included in your{" "}
+              <a
+                href="https://docs.spokerewired.com/article/43-create-interaction-script"
+                target="_blank"
+                rel="noreferrer"
+              >
+                interaction script
+              </a>{" "}
+              instead.
+            </>
+          }
         />
         {cannedResponses.length > 0 ? (
           <LargeList>

--- a/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/index.tsx
@@ -223,7 +223,7 @@ class CampaignCannedResponsesForm extends React.Component<InnerProps, State> {
       <div>
         <CampaignFormSectionHeading
           title="Canned responses for texters"
-          subtitle="Save some scripts for your texters to use to answer additional FAQs that may come up outside of the survey questions and scripts you already set up."
+          subtitle="Share additional FAQ responses with your texters that are NOT associated with logging data. Please note that canned responses are not tracked or stored when used. Responses associated with data collection should be included in your interaction script instead."
         />
         {cannedResponses.length > 0 ? (
           <LargeList>


### PR DESCRIPTION
## Description

Changed subtitle on campaign edit page to clarify instructional copy for canned responses

## Motivation and Context

Fixes #984 

## How Has This Been Tested?

No tests ran

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/105394952/219227825-1f5ee2e2-8eee-4c90-93b1-f95af47b6a7f.png)

![image](https://user-images.githubusercontent.com/105394952/219227852-ec3471bc-c09b-42de-b403-7bf240f61821.png)

## Documentation Changes

No documentation change needed

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
