### PR TITLE
docs(readme): update .env instructions to specify connection string format

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,16 @@ Install Node dependencies:
 yarn install
 ```
 
-Copy the example environment. The only change you may need to make is updating the database connection string.
+Copy the example environment. You will need to update the database connection
+string: it should contain the correct host, port, and username/password
+credentials to your development Postgres server.
 
 ```sh
 cp .env.example .env
 vi .env
+
+# in this case, the server is running at port 5432 (the default Postgres port)
+# DATABASE_URL=postgres://spoke:spoke@localhost:5432/spokedev
 ```
 
 Create the `spokedev` database (if it doesn't yet exist)


### PR DESCRIPTION
## Description

This PR revises README.md to include an example connection string for `.env` setup.

## Motivation and Context

Configuring the connection string with credentials is required, since later steps require authentication while connecting to the database. It's unlikely that the user will use the default `postgres`/`postgres` credentials, so explicitly specifying credentials in the connection string is imo good practice.

## How Has This Been Tested?

Locally, while going through the onboarding instructions

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

No, only for contributors to Spoke. Documentation included in the PR.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
