### PR TITLE
fix(users): set preferred notification frequency on signup

### DIFF
--- a/src/containers/UserEdit/index.jsx
+++ b/src/containers/UserEdit/index.jsx
@@ -4,9 +4,6 @@ import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
 import DialogTitle from "@material-ui/core/DialogTitle";
-import InputLabel from "@material-ui/core/InputLabel";
-import MenuItem from "@material-ui/core/MenuItem";
-import Select from "@material-ui/core/Select";
 import { css, StyleSheet } from "aphrodite";
 import PropTypes from "prop-types";
 import queryString from "query-string";
@@ -170,15 +167,6 @@ class UserEdit extends React.Component {
     this.setState({ changePasswordDialog: false, successDialog: false });
   };
 
-  handleNotificationFrequencyChange = (event) => {
-    const newFrequency = event.target.value;
-    const user = {
-      ...this.state.user,
-      notificationFrequency: newFrequency
-    };
-    this.setState({ user });
-  };
-
   openSuccessDialog = () => this.setState({ successDialog: true });
 
   buildFormSchema = (authType) => {
@@ -297,27 +285,18 @@ class UserEdit extends React.Component {
                 name="cell"
                 {...dataTest("cell")}
               />
-              <div style={{ marginTop: 20 }}>
-                <InputLabel
-                  style={{ marginBottom: 15 }}
-                  id="notification-frequency-label"
-                >
-                  Notification Frequency
-                </InputLabel>
-                <Select
-                  id="notification-frequency"
-                  labelId="notification-frequency-label"
-                  name="notificationFrequency"
-                  value={user.notificationFrequency}
-                  onChange={this.handleNotificationFrequencyChange}
-                >
-                  {Object.values(NotificationFrequencyType).map((option) => (
-                    <MenuItem key={option} value={option}>
-                      {titleCase(option)}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </div>
+              <SpokeFormField
+                label="Notification Frequency"
+                name="notificationFrequency"
+                {...dataTest("notificationFrequency")}
+                type="select"
+                choices={Object.values(NotificationFrequencyType).map(
+                  (option) => ({
+                    value: option,
+                    label: titleCase(option)
+                  })
+                )}
+              />
             </span>
           )}
           {(authType === UserEditMode.Login ||

--- a/src/server/local-auth-helpers.ts
+++ b/src/server/local-auth-helpers.ts
@@ -161,7 +161,8 @@ const signup: AuthHelper = async (options) => {
           first_name: capitalizeWord(reqBody.firstName),
           last_name: capitalizeWord(reqBody.lastName),
           cell: reqBody.cell,
-          is_superadmin: false
+          is_superadmin: false,
+          notification_frequency: reqBody.notificationFrequency
         })
         .returning("*");
       resolve(user);


### PR DESCRIPTION
## Description

This pr fixes a bug where the desired notification frequency that a user indicated during signup wasn't being set in the database, resulting in users getting the default value `ALL` on signup. 

It refactors the notification frequency field in the signup form to use the `SpokeFormField` `Select` component, ensuring that the value the user enters is included in the `formData` sent to the backend. 

It also sets the `notification_frequency` value inserted into the user table to the value in the `reqBody`. 

## Motivation and Context

It closes #1612 

## How Has This Been Tested?

Locally.

## Screenshots (if appropriate):

<img width="358" alt="Screenshot 2023-06-29 at 10 58 38 AM" src="https://github.com/politics-rewired/Spoke/assets/47220718/2f3ad470-7b94-464c-a622-260b38c36428">

<img width="1042" alt="Screenshot 2023-06-29 at 11 01 13 AM" src="https://github.com/politics-rewired/Spoke/assets/47220718/b4f7f4d6-db2a-48f6-87aa-961bfa4d8f2a">

<img width="516" alt="Screenshot 2023-06-29 at 10 59 06 AM" src="https://github.com/politics-rewired/Spoke/assets/47220718/916e4c86-741d-434b-ae08-7972ffb0bb5a">

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
