### PR TITLE
fix: take campaign to edit link for create from template

### DIFF
--- a/src/containers/AdminCampaignList.jsx
+++ b/src/containers/AdminCampaignList.jsx
@@ -452,7 +452,7 @@ class AdminCampaignList extends React.Component {
                     <a
                       key={id}
                       target="_blank"
-                      href={`${window.BASE_URL}/admin/${organizationId}/campaigns/${id}`}
+                      href={`${window.BASE_URL}/admin/${organizationId}/campaigns/${id}/edit`}
                       rel="noreferrer"
                     >
                       Campaign {id}


### PR DESCRIPTION
## Description

In snackbar alert, when creating campaigns from templates. Give correct link to the edit campaign page. 

## Motivation and Context

NA 

## How Has This Been Tested?

Tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
