### PR TITLE
fix: fix trollAlarms query

### DIFF
--- a/src/server/api/root-resolvers.ts
+++ b/src/server/api/root-resolvers.ts
@@ -254,7 +254,7 @@ const rootResolvers = {
 
       const countQuery = query.clone();
       const [{ count: totalCount }] = await countQuery.count();
-      const alarms = await query
+      const alarmRows = await query
         .join("message", "message.id", "=", "troll_alarm.message_id")
         .join("user", "user.id", "message.user_id")
         .join(
@@ -278,32 +278,32 @@ const rootResolvers = {
         )
         .orderBy("troll_alarm.message_id", "desc")
         .limit(limit)
-        .offset(offset)
-        .map(
-          ({
-            message_id,
-            token: alarmToken,
-            dismissed: alarmDismissed,
-            message_text,
-            cc_id,
+        .offset(offset);
+      const alarms = alarmRows.map(
+        ({
+          message_id,
+          token: alarmToken,
+          dismissed: alarmDismissed,
+          message_text,
+          cc_id,
+          campaign_id,
+          cc_first_name,
+          cc_last_name,
+          ...alarmUser
+        }) => ({
+          message_id,
+          token: alarmToken,
+          dismissed: alarmDismissed,
+          message_text,
+          user: alarmUser,
+          contact: {
+            id: cc_id,
             campaign_id,
-            cc_first_name,
-            cc_last_name,
-            ...alarmUser
-          }) => ({
-            message_id,
-            token: alarmToken,
-            dismissed: alarmDismissed,
-            message_text,
-            user: alarmUser,
-            contact: {
-              id: cc_id,
-              campaign_id,
-              first_name: cc_first_name,
-              last_name: cc_last_name
-            }
-          })
-        );
+            first_name: cc_first_name,
+            last_name: cc_last_name
+          }
+        })
+      );
 
       return { alarms, totalCount };
     },


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This fixes an error in the `trollAlarms` GraphQL query encountered in production Docker builds.

## Motivation and Context

After transpilation during the Docker build process (but not locally on my workstation), the `map()` was being called on the knex query object before the `await` executed the actual query. This fixes the issue and improves readability by separating the data fetching from the data transformation.

Closes #1597

## How Has This Been Tested?

This has been tested with local Docker builds.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
