### PR TITLE
feat: add shutdown notification

### DIFF
--- a/src/components/NoticeText/ShutdownNoticeText.tsx
+++ b/src/components/NoticeText/ShutdownNoticeText.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+const ShutdownNoticeText: React.FC = () => (
+  <>
+    <p>
+      Politics Rewired is winding down operations. Text messages will no longer
+      be deliverable after <strong> November 15</strong>, 2023 and your instance
+      will no longer be available after <strong> November 22</strong>, 2023.
+      Please find more details in our transition document here:
+      politicsrewired.com
+    </p>
+    <p>
+      Thank you for choosing us for your texting outreach, and we wish you the
+      best of luck with all of your future organizing work ❤️
+    </p>
+  </>
+);
+
+export default ShutdownNoticeText;

--- a/src/components/NoticeText/ShutdownNoticeText.tsx
+++ b/src/components/NoticeText/ShutdownNoticeText.tsx
@@ -4,10 +4,17 @@ const ShutdownNoticeText: React.FC = () => (
   <>
     <p>
       Politics Rewired is winding down operations. Text messages will no longer
-      be deliverable after <strong> November 15</strong>, 2023 and your instance
-      will no longer be available after <strong> November 22</strong>, 2023.
-      Please find more details in our transition document here:
-      politicsrewired.com
+      be deliverable after <strong> November 15, 2023 </strong> and your
+      instance will no longer be available after{" "}
+      <strong> November 22, 2023</strong>. Please find more details in our
+      transition document here:{" "}
+      <a
+        href="https://www.politicsrewired.com"
+        target="_blank"
+        rel="noreferrer"
+      >
+        politicsrewired.com
+      </a>
     </p>
     <p>
       Thank you for choosing us for your texting outreach, and we wish you the

--- a/src/containers/AdminDashboard/components/NotificationCard.tsx
+++ b/src/containers/AdminDashboard/components/NotificationCard.tsx
@@ -1,63 +1,64 @@
-import Card from "@material-ui/core/Card";
-import CardContent from "@material-ui/core/CardContent";
-import Divider from "@material-ui/core/Divider";
-import { useGetOrganizationNotificationsQuery } from "@spoke/spoke-codegen";
+// import Card from "@material-ui/core/Card";
+// import CardContent from "@material-ui/core/CardContent";
+// import Divider from "@material-ui/core/Divider";
+// import { useGetOrganizationNotificationsQuery } from "@spoke/spoke-codegen";
 import React from "react";
 
-import {
-  isPending10DlcCampaignNotice,
-  isPricing10DlcNotice,
-  isPricingTollFreeNotice,
-  isRegister10DlcBrandNotice,
-  isRegister10DlcCampaignNotice
-} from "../../../api/notice";
-import Pending10DlcCampaignNoticeCard from "./Pending10DlcCampaignNoticeCard";
-import PricingNoticeCard from "./PricingNoticeCard";
-import Register10DlcNoticeCard from "./Register10DlcNoticeCard";
+// import {
+//   isPending10DlcCampaignNotice,
+//   isPricing10DlcNotice,
+//   isPricingTollFreeNotice,
+//   isRegister10DlcBrandNotice,
+//   isRegister10DlcCampaignNotice
+// } from "../../../api/notice";
+// import Pending10DlcCampaignNoticeCard from "./Pending10DlcCampaignNoticeCard";
+// import PricingNoticeCard from "./PricingNoticeCard";
+// import Register10DlcNoticeCard from "./Register10DlcNoticeCard";
+import ShutdownNoticeCard from "./ShutdownNoticeCard";
 
 interface NotificationCardProps {
   organizationId: string;
 }
 
-export const NotificationCard: React.FC<NotificationCardProps> = ({
-  organizationId
-}) => {
-  const { data, loading, error } = useGetOrganizationNotificationsQuery({
-    variables: { organizationId }
-  });
+export const NotificationCard: React.FC<NotificationCardProps> = () => {
+  return <ShutdownNoticeCard />;
 
-  if (loading) return null;
+  // const { data, loading, error } = useGetOrganizationNotificationsQuery({
+  //   variables: { organizationId }
+  // });
 
-  if (error || !data?.notices) {
-    return (
-      <Card style={{ marginBottom: "2em" }}>
-        <CardContent>There was an error fetching notifications.</CardContent>
-      </Card>
-    );
-  }
+  // if (loading) return null;
 
-  return (
-    <div>
-      {data?.notices.edges.map(({ node }) => {
-        if (window.SHOW_10DLC_REGISTRATION_NOTICES) {
-          if (
-            isRegister10DlcBrandNotice(node) ||
-            isRegister10DlcCampaignNotice(node)
-          ) {
-            return <Register10DlcNoticeCard key={node.id} {...node} />;
-          }
-          if (isPending10DlcCampaignNotice(node)) {
-            return <Pending10DlcCampaignNoticeCard key={node.id} {...node} />;
-          }
-          if (isPricing10DlcNotice(node) || isPricingTollFreeNotice(node)) {
-            return <PricingNoticeCard key={node.id} {...node} />;
-          }
-        }
-        return null;
-      })}
-      {data?.notices.pageInfo.totalCount > 0 && <Divider />}
-    </div>
-  );
+  // if (error || !data?.notices) {
+  //   return (
+  //     <Card style={{ marginBottom: "2em" }}>
+  //       <CardContent>There was an error fetching notifications.</CardContent>
+  //     </Card>
+  //   );
+  // }
+
+  // return (
+  //   <div>
+  //     {data?.notices.edges.map(({ node }) => {
+  //       if (window.SHOW_10DLC_REGISTRATION_NOTICES) {
+  //         if (
+  //           isRegister10DlcBrandNotice(node) ||
+  //           isRegister10DlcCampaignNotice(node)
+  //         ) {
+  //           return <Register10DlcNoticeCard key={node.id} {...node} />;
+  //         }
+  //         if (isPending10DlcCampaignNotice(node)) {
+  //           return <Pending10DlcCampaignNoticeCard key={node.id} {...node} />;
+  //         }
+  //         if (isPricing10DlcNotice(node) || isPricingTollFreeNotice(node)) {
+  //           return <PricingNoticeCard key={node.id} {...node} />;
+  //         }
+  //       }
+  //       return null;
+  //     })}
+  //     {data?.notices.pageInfo.totalCount > 0 && <Divider />}
+  //   </div>
+  // );
 };
 
 export default NotificationCard;

--- a/src/containers/AdminDashboard/components/ShutdownNoticeCard.tsx
+++ b/src/containers/AdminDashboard/components/ShutdownNoticeCard.tsx
@@ -1,0 +1,23 @@
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import CardHeader from "@material-ui/core/CardHeader";
+import Announcement from "@material-ui/icons/Announcement";
+import React from "react";
+
+import ShutdownNoticeText from "../../../components/NoticeText/ShutdownNoticeText";
+
+const ShutdownNoticeCard: React.FC = () => {
+  return (
+    <Card variant="outlined" style={{ marginBottom: "2em" }}>
+      <CardHeader
+        title="Spoke Rewired Shutdown"
+        avatar={<Announcement color="error" />}
+      />
+      <CardContent>
+        <ShutdownNoticeText />
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ShutdownNoticeCard;


### PR DESCRIPTION
## Description

This adds a notification for Spoke Rewired users about upcoming shutdown

## Motivation and Context

thank you @politics-rewired ❤️ 

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

![image](https://github.com/politics-rewired/Spoke/assets/76596635/6fc03310-589c-4df8-9f3a-f288aa86273d)



## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
