### PR TITLE
fix: van configuration reading the wrong query

### DIFF
--- a/src/containers/AdminCampaignStats/components/SyncConfigurationModal/index.tsx
+++ b/src/containers/AdminCampaignStats/components/SyncConfigurationModal/index.tsx
@@ -172,7 +172,7 @@ const mutations: MutationMap<OuterProps> = {
       const variables = { campaignId: ownProps.campaignId };
       const data: any = cloneDeep(
         store.readQuery({
-          query: GetSyncTargetsDocument,
+          query: GetCampaignSyncConfigsDocument,
           variables
         })
       );
@@ -214,7 +214,7 @@ const mutations: MutationMap<OuterProps> = {
       const variables = { campaignId: ownProps.campaignId };
       const data: any = cloneDeep(
         store.readQuery({
-          query: GetSyncTargetsDocument,
+          query: GetCampaignSyncConfigsDocument,
           variables
         })
       );


### PR DESCRIPTION
## Description

Fix VAN sync modal reading the wrong query.

## Motivation and Context

Bug report by support in Slack

## How Has This Been Tested?

Tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
