### PR TITLE
fix(update-dump): add cap add flag

### DIFF
--- a/update-dump.sh
+++ b/update-dump.sh
@@ -7,6 +7,7 @@ echo "Spinning up Postgres Docker container..."
 
 # Start the container in the background
 CONTAINER_ID=$(docker container run -d  \
+  --cap-add SYS_RESOURCE \
   --platform linux/amd64 \
   -p $PG_HOST_PORT:5432  \
   -e ALLOW_NOSSL=true \


### PR DESCRIPTION
## Description

This adds the `--cap-add` flag for running the docker image in `update-dump.sh`

## Motivation and Context

This allows the script to run on my computer 😁 
https://rewiredcoop.slack.com/archives/C02KUGE68UX/p1692822132808449?thread_ts=1692820860.138249&cid=C02KUGE68UX

## How Has This Been Tested?

No changes to schema dump after running it with this change

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
