### PR TITLE
fix(canned responses): handle canned response moving up in the list

### DIFF
--- a/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/index.tsx
@@ -133,7 +133,7 @@ class CampaignCannedResponsesForm extends React.Component<InnerProps, State> {
     const cannedResponsesToAdd = this.state.cannedResponsesToAdd.concat({
       ...response,
       id: newId,
-      displayOrder: cannedResponses.length + 1
+      displayOrder: cannedResponses.length
     });
     this.setState({ cannedResponsesToAdd, shouldShowEditor: false });
   };

--- a/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/index.tsx
@@ -166,7 +166,7 @@ class CampaignCannedResponsesForm extends React.Component<InnerProps, State> {
       ...response,
       id: newId,
       displayOrder: cannedResponses.length
-    });
+    };
 
     if (
       this.cannedResponseArraysEqual(

--- a/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/index.tsx
@@ -208,8 +208,8 @@ class CampaignCannedResponsesForm extends React.Component<InnerProps, State> {
   onDragEnd = (result: DropResult) => {
     if (!result.destination) return;
 
-    const sourceDisplayOrder = result.source.index + 1;
-    const destinationDisplayOrder = result.destination.index + 1;
+    const sourceDisplayOrder = result.source.index;
+    const destinationDisplayOrder = result.destination.index;
     const cannedResponseId = result.draggableId;
 
     const { cannedResponses } = this.pendingCannedResponses();
@@ -226,11 +226,15 @@ class CampaignCannedResponsesForm extends React.Component<InnerProps, State> {
     );
 
     // Get all items that were moved, except item that was moved
-    const movedItems = allCannedResponses.filter(
+    const cannedResponsesToMoveDown = allCannedResponses.filter(
       ({ displayOrder }) =>
         displayOrder >= destinationDisplayOrder &&
-        displayOrder <= sourceDisplayOrder &&
-        displayOrder !== sourceDisplayOrder
+        displayOrder < sourceDisplayOrder
+    );
+    const cannedResponsesToMoveUp = allCannedResponses.filter(
+      ({ displayOrder }) =>
+        displayOrder <= destinationDisplayOrder &&
+        displayOrder > sourceDisplayOrder
     );
 
     updatedCannedResponses.push({
@@ -238,14 +242,23 @@ class CampaignCannedResponsesForm extends React.Component<InnerProps, State> {
       displayOrder: destinationDisplayOrder
     });
 
-    updatedCannedResponses = updatedCannedResponses.concat(
-      movedItems.map((cannedResponse) => {
-        return {
-          ...cannedResponse,
-          displayOrder: cannedResponse.displayOrder + 1
-        };
-      })
-    );
+    updatedCannedResponses = updatedCannedResponses
+      .concat(
+        cannedResponsesToMoveUp.map((cannedResponse) => {
+          return {
+            ...cannedResponse,
+            displayOrder: cannedResponse.displayOrder - 1
+          };
+        })
+      )
+      .concat(
+        cannedResponsesToMoveDown.map((cannedResponse) => {
+          return {
+            ...cannedResponse,
+            displayOrder: cannedResponse.displayOrder + 1
+          };
+        })
+      );
 
     this.setState({
       editedCannedResponses: unionBy(

--- a/src/containers/AdminCampaignEdit/sections/CampaignContactsForm/components/ConfigureColumnMappingDialog.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignContactsForm/components/ConfigureColumnMappingDialog.tsx
@@ -152,7 +152,7 @@ const ConfigureColumnMappingDialog: React.FC<ConfigureColumnMappingDialogProps> 
     onSave(remappedColumns);
   };
 
-  // Eslint disable required here to prevent enter from submitting form
+  // Eslint disable is required here to prevent enter from submitting form
   // Enter key is used to lock in the freesolo option in autocomplete
   // https://github.com/react-hook-form/react-hook-form/discussions/2549
   /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */


### PR DESCRIPTION
## Description

This changes the handling for dragging canned responses to better accomodate the case where a canned response is dragged up in the list instead of down.

## Motivation and Context

The case where a canned response is dragged up in the list doesn't consistently work with the current handling.

## How Has This Been Tested?
This has been tested locally

## Screenshots (if appropriate):

https://github.com/politics-rewired/Spoke/assets/76596635/b2b528a0-ecae-498d-9ec3-8e8e177a878e



## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
