### PR TITLE
fix(autosending): fetch campaign id when pausing

### DIFF
--- a/src/server/api/root-mutations.ts
+++ b/src/server/api/root-mutations.ts
@@ -1997,7 +1997,7 @@ const rootMutations = {
       const campaign = await r
         .knex("campaign")
         .where({ id })
-        .first(["organization_id", "is_archived", "autosend_status"]);
+        .first(["id", "organization_id", "is_archived", "autosend_status"]);
 
       const organizationId = campaign.organization_id;
 


### PR DESCRIPTION
## Description

This fetches a campaign ID for the `unqueueAutosending` function.
## Motivation and Context

Without fetching the campaign ID here, admins were unable to pause autosending after launching a campaign.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
