### PR TITLE
chore(10dlc): update notifications

### DIFF
--- a/src/components/Registration10DLCWarningText.tsx
+++ b/src/components/Registration10DLCWarningText.tsx
@@ -3,10 +3,11 @@ import React from "react";
 const Registration10DLCWarningText: React.FC = () => (
   <>
     <p>
-      You must provide details required for us to register a 10DLC brand on your
-      behalf by June 1st, 2023! If you do not provide this information by then,
-      you may not be able to send messages starting on June 1st, 2023. You may
-      also be subject to additional charges.
+      Provide details required for us to register a 10DLC brand on your behalf
+      by July 1st, 2023 for the best messaging experience! You may continue
+      sending without registering for 10DLC, but you will incur increased
+      charges for messaging, and may see lower message deliverability starting
+      on July 1st!
     </p>
     <p>
       To learn more about this change, please see our{" "}

--- a/src/components/Registration10DLCWarningText.tsx
+++ b/src/components/Registration10DLCWarningText.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+const Registration10DLCWarningText: React.FC = () => (
+  <>
+    <p>
+      You must provide details required for us to register a 10DLC brand on your
+      behalf by June 1st, 2023! If you do not provide this information by then,
+      you may not be able to send messages starting on June 1st, 2023. You may
+      also be subject to additional charges.
+    </p>
+    <p>
+      To learn more about this change, please see our{" "}
+      <a
+        href="https://docs.spokerewired.com/article/124-10dlc"
+        target="_blank"
+        rel="noreferrer"
+      >
+        10DLC knowledge base article
+      </a>
+      .
+    </p>
+  </>
+);
+
+export default Registration10DLCWarningText;

--- a/src/components/Registration10DLCWarningText.tsx
+++ b/src/components/Registration10DLCWarningText.tsx
@@ -7,7 +7,7 @@ const Registration10DLCWarningText: React.FC = () => (
       by July 1st, 2023 for the best messaging experience! You may continue
       sending without registering for 10DLC, but you will incur increased
       charges for messaging, and may see lower message deliverability starting
-      on July 1st!
+      on July 1st.
     </p>
     <p>
       To learn more about this change, please see our{" "}

--- a/src/components/Registration10DLCWarningText.tsx
+++ b/src/components/Registration10DLCWarningText.tsx
@@ -12,7 +12,7 @@ const Registration10DLCWarningText: React.FC = () => (
     <p>
       To learn more about this change, please see our{" "}
       <a
-        href="https://docs.spokerewired.com/article/124-10dlc"
+        href="https://docs.spokerewired.com/article/10dlc"
         target="_blank"
         rel="noreferrer"
       >

--- a/src/config.js
+++ b/src/config.js
@@ -445,6 +445,11 @@ const validators = {
       "A comma separated list of contact fields to not ship to the client. Can include 'external_id, cell, and lastName'",
     default: ""
   }),
+  HIDE_10DLC_REGISTRATION_WARNING: bool({
+    desc: "Whether the 10DLC Registration Warning is disabled for Admins",
+    default: false,
+    isClient: true
+  }),
   JOBS_SAME_PROCESS: bool({
     desc:
       "Whether jobs should be executed in the same process in which they are created (vs. processing asyncronously via worker processes).",

--- a/src/config.js
+++ b/src/config.js
@@ -445,9 +445,9 @@ const validators = {
       "A comma separated list of contact fields to not ship to the client. Can include 'external_id, cell, and lastName'",
     default: ""
   }),
-  HIDE_10DLC_REGISTRATION_WARNING: bool({
+  SHOW_10DLC_REGISTRATION_WARNING: bool({
     desc: "Whether the 10DLC Registration Warning is disabled for Admins",
-    default: false,
+    default: true,
     isClient: true
   }),
   JOBS_SAME_PROCESS: bool({

--- a/src/containers/AdminDashboard/components/NotificationCard.tsx
+++ b/src/containers/AdminDashboard/components/NotificationCard.tsx
@@ -75,7 +75,7 @@ export const NotificationCard: React.FC<InnerProps> = (props) => {
     <div>
       {props.data.notices.edges.map(({ node }) => {
         if (
-          !window.HIDE_10DLC_REGISTRATION_WARNING &&
+          window.SHOW_10DLC_REGISTRATION_WARNING &&
           isRegister10DlcBrandNotice(node)
         ) {
           return <Register10DlcBrandNoticeCard key={node.id} {...node} />;

--- a/src/containers/AdminDashboard/components/NotificationCard.tsx
+++ b/src/containers/AdminDashboard/components/NotificationCard.tsx
@@ -12,6 +12,7 @@ import type {
   Register10DlcBrandNotice
 } from "@spoke/spoke-codegen";
 import React from "react";
+import Registration10DLCWarningText from "src/components/Registration10DLCWarningText";
 
 import { isRegister10DlcBrandNotice } from "../../../api/notice";
 import type { QueryMap } from "../../../network/types";
@@ -35,24 +36,7 @@ const Register10DlcBrandNoticeCard: React.FC<Register10DlcBrandNotice> = (
         avatar={<Warning color="error" />}
       />
       <CardContent>
-        <p>
-          You must provide details required for us to register a 10DLC brand on
-          your behalf by May 1st, 2023! If you do not provide this information
-          by then, you may not be able to send messages starting on May 1st,
-          2023 until 5-10 business days after you provide this information.
-        </p>
-
-        <p>
-          To learn more about this change, please see our{" "}
-          <a
-            href="https://docs.spokerewired.com/article/124-10dlc"
-            target="_blank"
-            rel="noreferrer"
-          >
-            10DLC knowledge base article
-          </a>
-          .
-        </p>
+        <Registration10DLCWarningText />
 
         {props.tcrBrandRegistrationUrl === null && (
           <p style={{ fontWeight: "bold" }}>

--- a/src/containers/AdminDashboard/components/NotificationCard.tsx
+++ b/src/containers/AdminDashboard/components/NotificationCard.tsx
@@ -37,10 +37,9 @@ const Register10DlcBrandNoticeCard: React.FC<Register10DlcBrandNotice> = (
       <CardContent>
         <p>
           You must provide details required for us to register a 10DLC brand on
-          your behalf by February 22nd, 2022! If you do not provide this
-          information by then, you may not be able to send messages starting on
-          March 1st, 2022 until 3-5 business days after you provide this
-          information.
+          your behalf by May 1st, 2023! If you do not provide this information
+          by then, you may not be able to send messages starting on May 1st,
+          2023 until 5-10 business days after you provide this information.
         </p>
 
         <p>

--- a/src/containers/AdminDashboard/components/NotificationCard.tsx
+++ b/src/containers/AdminDashboard/components/NotificationCard.tsx
@@ -74,7 +74,10 @@ export const NotificationCard: React.FC<InnerProps> = (props) => {
   return (
     <div>
       {props.data.notices.edges.map(({ node }) => {
-        if (isRegister10DlcBrandNotice(node)) {
+        if (
+          !window.HIDE_10DLC_REGISTRATION_WARNING &&
+          isRegister10DlcBrandNotice(node)
+        ) {
           return <Register10DlcBrandNoticeCard key={node.id} {...node} />;
         }
         return null;

--- a/src/containers/Settings/components/Review10DlcInfo.tsx
+++ b/src/containers/Settings/components/Review10DlcInfo.tsx
@@ -6,6 +6,7 @@ import CardHeader from "@material-ui/core/CardHeader";
 import OpenInNew from "@material-ui/icons/OpenInNew";
 import React from "react";
 import { compose } from "recompose";
+import Registration10DLCWarningText from "src/components/Registration10DLCWarningText";
 
 import type { QueryMap } from "../../../network/types";
 import { loadData } from "../../hoc/with-operations";
@@ -42,24 +43,7 @@ const Review10DlcInfo: React.FC<InnerProps> = (props) => {
     <Card style={style}>
       <CardHeader title="10DLC Registration Information" />
       <CardContent>
-        <p>
-          You must provide details required for us to register a 10DLC brand on
-          your behalf by May 1st, 2023! If you do not provide this information
-          by then, you may not be able to send messages starting on May 1st,
-          2023 until 5-10 business days after you provide this information.
-        </p>
-
-        <p>
-          To learn more about this change, please see our{" "}
-          <a
-            href="https://docs.spokerewired.com/article/124-10dlc"
-            target="_blank"
-            rel="noreferrer"
-          >
-            10DLC knowledge base article
-          </a>
-          .
-        </p>
+        <Registration10DLCWarningText />
       </CardContent>
       <CardActions disableSpacing>
         <Button

--- a/src/containers/Settings/components/Review10DlcInfo.tsx
+++ b/src/containers/Settings/components/Review10DlcInfo.tsx
@@ -44,10 +44,9 @@ const Review10DlcInfo: React.FC<InnerProps> = (props) => {
       <CardContent>
         <p>
           You must provide details required for us to register a 10DLC brand on
-          your behalf by February 22nd, 2022! If you do not provide this
-          information by then, you may not be able to send messages starting on
-          March 1st, 2022 until 3-5 business days after you provide this
-          information.
+          your behalf by May 1st, 2023! If you do not provide this information
+          by then, you may not be able to send messages starting on May 1st,
+          2023 until 5-10 business days after you provide this information.
         </p>
 
         <p>

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -15,6 +15,7 @@ interface Window {
   NODE_ENV: string;
   BASE_URL: string;
   ENABLE_TROLLBOT: boolean;
+  HIDE_10DLC_REGISTRATION_WARNING: boolean;
 
   AuthService: any;
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -15,7 +15,7 @@ interface Window {
   NODE_ENV: string;
   BASE_URL: string;
   ENABLE_TROLLBOT: boolean;
-  HIDE_10DLC_REGISTRATION_WARNING: boolean;
+  SHOW_10DLC_REGISTRATION_WARNING: boolean;
 
   AuthService: any;
 }

--- a/src/server/lib/notices/register-10dlc-brand.ts
+++ b/src/server/lib/notices/register-10dlc-brand.ts
@@ -54,7 +54,8 @@ export const get10DlcBrandNotices: OrgLevelNotificationGetter = async (
     .groupBy("messaging_service_sid")
     .where({
       service_type: "assemble-numbers",
-      user_id: userId
+      user_id: userId,
+      active: true
     })
     .whereIn("role", ["OWNER", "ADMIN"]);
   if (organizationId !== undefined) {

--- a/src/server/lib/notices/register-10dlc-brand.ts
+++ b/src/server/lib/notices/register-10dlc-brand.ts
@@ -43,8 +43,6 @@ export const get10DlcBrandNotices: OrgLevelNotificationGetter = async (
   userId,
   organizationId
 ) => {
-  return [];
-
   const query = r
     .knex("messaging_service")
     .join(


### PR DESCRIPTION
## Description

This PR:
1. Updates Spoke's 10DLC warnings to reflect our intended 2023 timeline. 
2. Adds an envvar for hiding the warning that appears throughout the Admin pages. This envvar should be set to true for "leviathan" clients who manage their registrations directly with TCR, who will not find the warning useful.

## Motivation and Context

Closes #1586 

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

![image](https://github.com/politics-rewired/Spoke/assets/76596635/464fe000-cff4-4032-ad34-d4b1ee2da008)

## Documentation Changes
@politics-rewired/spoke-client is already aware, but dates + screenshots in our 10DLC articles need to be updated.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
