### PR TITLE
fix: link toll free pricing

### DIFF
--- a/src/components/NoticeText/PricingTollFreeNoticeText.tsx
+++ b/src/components/NoticeText/PricingTollFreeNoticeText.tsx
@@ -4,8 +4,15 @@ const PricingTollFreeNoticeText: React.FC = () => (
   <>
     <p>Your organization is fully registered for Toll Free sending!</p>
     <p>
-      You are currently on our Toll Free pricing plan, which provides our best
-      deliverability and sending throughput.
+      You are currently on our{" "}
+      <a
+        href="https://www.politicsrewired.com/pricing"
+        target="_blank"
+        rel="noreferrer"
+      >
+        Toll Free pricing plan
+      </a>
+      , which provides our best deliverability and sending throughput.
     </p>
   </>
 );


### PR DESCRIPTION
## Description

This adds a link for toll free pricing 

## Motivation and Context

Make it easier for users to understand what toll free pricing looks like

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

![image](https://github.com/politics-rewired/Spoke/assets/76596635/6ee2123f-5717-4ca2-ac5b-f0649579022e)
## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
