### PR TITLE
feat: use new API to check if organization has a 10dlc service

### DIFF
--- a/src/containers/AdminDashboard/components/NotificationCard.tsx
+++ b/src/containers/AdminDashboard/components/NotificationCard.tsx
@@ -20,6 +20,7 @@ import { withOperations } from "../../hoc/with-operations";
 
 interface InnerProps {
   organizationId: string;
+  loading: boolean;
   data: {
     error?: any;
     notices: NoticePage;
@@ -64,6 +65,9 @@ const Register10DlcBrandNoticeCard: React.FC<Register10DlcBrandNotice> = (
 };
 
 export const NotificationCard: React.FC<InnerProps> = (props) => {
+  if (props.loading) {
+    return null;
+  }
   if (props.data.error || !props.data.notices) {
     return (
       <Card style={{ marginBottom: "2em" }}>

--- a/src/server/lib/notices/register-10dlc-brand.ts
+++ b/src/server/lib/notices/register-10dlc-brand.ts
@@ -101,8 +101,7 @@ export const get10DlcBrandNotices: OrgLevelNotificationGetter = async (
   );
 
   // Check if there are no registered profiles
-  // .some(Boolean) will return true if any value in array is true
-  if (!registeredProfiles.some(Boolean)) {
+  if (registeredProfiles.every((registered) => !registered)) {
     const { messaging_service_sid: messagingServiceSid } = ownedProfiles[0];
     return [
       {

--- a/src/server/lib/notices/register-10dlc-brand.ts
+++ b/src/server/lib/notices/register-10dlc-brand.ts
@@ -100,9 +100,9 @@ export const get10DlcBrandNotices: OrgLevelNotificationGetter = async (
     })
   );
 
-  console.log(registeredProfiles);
-
-  if (registeredProfiles.some((registered) => !registered)) {
+  // Check if there are no registered profiles
+  // .some(Boolean) will return true if any value in array is true
+  if (!registeredProfiles.some(Boolean)) {
     const { messaging_service_sid: messagingServiceSid } = ownedProfiles[0];
     return [
       {

--- a/src/server/lib/notices/register-10dlc-brand.ts
+++ b/src/server/lib/notices/register-10dlc-brand.ts
@@ -1,41 +1,35 @@
 import request from "superagent";
 
-import type { Register10DlcBrandNotice } from "../../../api/notice";
 import { r } from "../../models";
 import type { OrgLevelNotificationGetter } from "./types";
 
-const graphqlQuery = `
-  query AnonGetTcr10DlcSurvey($switchboardProfileId: String!) {
-    billingAccountId: billingAccountIdBySwitchboardProfileId(
-      switchboardProfileId: $switchboardProfileId
-    )
-    billingAccountName: billingAccountNameBySwitchboardProfileId(
-      switchboardProfileId: $switchboardProfileId
-    )
-    survey: tcr10DlcSurveyBySwitchboardProfileId(
+const PORTAL_API_URL = "https://portal-api.spokerewired.com/graphql";
+
+const fetchBillingAccountQuery = `
+  query GetBillingAccountBySwitchboardProfileId($switchboardProfileId: UUID!) {
+    billingAccount: billingAccountBySwitchboardProfileId(
       switchboardProfileId: $switchboardProfileId
     ) {
-      ...Tcr10DlcSurveyInfo
+      id
       __typename
     }
   }
+`;
 
-  fragment Tcr10DlcSurveyInfo on Tcr10DlcSurvey {
+const fetchBrandQuery = `
+  query AnonGetTcr10DlcBrandByBillingAccountId($billingAccountId: UUID!) {
+    brand: brandByBillingAccountId(billingAccountId: $billingAccountId) {
     id
-    nodeId
-    legalCompanyName
-    dba
-    entityForm
-    industry
-    website
-    usFein
-    address
-    city
     state
-    postalCode
-    email
-    phoneNumber
+    campaigns: tcr10DlcCampaignsByBrandId {
+      nodes {
+        id
+        state
+        __typename
+      }
+    }
     __typename
+    }
   }
 `;
 
@@ -66,42 +60,60 @@ export const get10DlcBrandNotices: OrgLevelNotificationGetter = async (
     messaging_service_sid: string;
     roles: string[];
   }[] = await query;
-  const notifications: (
-    | Register10DlcBrandNotice
-    | undefined
-  )[] = await Promise.all(
-    profiles.map(async ({ messaging_service_sid, roles }) => {
+  const ownedProfiles = profiles.filter(({ roles }) => roles.includes("OWNER"));
+
+  const registeredProfiles: Array<boolean> = await Promise.all(
+    ownedProfiles.map(async ({ messaging_service_sid }) => {
       const payload = {
-        operationName: "AnonGetTcr10DlcSurvey",
-        query: graphqlQuery,
+        operationName: "GetBillingAccountBySwitchboardProfileId",
+        query: fetchBillingAccountQuery,
         variables: {
           switchboardProfileId: messaging_service_sid
         }
       };
-      const response = await request
-        .post(`https://portal-api.spokerewired.com/graphql`)
+
+      const billingAccountResponse = await request
+        .post(PORTAL_API_URL)
         .send(payload);
 
-      if (!response.body.data.survey) {
-        return {
-          __typename: "Register10DlcBrandNotice",
-          id: messaging_service_sid,
-          tcrBrandRegistrationUrl: roles.includes("OWNER")
-            ? `https://portal.spokerewired.com/10dlc-registration/${messaging_service_sid}`
-            : null
+      if (billingAccountResponse.body?.data?.billingAccount?.id) {
+        const brandPayload = {
+          operationName: "AnonGetTcr10DlcBrandByBillingAccountId",
+          query: fetchBrandQuery,
+          variables: {
+            billingAccountId: billingAccountResponse.body.data.billingAccount.id
+          }
         };
+
+        const brandResponse = await request
+          .post(PORTAL_API_URL)
+          .send(brandPayload);
+
+        if (brandResponse.body.data?.brand?.campaigns?.nodes) {
+          return brandResponse.body.data?.brand?.campaigns?.nodes.some(
+            ({ state }: { state: string }) => state === "REGISTERED"
+          );
+        }
       }
-      return undefined;
+
+      return false;
     })
   );
 
-  const result = notifications.reduce<Register10DlcBrandNotice[]>(
-    (acc, notification) =>
-      notification !== undefined ? [...acc, notification] : acc,
-    []
-  );
+  console.log(registeredProfiles);
 
-  return result;
+  if (registeredProfiles.some((registered) => !registered)) {
+    const { messaging_service_sid: messagingServiceSid } = ownedProfiles[0];
+    return [
+      {
+        __typename: "Register10DlcBrandNotice",
+        id: messagingServiceSid,
+        tcrBrandRegistrationUrl: `https://portal.spokerewired.com/10dlc-registration/${messagingServiceSid}`
+      }
+    ];
+  }
+
+  return [];
 };
 
 export default get10DlcBrandNotices;


### PR DESCRIPTION
## Description

Use new APIs to check if organization has a 10dlc service before showing registration notices

## How Has This Been Tested?

Tested locally with multiple random messaging service ids

## Screenshots (if appropriate):

NA

## Documentation Changes

NA

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
