### PR TITLE
chore: replace useless map with copy-on-destructure

### DIFF
--- a/src/containers/AssignmentTexterContact/components/ApplyTagDialog.tsx
+++ b/src/containers/AssignmentTexterContact/components/ApplyTagDialog.tsx
@@ -57,7 +57,7 @@ const ApplyTagDialog: React.FC<ApplyTagDialogProps> = ({
   );
   useEffect(() => {
     if (open) {
-      setSelectedContactTags(contactTagsTags.map((contactTag) => contactTag));
+      setSelectedContactTags([...contactTagsTags]);
     }
   }, [open]);
 


### PR DESCRIPTION
## Description

This replaces a useless `map()` with a useful copy via array destructuring (to avoid accidentally mutating source array).

## Motivation and Context

Comment in #1573.

See https://medium.com/@abdulrasheed.formal/different-ways-to-clone-copy-an-array-in-javascript-be0f5a2ec24e#7963 for more info about destructuring/spreading arrays to copy them.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
