### PR TITLE
fix(csv mapping): rerender on file upload

### DIFF
--- a/src/containers/AdminCampaignEdit/sections/CampaignContactsForm/components/ConfigureColumnMappingDialog.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignContactsForm/components/ConfigureColumnMappingDialog.tsx
@@ -107,7 +107,7 @@ const ConfigureColumnMappingDialog: React.FC<ConfigureColumnMappingDialogProps> 
   };
 
   useEffect(() => {
-    if (open && !parseComplete && contactsFile) {
+    if (open && contactsFile) {
       Papa.parse(contactsFile, {
         header: true,
         preview: 2,
@@ -125,7 +125,7 @@ const ConfigureColumnMappingDialog: React.FC<ConfigureColumnMappingDialogProps> 
         }
       });
     }
-  }, [open, contactsFile]);
+  }, [contactsFile]);
 
   const handleSave = (formValues: FormValues) => {
     const mappedColumns = formValues.columnMappings.filter((column) =>


### PR DESCRIPTION
## Description

This alters the csv mapping dialog to rerender whenever a new file is uploaded.

## Motivation and Context

The mapping columns wouldn't reset when a new file was uploaded previously.

## How Has This Been Tested?

This has been tested locally. Went through a few different versions of this `useEffect` before getting the rerender behavior right.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
