### PR TITLE
feat(campaign-interaction-steps): add save button to top of section

### DIFF
--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
@@ -389,9 +389,22 @@ const CampaignInteractionStepsForm: React.FC<InnerProps> = (props) => {
         title="What do you want to discuss?"
         subtitle="You can add scripts and questions and your texters can indicate responses from your contacts. For example, you might want to collect RSVPs to an event or find out whether to follow up about a different volunteer activity."
       />
-      <Box m={2}>
-        <ScriptPreviewButton campaignId={campaignId} />
-      </Box>
+      <div style={{ display: "flex", justifyContent: "space-between" }}>
+        <Box m={2}>
+          <ScriptPreviewButton campaignId={campaignId} />
+        </Box>
+        <Box m={2}>
+          <Button
+            {...dataTest("interactionSubmit", true)}
+            variant="contained"
+            color="primary"
+            disabled={isSaveDisabled}
+            onClick={handleSave}
+          >
+            {finalSaveLabel}
+          </Button>
+        </Box>
+      </div>
       {renderInvalidScriptFields()}
       <InteractionStepCard
         interactionStep={finalFree}


### PR DESCRIPTION
## Description

This pr adds the save button at the bottom of the interaction steps section of a campaign to the top of the section as well, so that users can scroll up to save when editing campaigns with long scripts

## Motivation and Context

It closes #1547 

## How Has This Been Tested?

Locally

## Screenshots (if appropriate):

<img width="889" alt="Screenshot 2023-05-15 at 12 40 52 PM" src="https://github.com/politics-rewired/Spoke/assets/47220718/15a268cd-2e2c-4d00-ac00-322d92b03ef1">

## Documentation Changes

n/a

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
