### PR TITLE
chore: add docker-compose instructions for local postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,17 @@ Runtimes and package managers:
 External services:
 
 - Postgres (>= 11)
-  - [Install](https://postgresql.org/download) and [start](https://www.postgresql.org/docs/current/server-start.html) documentation
+
+Recommended:
+
+- Docker, for running Postgres as a container
+  - [install documentation](https://docs.docker.com/engine/install/)
 
 ### Setting up a development environment
 
-Install Node and Yarn. We recommend using the [asdf version manager](https://github.com/asdf-vm/asdf).
+#### Install Node and Yarn
+
+We recommend using the [asdf version manager](https://github.com/asdf-vm/asdf).
 
 ```sh
 # Example using `asdf` (https://github.com/asdf-vm/asdf)
@@ -42,7 +48,50 @@ You can also install the prereqs manually:
 - [Node install documentation](https://nodejs.dev/learn/how-to-install-nodejs)
 - [Yarn install documentation](https://classic.yarnpkg.com/en/docs/install)
 
-Clone the repo:
+#### Install and run a Postgres server
+
+If you have Docker installed, we recommend using Postgres as a container.
+
+Spoke Rewired comes with a `postgres` container in `docker-compose.yml`, which you can start with the following command:
+
+```sh
+# Run in the foreground, so you can watch logs and stop with Ctrl-C
+docker compose up postgres
+
+# Run in the background so you can use the terminal for other things
+docker compose up postgres -d
+
+# (if you have an older version of Docker installed, you may have to run
+# "docker-compose" with a hyphen instead of "docker compose" with a space)
+```
+
+The `postgres` container will automatically start up a server with the following configuration:
+
+- connection string (for `DATABASE_URL`): `postgres://spoke:spoke@localhost:15432/spokedev`
+- port: 15432
+- default database: `spokedev`
+- user: `spoke`
+- password: `spoke`
+
+To stop all containers, including Postgres, run:
+
+```sh
+docker compose down
+```
+
+To delete all container data, including the Postgres database, and stop all containers, run:
+
+```sh
+docker compose down -v
+```
+
+After the database container is taken down, you can run the `up` commands above to restart it. For more information, see [the Docker Compose reference documentation](https://docs.docker.com/compose/reference/).
+
+You can also install and run a Postgres server manually without Docker:
+
+- Postgres [Install](https://postgresql.org/download) and [start](https://www.postgresql.org/docs/current/server-start.html) documentation
+
+#### Clone the repo
 
 ```sh
 git clone git@github.com:politics-rewired/Spoke.git
@@ -50,13 +99,15 @@ cd Spoke
 git config --local blame.ignoreRevsFile .git-blame-ignore-revs
 ```
 
-Install Node dependencies:
+#### Install Node dependencies
 
 ```sh
 yarn install
 ```
 
-Copy the example environment. You will need to update the database connection
+#### Copy the example environment
+
+You will need to update the database connection
 string: it should contain the correct host, port, and username/password
 credentials to your development Postgres server.
 
@@ -68,26 +119,26 @@ vi .env
 # DATABASE_URL=postgres://spoke:spoke@localhost:5432/spokedev
 ```
 
-Create the `spokedev` database (if it doesn't yet exist)
+#### Create the `spokedev` database (if it doesn't yet exist)
 
 ```sh
 psql -c "create database spokedev;"
 ```
 
-Run the migrations:
+#### Run the migrations
 
 ```sh
 yarn migrate:worker
 yarn knex migrate:latest
 ```
 
-Run codegen:
+#### Run codegen
 
 ```sh
 yarn codegen
 ```
 
-Run in development mode:
+#### Start the Spoke application in develpoment mode
 
 ```sh
 yarn dev

--- a/README.md
+++ b/README.md
@@ -144,14 +144,6 @@ yarn codegen
 yarn dev
 ```
 
-If you plan to build container images locally for use in production you may want to set the default architecture by adding the following to your shell config (e.g. `~/.bash_profile`):
-
-```sh
-export DOCKER_DEFAULT_PLATFORM=linux/amd64
-```
-
-or pass `--platform=linux/amd64` to all `docker buildx` commands.
-
 ### SMS
 
 For development, you can set `DEFAULT_SERVICE=fakeservice` to skip using an SMS provider (Assemble Switchboard or Twilio) and insert the message directly into the database. This is set by default in `.env`.
@@ -224,6 +216,16 @@ yarn release --prerelease
 # or the pre-release type
 yarn release --prerelease alpha
 ```
+
+## Building container images locally
+
+If you plan to build container images locally for use in production you may want to set the default architecture by adding the following to your shell config (e.g. `~/.bash_profile`):
+
+```sh
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
+```
+
+or pass `--platform=linux/amd64` to all `docker buildx` commands.
 
 ## Deploying
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,11 +11,6 @@ services:
       - postgres:/var/lib/postgresql/data
     ports:
       - 15432:5432
-  redis:
-    image: redis
-    restart: always
-    volumes:
-      - redis:/data
   app:
     build:
       context: .
@@ -23,12 +18,10 @@ services:
         SPOKE_VERSION: 1.4.1
     depends_on:
       - postgres
-      - redis
     env_file:
       - ./.env
     environment:
       DATABASE_URL: postgres://spoke:spoke@postgres:5432/spokedev
-      REDIS_URL: redis://redis:6379
     image: spoke
     ports:
       - 3000:3000
@@ -36,6 +29,4 @@ services:
       - ./.env:/Spoke/.env
 volumes:
   postgres:
-    external: false
-  redis:
     external: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   postgres:
-    image: postgres
+    image: postgres:15
     restart: always
     environment:
       POSTGRES_DB: spokedev
@@ -9,6 +9,8 @@ services:
       POSTGRES_USER: spoke
     volumes:
       - postgres:/var/lib/postgresql/data
+    ports:
+      - 15432:5432
   redis:
     image: redis
     restart: always


### PR DESCRIPTION
## Merge notes

This PR builds on top of #1598. Merge that one first before merging this one. Can modify this PR to exclude those changes if you decline to merge #1598.

## Description

This PR tweaks `docker-compose.yml` to improve its suitability for local development, and adds instructions to README.md on using Docker to provide a local postgres server.

## Motivation and Context

This PR provides another option for streamlining the developer environment setup for new contributors. In my opinion, we should move to a Docker-based setup for providing external services in a local development environment.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Locally, following README instructions

## Screenshots (if appropriate):

[Kooha-2023-05-09-19-47-51.webm](https://github.com/politics-rewired/Spoke/assets/1077648/68e875aa-c986-4f6e-9a7d-473f801f286c)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

No user facing changes. Contributor facing changes included in PR.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have included updates for the documentation accordingly.
