### PR TITLE
chore: clarify shutdown email copy

### DIFF
--- a/src/server/api/root-mutations.ts
+++ b/src/server/api/root-mutations.ts
@@ -3502,9 +3502,10 @@ const rootMutations = {
                 const switchboard = config.SWITCHBOARD_BASE_URL ?? "[default]";
 
                 const text = [
-                  "This is an automated org shutdown request triggered through the superadmin.",
+                  "This is an automated org shutdown request triggered by a superadmin.",
                   `Organization id: ${organizationId}, name: ${org.name}, from instance hosted at ${config.BASE_URL}.`,
-                  `Switchboard ${switchboard}, profiles:\n${messagingServiceSids}`
+                  `Switchboard ${switchboard}, profiles:\n${messagingServiceSids}`,
+                  "Note: This is NOT necessarily an instance shutdown request."
                 ].join("\n\n");
 
                 await sendEmail({


### PR DESCRIPTION
## Description

This clarifies within the email copy that organization shutdown requests are not necessarily instance shutdown requests.

## Motivation and Context

We had tickets opened on consecutive weekends because of org shutdown emails interpreted as instance shutdowns.

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

![image](https://github.com/politics-rewired/Spoke/assets/76596635/9883de9e-99a8-4a14-ab22-82870ab9d1dd)
## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
