### PR TITLE
chore: use more accurate variable naming

### DIFF
--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -474,8 +474,8 @@ export class AssignmentTexterContact extends React.Component {
     }
   };
 
-  handleApplyTagsAndMoveOn = (addedTags, removedTags) => {
-    this.handleApplyTags(addedTags, removedTags, async () => {
+  handleApplyTagsAndMoveOn = (addedContactTags, removedContactTags) => {
+    this.handleApplyTags(addedContactTags, removedContactTags, async () => {
       const { contact } = this.props;
       const payload = this.gatherSurveyChanges();
       await this.props.sendMessage(contact.id, payload);

--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -447,24 +447,28 @@ export class AssignmentTexterContact extends React.Component {
     this.setState({ dialogType: TexterDialogType.OptOut });
   };
 
-  handleApplyTags = (addedTags, removedTags, callback) => {
-    this.tagContact(addedTags, removedTags);
+  handleApplyTags = (addedContactTags, removedContactTags, callback) => {
+    this.tagContact(addedContactTags, removedContactTags);
 
     if (callback) {
       this.setState(
-        { addedTags, removedTags, isTagEditorOpen: false },
+        {
+          addedTags: addedContactTags,
+          removedTags: removedContactTags,
+          isTagEditorOpen: false
+        },
         callback
       );
     } else {
       this.setState({
-        addedTags,
-        removedTags,
+        addedTags: addedContactTags,
+        removedTags: removedContactTags,
         isTagEditorOpen: false
       });
     }
 
-    if (!callback && addedTags.length > 0) {
-      const mostImportantTag = sortBy(addedTags, "id")[0];
+    if (!callback && addedContactTags.length > 0) {
+      const mostImportantTag = sortBy(addedContactTags, "id")[0];
       const tagMessageText = mostImportantTag.tag.onApplyScript;
       if (tagMessageText !== "") this.handleChangeScript(tagMessageText);
     }
@@ -479,11 +483,11 @@ export class AssignmentTexterContact extends React.Component {
   };
 
   // run mutation with added and removed tags
-  tagContact = (addedTags, removedTags) => {
+  tagContact = (addedContactTags, removedContactTags) => {
     const { contact } = this.props;
     const tag = {
-      addedTagIds: addedTags.map((t) => t.tag.id),
-      removedTagIds: removedTags.map((t) => t.tag.id)
+      addedTagIds: addedContactTags.map((t) => t.tag.id),
+      removedTagIds: removedContactTags.map((t) => t.tag.id)
     };
 
     this.props.addTagToContact(contact.id, tag);


### PR DESCRIPTION
## Description

This rename makes it clear that the objects being passed around are CampaignContactTags and not Tags.

## Motivation and Context

Without type checking it is easy to make a mistake if variable names are misleading.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

This has been tested locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
