### PR TITLE
chore(telco errors): update with latest known descriptions

### DIFF
--- a/src/lib/telco-error-codes.ts
+++ b/src/lib/telco-error-codes.ts
@@ -31,7 +31,7 @@ export const errorCodeDescriptions: Record<string, string> = {
   "4750": "Unknown AT&T Error (block can be contested)",
   "4770": "Blocked as spam (block can be contested)",
   "4780": "Carrier rejected (sending rates exceeded)",
-  "4781": "Unknown AT&T Error (block can be contested)"
+  "4781": "Unknown AT&T Error (block can be contested)",
   "5106": "Unroutable (can be retried)",
   "5620": "Carrier outage",
   "9902": "Delivery receipt expired",

--- a/src/lib/telco-error-codes.ts
+++ b/src/lib/telco-error-codes.ts
@@ -28,9 +28,10 @@ export const errorCodeDescriptions: Record<string, string> = {
   "4720": "Unreachable phone number",
   "4730": "Unreachable phone number (recipient maybe roaming)",
   "4740": "Unreachable sending phone number", // this one shouldn't happen, but has happened
-  "4750": "Carrier rejected (maybe spam)",
-  "4770": "Blocked as spam",
+  "4750": "Unknown AT&T Error (block can be contested)",
+  "4770": "Blocked as spam (block can be contested)",
   "4780": "Carrier rejected (sending rates exceeded)",
+  "4781": "Unknown AT&T Error (block can be contested)"
   "5106": "Unroutable (can be retried)",
   "5620": "Carrier outage",
   "9902": "Delivery receipt expired",


### PR DESCRIPTION
## Description

This updates the list of telco errors to account for recent changes to our understanding of certain error codes.

## Motivation and Context
Combination of references to https://dev.bandwidth.com/docs/messaging/errors/ and recent responses to tickets

4750s - can be sending to prepaid AT&T numbers out of credit, but is more often a spam block when seen at high volume
4770s - blocks have been lifted when we open tickets, so we want this to be reflected
4781s - can be exceeding AT&T throughput or a spam block. Once switchboard is handling 10DLC throttling, we can update this to indicate a spam block that can be contested

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
