### PR TITLE
fix(copy campaign): copy display order for canned responses

### DIFF
--- a/dev-tools/clone_campaign_sproc.sql
+++ b/dev-tools/clone_campaign_sproc.sql
@@ -105,11 +105,12 @@ begin
   left join payloads parent_id_mapping on payloads.parent_interaction_id = parent_id_mapping.id;
 
   -- Copy canned responses
-  insert into canned_response (campaign_id, title, text)
+  insert into canned_response (campaign_id, title, text, display_order)
   select
     v_campaign.id as campaign_id,
     title,
-    text
+    text,
+    display_order
   from canned_response
   where campaign_id = template_id;
 

--- a/src/server/api/lib/campaign.ts
+++ b/src/server/api/lib/campaign.ts
@@ -301,11 +301,12 @@ export const copyCampaign = async (options: CopyCampaignOptions) => {
       // Copy canned responses
       await trx.raw(
         `
-          insert into canned_response (campaign_id, title, text)
+          insert into canned_response (campaign_id, title, text, display_order)
           select
             ? as campaign_id,
             title,
-            text
+            text,
+            display_order
           from canned_response
           where campaign_id = ?
         `,


### PR DESCRIPTION
## Description

This alters the SQL for copying canned responses, to add the `display_order` field when canned responses are copied to a new campaign.

## Motivation and Context

The changes in #1551 require us to pass this field to avoid violating the unique constraint on `display_order`. This error was seen on a beta instance.
```
Postgres error: 
          insert into canned_response (campaign_id, title, text)
          select
            $1 as campaign_id,
            title,
            text
          from canned_response
          where campaign_id = $2
         - duplicate key value violates unique constraint "canned_response_campaign_id_display_order_unique"
```

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
