### PR TITLE
feat: add generic title/content notice type

### DIFF
--- a/libs/gql-schema/notice.ts
+++ b/libs/gql-schema/notice.ts
@@ -30,7 +30,15 @@ export const schema = `
     id: ID!
   }
 
-  union Notice = Register10DlcBrandNotice | Register10DlcCampaignNotice | Pending10DlcCampaignNotice | Pricing10DlcNotice | PricingTollFreeNotice
+  type TitleContentNotice {
+    id: ID!
+    title: String!
+    avatarIcon: String!
+    avatarColor: String!
+    markdownContent: String!
+  }
+
+  union Notice = Register10DlcBrandNotice | Register10DlcCampaignNotice | Pending10DlcCampaignNotice | Pricing10DlcNotice | PricingTollFreeNotice | TitleContentNotice
 
   type NoticeEdge {
     cursor: Cursor!

--- a/libs/spoke-codegen/src/graphql/notifications.graphql
+++ b/libs/spoke-codegen/src/graphql/notifications.graphql
@@ -5,6 +5,13 @@ query getOrganizationNotifications($organizationId: String!) {
     }
     edges {
       node {
+        ... on TitleContentNotice {
+          id
+          title
+          avatarIcon
+          avatarColor
+          markdownContent
+        }
         ... on Register10DlcBrandNotice {
           id
           tcrRegistrationUrl

--- a/src/api/notice.ts
+++ b/src/api/notice.ts
@@ -4,9 +4,17 @@ import type {
   Pricing10DlcNotice,
   PricingTollFreeNotice,
   Register10DlcBrandNotice,
-  Register10DlcCampaignNotice
+  Register10DlcCampaignNotice,
+  TitleContentNotice
 } from "@spoke/spoke-codegen";
 import type { GraphQLType } from "graphql";
+
+export function isTitleContentNotice(obj: Notice): obj is TitleContentNotice {
+  return (
+    (obj as TitleContentNotice & GraphQLType).__typename ===
+    "TitleContentNotice"
+  );
+}
 
 export function isRegister10DlcBrandNotice(
   obj: Notice

--- a/src/containers/AdminDashboard/components/NotificationCard.tsx
+++ b/src/containers/AdminDashboard/components/NotificationCard.tsx
@@ -9,12 +9,14 @@ import {
   isPricing10DlcNotice,
   isPricingTollFreeNotice,
   isRegister10DlcBrandNotice,
-  isRegister10DlcCampaignNotice
+  isRegister10DlcCampaignNotice,
+  isTitleContentNotice
 } from "../../../api/notice";
 import Pending10DlcCampaignNoticeCard from "./Pending10DlcCampaignNoticeCard";
 import PricingNoticeCard from "./PricingNoticeCard";
 import Register10DlcNoticeCard from "./Register10DlcNoticeCard";
 import ShutdownNoticeCard from "./ShutdownNoticeCard";
+import TitleContentNoticeCard from "./TitleContentNoticeCard";
 
 interface NotificationCardProps {
   organizationId: string;
@@ -42,6 +44,17 @@ export const NotificationCard: React.FC<NotificationCardProps> = ({
   return (
     <div>
       {data?.notices.edges.map(({ node }) => {
+        if (isTitleContentNotice(node)) {
+          return (
+            <TitleContentNoticeCard
+              key={node.id}
+              title={node.title}
+              avatarIcon={node.avatarIcon}
+              avatarColor={node.avatarColor as any}
+              markdownContent={node.markdownContent}
+            />
+          );
+        }
         if (window.SHOW_10DLC_REGISTRATION_NOTICES) {
           if (
             isRegister10DlcBrandNotice(node) ||

--- a/src/containers/AdminDashboard/components/TitleContentNoticeCard.tsx
+++ b/src/containers/AdminDashboard/components/TitleContentNoticeCard.tsx
@@ -1,0 +1,52 @@
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import CardHeader from "@material-ui/core/CardHeader";
+import Announcement from "@material-ui/icons/Announcement";
+import React from "react";
+import type { Components } from "react-markdown";
+import ReactMarkdown from "react-markdown";
+
+type TitleContentNoticeCardProps = {
+  title: string;
+  avatarIcon: string;
+  avatarColor:
+    | "error"
+    | "inherit"
+    | "disabled"
+    | "action"
+    | "primary"
+    | "secondary"
+    | undefined;
+  markdownContent: string;
+};
+
+// Force links to open in a new window/tab
+const components: Components = {
+  a: ({ node: _node, children, href, title, ...props }) => (
+    <a href={href} title={title} rel="noreferrer" target="_blank" {...props}>
+      {children}
+    </a>
+  )
+};
+
+const TitleContentNoticeCard: React.FC<TitleContentNoticeCardProps> = (
+  props
+) => {
+  const avatar =
+    props.avatarIcon === "announcement" ? (
+      <Announcement color={props.avatarColor} />
+    ) : null;
+
+  return (
+    <Card variant="outlined" style={{ marginBottom: "2em" }}>
+      <CardHeader title={props.title} avatar={avatar} />
+      <CardContent>
+        <ReactMarkdown components={components}>
+          {props.markdownContent}
+        </ReactMarkdown>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default TitleContentNoticeCard;

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -889,7 +889,15 @@ type PricingTollFreeNotice implements PricingNotice {
   id: ID!
 }
 
-union Notice = Register10DlcBrandNotice | Register10DlcCampaignNotice | Pending10DlcCampaignNotice | Pricing10DlcNotice | PricingTollFreeNotice
+type TitleContentNotice {
+  id: ID!
+  title: String!
+  avatarIcon: String!
+  avatarColor: String!
+  markdownContent: String!
+}
+
+union Notice = Register10DlcBrandNotice | Register10DlcCampaignNotice | Pending10DlcCampaignNotice | Pricing10DlcNotice | PricingTollFreeNotice | TitleContentNotice
 
 type NoticeEdge {
   cursor: Cursor!

--- a/src/server/api/notice.ts
+++ b/src/server/api/notice.ts
@@ -6,13 +6,17 @@ import {
   isPricing10DlcNotice,
   isPricingTollFreeNotice,
   isRegister10DlcBrandNotice,
-  isRegister10DlcCampaignNotice
+  isRegister10DlcCampaignNotice,
+  isTitleContentNotice
 } from "../../api/notice";
 
 // explicitly setting typename
 export const resolvers = {
   Notice: {
     __resolveType(obj: Notice) {
+      if (isTitleContentNotice(obj)) {
+        return "TitleContentNotice";
+      }
       if (isRegister10DlcBrandNotice(obj)) {
         return "Register10DlcBrandNotice";
       }


### PR DESCRIPTION
## Description

This adds a generic notice type with a title and markdown content.

## Motivation and Context

Many notices are just informational and this covers those.

Part 1 of 2.

## How Has This Been Tested?

This has been tested locally.

## Screenshots (if appropriate):

See forthcoming part 2.

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
