### PR TITLE
fix: create campaign speed dial open/close behavior

### DIFF
--- a/src/components/CreateCampaignFromTemplateDialog.tsx
+++ b/src/components/CreateCampaignFromTemplateDialog.tsx
@@ -128,6 +128,7 @@ export const CreateCampaignFromTemplateDialog: React.FC<CreateCampaignFromTempla
       onClose={props.onClose}
       aria-labelledby="create-from-template-dialog-title"
       open={props.open}
+      disableRestoreFocus
     >
       <DialogTitle id="create-from-template-dialog-title">
         Create Campaign from Template

--- a/src/containers/AdminCampaignList.jsx
+++ b/src/containers/AdminCampaignList.jsx
@@ -1,10 +1,14 @@
 import { gql } from "@apollo/client";
+import { withStyles } from "@material-ui/core";
+import Box from "@material-ui/core/Box";
 import Button from "@material-ui/core/Button";
 import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import Snackbar from "@material-ui/core/Snackbar";
+import Typography from "@material-ui/core/Typography";
+import ClearIcon from "@material-ui/icons/Clear";
 import CreateIcon from "@material-ui/icons/Create";
 import FileCopyIcon from "@material-ui/icons/FileCopyOutlined";
 import MuiAlert from "@material-ui/lab/Alert";
@@ -36,27 +40,54 @@ const styles = {
   }
 };
 
+const AdminCampaignListSpeedDialAction = withStyles(() => ({
+  staticTooltipLabel: {
+    display: "inline-block",
+    width: "max-content"
+  }
+}))(SpeedDialAction);
+
+const AdminCampaignListSpeedDial = withStyles(() => ({
+  root: {
+    "align-items": "flex-end"
+  }
+}))(SpeedDial);
+
+const AdminCampaignListSpeedDialIcon = withStyles(() => ({
+  root: {
+    display: "inline-box",
+    position: "relative",
+    width: "100%"
+  },
+  openIcon: {
+    width: "100%"
+  }
+}))(SpeedDialIcon);
+
 // The campaign list uses infinite scrolling now so we fix the page size
 const DEFAULT_PAGE_SIZE = 10;
 
 class AdminCampaignList extends React.Component {
-  state = {
-    speedDialOpen: false,
-    createFromTemplateOpen: false,
-    // created from template state
-    showCreatedFromTemplateSnackbar: false,
-    createdFromTemplateIds: [],
-    createdFromTemplateTitle: "",
-    // end created from template state
-    isCreating: false,
-    campaignsFilter: {
-      isArchived: false
-    },
-    releasingInProgress: false,
-    releasingAllReplies: false,
-    releaseAllRepliesError: undefined,
-    releaseAllRepliesResult: undefined
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      speedDialOpen: false,
+      createFromTemplateOpen: false,
+      // created from template state
+      showCreatedFromTemplateSnackbar: false,
+      createdFromTemplateIds: [],
+      createdFromTemplateTitle: "",
+      // end created from template state
+      isCreating: false,
+      campaignsFilter: {
+        isArchived: false
+      },
+      releasingInProgress: false,
+      releasingAllReplies: false,
+      releaseAllRepliesError: undefined,
+      releaseAllRepliesResult: undefined
+    };
+  }
 
   handleClickNewButton = async () => {
     const { history, match } = this.props;
@@ -133,6 +164,36 @@ class AdminCampaignList extends React.Component {
 
   startReleasingAllReplies = () => {
     this.setState({ releasingAllReplies: true });
+  };
+
+  handleOnCreateClickFromTemplate = () => {
+    this.setState({
+      createFromTemplateOpen: true,
+      speedDialOpen: false
+    });
+  };
+
+  handleSpeedDialOnKeyDown = (event) => {
+    /* "toggle", "blur", "mouseLeave", "escapeKeyDown" are the possible close events,
+      so we're handling escapeKeyDown here * */
+    if (event.key === "Escape") {
+      this.setState({ speedDialOpen: false });
+    }
+  };
+
+  handleSpeedDialOnFocus = () => {
+    this.setState({ speedDialOpen: true });
+  };
+
+  handleSpeedDialOnBlur = () => {
+    this.setState({ speedDialOpen: false });
+  };
+
+  /**
+   * We listen to mouse down because we don't close the speed dial menu right after opening it in the focus event
+   */
+  handleSpeedDialOnMouseDown = () => {
+    this.setState({ speedDialOpen: !this.state.speedDialOpen });
   };
 
   releaseAllReplies = () => {
@@ -269,7 +330,7 @@ class AdminCampaignList extends React.Component {
               {releasingInProgress
                 ? []
                 : doneReleasingReplies
-                ? [
+                  ? [
                     <Button
                       key="done"
                       variant="contained"
@@ -278,7 +339,7 @@ class AdminCampaignList extends React.Component {
                       Done
                     </Button>
                   ]
-                : [
+                  : [
                     <Button
                       key="cancel"
                       variant="contained"
@@ -310,26 +371,61 @@ class AdminCampaignList extends React.Component {
         )}
 
         {isAdmin ? (
-          <SpeedDial
+          <AdminCampaignListSpeedDial
+            id="adminCampaignListSpeedDial"
             ariaLabel="Open create campaign actions"
             style={theme.components.floatingButton}
-            icon={<SpeedDialIcon />}
-            onClick={this.handleClickSpeedDial}
-            onOpen={() => this.setState({ speedDialOpen: true })}
-            open={speedDialOpen}
+            onFocus={this.handleSpeedDialOnFocus}
+            onMouseDown={this.handleSpeedDialOnMouseDown}
+            onBlur={this.handleSpeedDialOnBlur}
+            onKeyDown={this.handleSpeedDialOnKeyDown}
+            open={this.state.speedDialOpen}
             direction="up"
+            FabProps={{ variant: "extended" }}
+            icon={
+              <AdminCampaignListSpeedDialIcon
+                icon={
+                  <Box
+                    sx={{
+                      display: "flex",
+                      alignContent: "center",
+                      justifyContent: "center"
+                    }}
+                  >
+                    <SpeedDialIcon />
+                    <Typography variant="button">
+                      {" "}
+                      Create a campaign{" "}
+                    </Typography>
+                  </Box>
+                }
+                openIcon={
+                  <Box
+                    sx={{
+                      display: "flex",
+                      alignContent: "center",
+                      justifyContent: "center"
+                    }}
+                  >
+                    <ClearIcon />
+                  </Box>
+                }
+              />
+            }
           >
-            <SpeedDialAction
+            <AdminCampaignListSpeedDialAction
               icon={<CreateIcon />}
-              tooltipTitle="Create Blank Campaign"
+              tooltipOpen
+              tooltipTitle="Create new campaign"
               onClick={this.handleClickNewButton}
             />
-            <SpeedDialAction
+            <AdminCampaignListSpeedDialAction
               icon={<FileCopyIcon />}
-              tooltipTitle="Create Campaign from Template"
-              onClick={() => this.setState({ createFromTemplateOpen: true })}
+              tooltipOpen
+              tooltipTitle="Create campaign from template"
+              onClick={this.handleOnCreateClickFromTemplate}
             />
-          </SpeedDial>
+          </AdminCampaignListSpeedDial>
         ) : null}
         <CreateCampaignFromTemplateDialog
           organizationId={organizationId}

--- a/src/containers/AdminCampaignList.jsx
+++ b/src/containers/AdminCampaignList.jsx
@@ -311,7 +311,7 @@ class AdminCampaignList extends React.Component {
 
         {isAdmin ? (
           <SpeedDial
-            ariaLabel="SpeedDial example"
+            ariaLabel="Open create campaign actions"
             style={theme.components.floatingButton}
             icon={<SpeedDialIcon />}
             onClick={this.handleClickSpeedDial}
@@ -321,12 +321,12 @@ class AdminCampaignList extends React.Component {
           >
             <SpeedDialAction
               icon={<CreateIcon />}
-              tooltipTitle="Create Blank"
+              tooltipTitle="Create Blank Campaign"
               onClick={this.handleClickNewButton}
             />
             <SpeedDialAction
               icon={<FileCopyIcon />}
-              tooltipTitle="Create from Template"
+              tooltipTitle="Create Campaign from Template"
               onClick={() => this.setState({ createFromTemplateOpen: true })}
             />
           </SpeedDial>

--- a/src/containers/AdminCampaignList.jsx
+++ b/src/containers/AdminCampaignList.jsx
@@ -121,11 +121,6 @@ class AdminCampaignList extends React.Component {
     });
   };
 
-  handleClickSpeedDial = () => {
-    const { speedDialOpen } = this.state;
-    this.setState({ speedDialOpen: !speedDialOpen });
-  };
-
   handleCreatedFromTemplateSnackbarClose = (_event, reason) => {
     if (reason === "clickaway") {
       return;
@@ -252,7 +247,6 @@ class AdminCampaignList extends React.Component {
       createdFromTemplateIds,
       createdFromTemplateTitle,
       showCreatedFromTemplateSnackbar,
-      speedDialOpen,
       isCreating
     } = this.state;
 
@@ -330,7 +324,7 @@ class AdminCampaignList extends React.Component {
               {releasingInProgress
                 ? []
                 : doneReleasingReplies
-                  ? [
+                ? [
                     <Button
                       key="done"
                       variant="contained"
@@ -339,7 +333,7 @@ class AdminCampaignList extends React.Component {
                       Done
                     </Button>
                   ]
-                  : [
+                : [
                     <Button
                       key="cancel"
                       variant="contained"
@@ -372,6 +366,7 @@ class AdminCampaignList extends React.Component {
 
         {isAdmin ? (
           <AdminCampaignListSpeedDial
+            id="adminCampaignListSpeedDial"
             ariaLabel="Open create campaign actions"
             style={theme.components.floatingButton}
             onFocus={this.handleSpeedDialOnFocus}

--- a/src/containers/AdminCampaignList.jsx
+++ b/src/containers/AdminCampaignList.jsx
@@ -372,7 +372,6 @@ class AdminCampaignList extends React.Component {
 
         {isAdmin ? (
           <AdminCampaignListSpeedDial
-            id="adminCampaignListSpeedDial"
             ariaLabel="Open create campaign actions"
             style={theme.components.floatingButton}
             onFocus={this.handleSpeedDialOnFocus}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

- removed all hover-related behavior from the create campaign button
- on "toggle", "focus", the action buttons show up
- on "blur","toggle", "escapeKeyDown". the action buttons hide
- updated action buttons to say "Create New Campaign", "Create Campaign from Template" and have the tooltips remain

Completed one of the stretch goals of the ticket:
- Made it say “+ Create a campaign” when the actions are not showing and keep the “X” when the actions are showing

- [x] @mkoontz-rewired Make sure to write up a ticket for the stretch goal of "Move it to the top of the page to the right of "Current" and left of "Release all unhandled replies". At the moment, these buttons won't be absolutely positioned."/ a ticket for Kenny to re-consider the create flow in general
Design ticket created: https://app.asana.com/0/1202110006089866/1204849793973501

## Motivation and Context

Closes #1564 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

locally

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![Screenshot 2023-06-20 at 6 08 42 PM](https://github.com/politics-rewired/Spoke/assets/97469439/b0cdd02a-1aab-4a72-9f11-5e3d8c337c55)


![Screenshot 2023-06-20 at 6 08 50 PM](https://github.com/politics-rewired/Spoke/assets/97469439/7adf4116-127a-414c-b1fe-c8814258b976)


<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
