### PR TITLE
fix: handle Spoke Portal being unreachable

### DIFF
--- a/src/server/lib/notices/register-10dlc-brand.ts
+++ b/src/server/lib/notices/register-10dlc-brand.ts
@@ -72,20 +72,30 @@ export const get10DlcBrandNotices: OrgLevelNotificationGetter = async (
 
   const ownedProfiles = profiles.filter(({ roles }) => roles.includes("OWNER"));
 
-  const profilesWithChannels = await Promise.all(
-    profiles.map(async ({ messaging_service_sid }) => {
-      const payload = {
-        operationName: "GetSwitchboardProfile",
-        query: fetchProfileQuery,
-        variables: {
-          profileId: messaging_service_sid
-        }
-      };
+  let profilesWithChannels: any[] = [];
+  try {
+    profilesWithChannels = await Promise.all(
+      profiles.map(async ({ messaging_service_sid }) => {
+        const payload = {
+          operationName: "GetSwitchboardProfile",
+          query: fetchProfileQuery,
+          variables: {
+            profileId: messaging_service_sid
+          }
+        };
 
-      const profileResponse = await request.post(PORTAL_API_URL).send(payload);
-      return profileResponse.body.data?.profile;
-    })
-  );
+        const profileResponse = await request
+          .post(PORTAL_API_URL)
+          .timeout(1000)
+          .send(payload);
+
+        return profileResponse.body.data?.profile;
+      })
+    );
+  } catch {
+    // Error fetching from Portal (it may not be reachable)
+    return [];
+  }
 
   // if a registered profile exists, show the notice for their lowest cost pricing plan
 


### PR DESCRIPTION
## Description

This adds a timeout and error handling for times when Spoke Portal is unreachable.

## Motivation and Context

Spoke Portal being unreachable caused fetching notices to fail with an error every time.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

N/A

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
