### PR TITLE
chore(template campaigns): use number copies field component

### DIFF
--- a/src/components/CreateCampaignFromTemplateDialog.tsx
+++ b/src/components/CreateCampaignFromTemplateDialog.tsx
@@ -45,15 +45,10 @@ export const CreateCampaignFromTemplateDialog: React.FC<CreateCampaignFromTempla
   const templates =
     data?.organization?.templateCampaigns?.edges?.map(({ node }) => node) ?? [];
 
-  const handleChangeTemplate = useCallback(
-    (
-      _event: React.ChangeEvent<unknown>,
-      value: TemplateCampaignFragment | null
-    ) => {
-      setSelectedTemplate(value);
-    },
-    [setSelectedTemplate]
-  );
+  const handleChangeTemplate = (
+    _event: React.ChangeEvent<unknown>,
+    value: TemplateCampaignFragment | null
+  ) => setSelectedTemplate(value);
 
   const handleChangeQuantity: React.ChangeEventHandler<HTMLInputElement> = (
     event

--- a/src/components/CreateCampaignFromTemplateDialog.tsx
+++ b/src/components/CreateCampaignFromTemplateDialog.tsx
@@ -23,6 +23,7 @@ export interface CreateCampaignFromTemplateDialogProps {
   defaultTemplate?: TemplateCampaignFragment;
 }
 
+// eslint-disable-next-line max-len
 export const CreateCampaignFromTemplateDialog: React.FC<CreateCampaignFromTemplateDialogProps> = (
   props
 ) => {

--- a/src/components/CreateCampaignFromTemplateDialog.tsx
+++ b/src/components/CreateCampaignFromTemplateDialog.tsx
@@ -14,6 +14,8 @@ import {
 } from "@spoke/spoke-codegen";
 import React, { useCallback, useMemo, useState } from "react";
 
+import NumberCopiesField from "./NumberCopiesField";
+
 export interface CreateCampaignFromTemplateDialogProps {
   organizationId: string;
   open: boolean;
@@ -28,7 +30,7 @@ export const CreateCampaignFromTemplateDialog: React.FC<CreateCampaignFromTempla
     selectedTemplate,
     setSelectedTemplate
   ] = useState<TemplateCampaignFragment | null>(props.defaultTemplate ?? null);
-  const [quantity, setQuantity] = useState<number | null>(1);
+  const [quantity, setQuantity] = useState<number>(1);
   const { data, error } = useGetTemplateCampaignsQuery({
     variables: { organizationId: props.organizationId }
   });
@@ -52,22 +54,9 @@ export const CreateCampaignFromTemplateDialog: React.FC<CreateCampaignFromTempla
     [setSelectedTemplate]
   );
 
-  const handleKeyDown: React.KeyboardEventHandler = useCallback((event) => {
-    const badKey = event.keyCode === 69 || event.keyCode === 101;
-    if (badKey) event.preventDefault();
-  }, []);
-
-  const handleChangeQuantity: React.ChangeEventHandler<
-    HTMLInputElement | HTMLTextAreaElement
-  > = useCallback(
-    (event) => {
-      const textValue = event.target.value.replace(/\D/g, "");
-      const intValue = parseInt(textValue, 10);
-      const finalValue = Number.isNaN(intValue) ? null : Math.max(1, intValue);
-      setQuantity(finalValue);
-    },
-    [setQuantity]
-  );
+  const handleChangeQuantity: React.ChangeEventHandler<HTMLInputElement> = (
+    event
+  ) => setQuantity(event.target.valueAsNumber);
 
   const canCreate = useMemo(
     () => quantity !== null && selectedTemplate !== null && !working,
@@ -112,14 +101,7 @@ export const CreateCampaignFromTemplateDialog: React.FC<CreateCampaignFromTempla
           )}
         />
         <br />
-        <TextField
-          fullWidth
-          label="Quantity"
-          type="number"
-          value={quantity ?? ""}
-          onChange={handleChangeQuantity}
-          onKeyDown={handleKeyDown}
-        />
+        <NumberCopiesField qty={quantity} onChange={handleChangeQuantity} />
       </DialogContent>
       <DialogActions>
         <Button onClick={props.onClose}>Cancel</Button>


### PR DESCRIPTION
## Description

This modifies the[ `CreateCampaignFromTemplateDialog`](https://github.com/politics-rewired/Spoke/blob/main/src/components/CreateCampaignFromTemplateDialog.tsx) dialog to use the [`NumberCopiesField`](https://github.com/politics-rewired/Spoke/blob/main/src/components/NumberCopiesField.tsx) component

## Motivation and Context

Follow up to #1609 for code reuse

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
